### PR TITLE
Formatting

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,7 +1,7 @@
 {
   "python.envFile": "${workspaceFolder}/.venv",
-  "python.formatting.provider": "yapf",
-  "editor.tabSize": 2,
+  "python.formatting.provider": "black",
+  "editor.tabSize": 4,
   "editor.formatOnSave": true,
   "python.linting.flake8Enabled": false,
   "python.linting.pylintEnabled": true,
@@ -9,4 +9,9 @@
   "editor.rulers": [
     80
   ],
+  "editor.codeActionsOnSave": {
+    "source.organizeImports": false
+  },
+  "files.trimFinalNewlines": true,
+  "files.trimTrailingWhitespace": true,
 }

--- a/README.md
+++ b/README.md
@@ -52,6 +52,14 @@ poetry shell
 
 ## Run all tests
 
+Install bazel and buildifier (in Mac we recommend installing bazelisk with brew)
+
+```shell
+brew install bazelisk buildifier
+```
+
+Run all tests with bazel:
+
 ```shell
 bazel test //...:all
 ```

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ poetry shell
 Install bazel and buildifier (in Mac we recommend installing bazelisk with brew)
 
 ```shell
-brew install bazelisk buildifier
+brew install bazelisk
 ```
 
 Run all tests with bazel:

--- a/README.md
+++ b/README.md
@@ -41,17 +41,8 @@ located) and execute:
 poetry install
 ```
 
-The virtual environment installation directory will depend on your operating
-system as follows:
-
--   Linux: `$XDG_CACHE_HOME/pypoetry/virtualenvs or
-~/.cache/pypoetry/virtualenvs`
--   Windows: `%LOCALAPPDATA%\pypoetry/virtualenvs`
--   MacOS: `~/Library/Caches/pypoetry/virtualenvs`
-
 You can also install the environment in the project's root directory by
-executing `shell poetry config virtualenvs.in-project true` before running
-`poetry install`.
+executing `poetry config virtualenvs.in-project true` before it.
 
 Finally, activate the virtual environment by executing:
 

--- a/poetry.lock
+++ b/poetry.lock
@@ -23,6 +23,39 @@ wrapt = [
 ]
 
 [[package]]
+name = "black"
+version = "22.12.0"
+description = "The uncompromising code formatter."
+category = "dev"
+optional = false
+python-versions = ">=3.7"
+
+[package.dependencies]
+click = ">=8.0.0"
+mypy-extensions = ">=0.4.3"
+pathspec = ">=0.9.0"
+platformdirs = ">=2"
+tomli = {version = ">=1.1.0", markers = "python_full_version < \"3.11.0a7\""}
+typing-extensions = {version = ">=3.10.0.0", markers = "python_version < \"3.10\""}
+
+[package.extras]
+colorama = ["colorama (>=0.4.3)"]
+d = ["aiohttp (>=3.7.4)"]
+jupyter = ["ipython (>=7.8.0)", "tokenize-rt (>=3.2.0)"]
+uvloop = ["uvloop (>=0.15.2)"]
+
+[[package]]
+name = "click"
+version = "8.1.3"
+description = "Composable command line interface toolkit"
+category = "dev"
+optional = false
+python-versions = ">=3.7"
+
+[package.dependencies]
+colorama = {version = "*", markers = "platform_system == \"Windows\""}
+
+[[package]]
 name = "colorama"
 version = "0.4.6"
 description = "Cross-platform colored terminal text."
@@ -43,17 +76,17 @@ graph = ["objgraph (>=1.7.2)"]
 
 [[package]]
 name = "isort"
-version = "5.11.4"
+version = "5.12.0"
 description = "A Python utility / library to sort Python imports."
 category = "main"
 optional = false
-python-versions = ">=3.7.0"
+python-versions = ">=3.8.0"
 
 [package.extras]
-colors = ["colorama (>=0.4.3,<0.5.0)"]
-requirements-deprecated-finder = ["pip-api", "pipreqs"]
-pipfile-deprecated-finder = ["pipreqs", "requirementslib"]
+colors = ["colorama (>=0.4.3)"]
+pipfile-deprecated-finder = ["pip-shims (>=0.5.2)", "pipreqs", "requirementslib"]
 plugins = ["setuptools"]
+requirements-deprecated-finder = ["pip-api", "pipreqs"]
 
 [[package]]
 name = "lazy-object-proxy"
@@ -70,6 +103,14 @@ description = "McCabe checker, plugin for flake8"
 category = "main"
 optional = false
 python-versions = ">=3.6"
+
+[[package]]
+name = "mypy-extensions"
+version = "0.4.3"
+description = "Experimental type system extensions for programs checked with the mypy typechecker."
+category = "dev"
+optional = false
+python-versions = "*"
 
 [[package]]
 name = "numpy"
@@ -100,6 +141,14 @@ pytz = ">=2020.1"
 test = ["hypothesis (>=5.5.3)", "pytest (>=6.0)", "pytest-xdist (>=1.31)"]
 
 [[package]]
+name = "pathspec"
+version = "0.11.0"
+description = "Utility library for gitignore style pattern matching of file paths."
+category = "dev"
+optional = false
+python-versions = ">=3.7"
+
+[[package]]
 name = "platformdirs"
 version = "2.6.2"
 description = "A small Python package for determining appropriate platform-specific dirs, e.g. a \"user data dir\"."
@@ -108,8 +157,8 @@ optional = false
 python-versions = ">=3.7"
 
 [package.extras]
-docs = ["furo (>=2022.12.7)", "proselint (>=0.13)", "sphinx-autodoc-typehints (>=1.19.5)", "sphinx (>=5.3)"]
-test = ["appdirs (==1.4.4)", "covdefaults (>=2.2.2)", "pytest-cov (>=4)", "pytest-mock (>=3.10)", "pytest (>=7.2)"]
+docs = ["furo (>=2022.12.7)", "proselint (>=0.13)", "sphinx (>=5.3)", "sphinx-autodoc-typehints (>=1.19.5)"]
+test = ["appdirs (==1.4.4)", "covdefaults (>=2.2.2)", "pytest (>=7.2)", "pytest-cov (>=4)", "pytest-mock (>=3.10)"]
 
 [[package]]
 name = "protobuf"
@@ -212,44 +261,274 @@ category = "main"
 optional = false
 python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,>=2.7"
 
-[[package]]
-name = "yapf"
-version = "0.32.0"
-description = "A formatter for Python code."
-category = "dev"
-optional = false
-python-versions = "*"
-
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.9"
-content-hash = "cc04406fa6bc2b410b202d79b2816106dc27112e0ea196b1a541c53037297d09"
+content-hash = "d0617f68addb62cc00b09770bbf93ebf988d22062a4cf173a48bac1db51102c8"
 
 [metadata.files]
-absl-py = []
-astroid = []
-colorama = []
-dill = []
-isort = []
-lazy-object-proxy = []
-mccabe = []
-numpy = []
-pandas = []
-platformdirs = []
-protobuf = []
-pylint = []
+absl-py = [
+    {file = "absl-py-1.4.0.tar.gz", hash = "sha256:d2c244d01048ba476e7c080bd2c6df5e141d211de80223460d5b3b8a2a58433d"},
+    {file = "absl_py-1.4.0-py3-none-any.whl", hash = "sha256:0d3fe606adfa4f7db64792dd4c7aee4ee0c38ab75dfd353b7a83ed3e957fcb47"},
+]
+astroid = [
+    {file = "astroid-2.13.2-py3-none-any.whl", hash = "sha256:8f6a8d40c4ad161d6fc419545ae4b2f275ed86d1c989c97825772120842ee0d2"},
+    {file = "astroid-2.13.2.tar.gz", hash = "sha256:3bc7834720e1a24ca797fd785d77efb14f7a28ee8e635ef040b6e2d80ccb3303"},
+]
+black = [
+    {file = "black-22.12.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9eedd20838bd5d75b80c9f5487dbcb06836a43833a37846cf1d8c1cc01cef59d"},
+    {file = "black-22.12.0-cp310-cp310-win_amd64.whl", hash = "sha256:159a46a4947f73387b4d83e87ea006dbb2337eab6c879620a3ba52699b1f4351"},
+    {file = "black-22.12.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d30b212bffeb1e252b31dd269dfae69dd17e06d92b87ad26e23890f3efea366f"},
+    {file = "black-22.12.0-cp311-cp311-win_amd64.whl", hash = "sha256:7412e75863aa5c5411886804678b7d083c7c28421210180d67dfd8cf1221e1f4"},
+    {file = "black-22.12.0-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c116eed0efb9ff870ded8b62fe9f28dd61ef6e9ddd28d83d7d264a38417dcee2"},
+    {file = "black-22.12.0-cp37-cp37m-win_amd64.whl", hash = "sha256:1f58cbe16dfe8c12b7434e50ff889fa479072096d79f0a7f25e4ab8e94cd8350"},
+    {file = "black-22.12.0-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:77d86c9f3db9b1bf6761244bc0b3572a546f5fe37917a044e02f3166d5aafa7d"},
+    {file = "black-22.12.0-cp38-cp38-win_amd64.whl", hash = "sha256:82d9fe8fee3401e02e79767016b4907820a7dc28d70d137eb397b92ef3cc5bfc"},
+    {file = "black-22.12.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:101c69b23df9b44247bd88e1d7e90154336ac4992502d4197bdac35dd7ee3320"},
+    {file = "black-22.12.0-cp39-cp39-win_amd64.whl", hash = "sha256:559c7a1ba9a006226f09e4916060982fd27334ae1998e7a38b3f33a37f7a2148"},
+    {file = "black-22.12.0-py3-none-any.whl", hash = "sha256:436cc9167dd28040ad90d3b404aec22cedf24a6e4d7de221bec2730ec0c97bcf"},
+    {file = "black-22.12.0.tar.gz", hash = "sha256:229351e5a18ca30f447bf724d007f890f97e13af070bb6ad4c0a441cd7596a2f"},
+]
+click = [
+    {file = "click-8.1.3-py3-none-any.whl", hash = "sha256:bb4d8133cb15a609f44e8213d9b391b0809795062913b383c62be0ee95b1db48"},
+    {file = "click-8.1.3.tar.gz", hash = "sha256:7682dc8afb30297001674575ea00d1814d808d6a36af415a82bd481d37ba7b8e"},
+]
+colorama = [
+    {file = "colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6"},
+    {file = "colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44"},
+]
+dill = [
+    {file = "dill-0.3.6-py3-none-any.whl", hash = "sha256:a07ffd2351b8c678dfc4a856a3005f8067aea51d6ba6c700796a4d9e280f39f0"},
+    {file = "dill-0.3.6.tar.gz", hash = "sha256:e5db55f3687856d8fbdab002ed78544e1c4559a130302693d839dfe8f93f2373"},
+]
+isort = [
+    {file = "isort-5.12.0-py3-none-any.whl", hash = "sha256:f84c2818376e66cf843d497486ea8fed8700b340f308f076c6fb1229dff318b6"},
+    {file = "isort-5.12.0.tar.gz", hash = "sha256:8bef7dde241278824a6d83f44a544709b065191b95b6e50894bdc722fcba0504"},
+]
+lazy-object-proxy = [
+    {file = "lazy-object-proxy-1.9.0.tar.gz", hash = "sha256:659fb5809fa4629b8a1ac5106f669cfc7bef26fbb389dda53b3e010d1ac4ebae"},
+    {file = "lazy_object_proxy-1.9.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:b40387277b0ed2d0602b8293b94d7257e17d1479e257b4de114ea11a8cb7f2d7"},
+    {file = "lazy_object_proxy-1.9.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e8c6cfb338b133fbdbc5cfaa10fe3c6aeea827db80c978dbd13bc9dd8526b7d4"},
+    {file = "lazy_object_proxy-1.9.0-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:721532711daa7db0d8b779b0bb0318fa87af1c10d7fe5e52ef30f8eff254d0cd"},
+    {file = "lazy_object_proxy-1.9.0-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:66a3de4a3ec06cd8af3f61b8e1ec67614fbb7c995d02fa224813cb7afefee701"},
+    {file = "lazy_object_proxy-1.9.0-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:1aa3de4088c89a1b69f8ec0dcc169aa725b0ff017899ac568fe44ddc1396df46"},
+    {file = "lazy_object_proxy-1.9.0-cp310-cp310-win32.whl", hash = "sha256:f0705c376533ed2a9e5e97aacdbfe04cecd71e0aa84c7c0595d02ef93b6e4455"},
+    {file = "lazy_object_proxy-1.9.0-cp310-cp310-win_amd64.whl", hash = "sha256:ea806fd4c37bf7e7ad82537b0757999264d5f70c45468447bb2b91afdbe73a6e"},
+    {file = "lazy_object_proxy-1.9.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:946d27deaff6cf8452ed0dba83ba38839a87f4f7a9732e8f9fd4107b21e6ff07"},
+    {file = "lazy_object_proxy-1.9.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:79a31b086e7e68b24b99b23d57723ef7e2c6d81ed21007b6281ebcd1688acb0a"},
+    {file = "lazy_object_proxy-1.9.0-cp311-cp311-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f699ac1c768270c9e384e4cbd268d6e67aebcfae6cd623b4d7c3bfde5a35db59"},
+    {file = "lazy_object_proxy-1.9.0-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:bfb38f9ffb53b942f2b5954e0f610f1e721ccebe9cce9025a38c8ccf4a5183a4"},
+    {file = "lazy_object_proxy-1.9.0-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:189bbd5d41ae7a498397287c408617fe5c48633e7755287b21d741f7db2706a9"},
+    {file = "lazy_object_proxy-1.9.0-cp311-cp311-win32.whl", hash = "sha256:81fc4d08b062b535d95c9ea70dbe8a335c45c04029878e62d744bdced5141586"},
+    {file = "lazy_object_proxy-1.9.0-cp311-cp311-win_amd64.whl", hash = "sha256:f2457189d8257dd41ae9b434ba33298aec198e30adf2dcdaaa3a28b9994f6adb"},
+    {file = "lazy_object_proxy-1.9.0-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:d9e25ef10a39e8afe59a5c348a4dbf29b4868ab76269f81ce1674494e2565a6e"},
+    {file = "lazy_object_proxy-1.9.0-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:cbf9b082426036e19c6924a9ce90c740a9861e2bdc27a4834fd0a910742ac1e8"},
+    {file = "lazy_object_proxy-1.9.0-cp37-cp37m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9f5fa4a61ce2438267163891961cfd5e32ec97a2c444e5b842d574251ade27d2"},
+    {file = "lazy_object_proxy-1.9.0-cp37-cp37m-musllinux_1_1_aarch64.whl", hash = "sha256:8fa02eaab317b1e9e03f69aab1f91e120e7899b392c4fc19807a8278a07a97e8"},
+    {file = "lazy_object_proxy-1.9.0-cp37-cp37m-musllinux_1_1_x86_64.whl", hash = "sha256:e7c21c95cae3c05c14aafffe2865bbd5e377cfc1348c4f7751d9dc9a48ca4bda"},
+    {file = "lazy_object_proxy-1.9.0-cp37-cp37m-win32.whl", hash = "sha256:f12ad7126ae0c98d601a7ee504c1122bcef553d1d5e0c3bfa77b16b3968d2734"},
+    {file = "lazy_object_proxy-1.9.0-cp37-cp37m-win_amd64.whl", hash = "sha256:edd20c5a55acb67c7ed471fa2b5fb66cb17f61430b7a6b9c3b4a1e40293b1671"},
+    {file = "lazy_object_proxy-1.9.0-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:2d0daa332786cf3bb49e10dc6a17a52f6a8f9601b4cf5c295a4f85854d61de63"},
+    {file = "lazy_object_proxy-1.9.0-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:9cd077f3d04a58e83d04b20e334f678c2b0ff9879b9375ed107d5d07ff160171"},
+    {file = "lazy_object_proxy-1.9.0-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:660c94ea760b3ce47d1855a30984c78327500493d396eac4dfd8bd82041b22be"},
+    {file = "lazy_object_proxy-1.9.0-cp38-cp38-musllinux_1_1_aarch64.whl", hash = "sha256:212774e4dfa851e74d393a2370871e174d7ff0ebc980907723bb67d25c8a7c30"},
+    {file = "lazy_object_proxy-1.9.0-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:f0117049dd1d5635bbff65444496c90e0baa48ea405125c088e93d9cf4525b11"},
+    {file = "lazy_object_proxy-1.9.0-cp38-cp38-win32.whl", hash = "sha256:0a891e4e41b54fd5b8313b96399f8b0e173bbbfc03c7631f01efbe29bb0bcf82"},
+    {file = "lazy_object_proxy-1.9.0-cp38-cp38-win_amd64.whl", hash = "sha256:9990d8e71b9f6488e91ad25f322898c136b008d87bf852ff65391b004da5e17b"},
+    {file = "lazy_object_proxy-1.9.0-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:9e7551208b2aded9c1447453ee366f1c4070602b3d932ace044715d89666899b"},
+    {file = "lazy_object_proxy-1.9.0-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:5f83ac4d83ef0ab017683d715ed356e30dd48a93746309c8f3517e1287523ef4"},
+    {file = "lazy_object_proxy-1.9.0-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7322c3d6f1766d4ef1e51a465f47955f1e8123caee67dd641e67d539a534d006"},
+    {file = "lazy_object_proxy-1.9.0-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:18b78ec83edbbeb69efdc0e9c1cb41a3b1b1ed11ddd8ded602464c3fc6020494"},
+    {file = "lazy_object_proxy-1.9.0-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:09763491ce220c0299688940f8dc2c5d05fd1f45af1e42e636b2e8b2303e4382"},
+    {file = "lazy_object_proxy-1.9.0-cp39-cp39-win32.whl", hash = "sha256:9090d8e53235aa280fc9239a86ae3ea8ac58eff66a705fa6aa2ec4968b95c821"},
+    {file = "lazy_object_proxy-1.9.0-cp39-cp39-win_amd64.whl", hash = "sha256:db1c1722726f47e10e0b5fdbf15ac3b8adb58c091d12b3ab713965795036985f"},
+]
+mccabe = [
+    {file = "mccabe-0.7.0-py2.py3-none-any.whl", hash = "sha256:6c2d30ab6be0e4a46919781807b4f0d834ebdd6c6e3dca0bda5a15f863427b6e"},
+    {file = "mccabe-0.7.0.tar.gz", hash = "sha256:348e0240c33b60bbdf4e523192ef919f28cb2c3d7d5c7794f74009290f236325"},
+]
+mypy-extensions = [
+    {file = "mypy_extensions-0.4.3-py2.py3-none-any.whl", hash = "sha256:090fedd75945a69ae91ce1303b5824f428daf5a028d2f6ab8a299250a846f15d"},
+    {file = "mypy_extensions-0.4.3.tar.gz", hash = "sha256:2d82818f5bb3e369420cb3c4060a7970edba416647068eb4c5343488a6c604a8"},
+]
+numpy = [
+    {file = "numpy-1.24.1-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:179a7ef0889ab769cc03573b6217f54c8bd8e16cef80aad369e1e8185f994cd7"},
+    {file = "numpy-1.24.1-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:b09804ff570b907da323b3d762e74432fb07955701b17b08ff1b5ebaa8cfe6a9"},
+    {file = "numpy-1.24.1-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f1b739841821968798947d3afcefd386fa56da0caf97722a5de53e07c4ccedc7"},
+    {file = "numpy-1.24.1-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:0e3463e6ac25313462e04aea3fb8a0a30fb906d5d300f58b3bc2c23da6a15398"},
+    {file = "numpy-1.24.1-cp310-cp310-win32.whl", hash = "sha256:b31da69ed0c18be8b77bfce48d234e55d040793cebb25398e2a7d84199fbc7e2"},
+    {file = "numpy-1.24.1-cp310-cp310-win_amd64.whl", hash = "sha256:b07b40f5fb4fa034120a5796288f24c1fe0e0580bbfff99897ba6267af42def2"},
+    {file = "numpy-1.24.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:7094891dcf79ccc6bc2a1f30428fa5edb1e6fb955411ffff3401fb4ea93780a8"},
+    {file = "numpy-1.24.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:28e418681372520c992805bb723e29d69d6b7aa411065f48216d8329d02ba032"},
+    {file = "numpy-1.24.1-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e274f0f6c7efd0d577744f52032fdd24344f11c5ae668fe8d01aac0422611df1"},
+    {file = "numpy-1.24.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:0044f7d944ee882400890f9ae955220d29b33d809a038923d88e4e01d652acd9"},
+    {file = "numpy-1.24.1-cp311-cp311-win32.whl", hash = "sha256:442feb5e5bada8408e8fcd43f3360b78683ff12a4444670a7d9e9824c1817d36"},
+    {file = "numpy-1.24.1-cp311-cp311-win_amd64.whl", hash = "sha256:de92efa737875329b052982e37bd4371d52cabf469f83e7b8be9bb7752d67e51"},
+    {file = "numpy-1.24.1-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:b162ac10ca38850510caf8ea33f89edcb7b0bb0dfa5592d59909419986b72407"},
+    {file = "numpy-1.24.1-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:26089487086f2648944f17adaa1a97ca6aee57f513ba5f1c0b7ebdabbe2b9954"},
+    {file = "numpy-1.24.1-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:caf65a396c0d1f9809596be2e444e3bd4190d86d5c1ce21f5fc4be60a3bc5b36"},
+    {file = "numpy-1.24.1-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b0677a52f5d896e84414761531947c7a330d1adc07c3a4372262f25d84af7bf7"},
+    {file = "numpy-1.24.1-cp38-cp38-win32.whl", hash = "sha256:dae46bed2cb79a58d6496ff6d8da1e3b95ba09afeca2e277628171ca99b99db1"},
+    {file = "numpy-1.24.1-cp38-cp38-win_amd64.whl", hash = "sha256:6ec0c021cd9fe732e5bab6401adea5a409214ca5592cd92a114f7067febcba0c"},
+    {file = "numpy-1.24.1-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:28bc9750ae1f75264ee0f10561709b1462d450a4808cd97c013046073ae64ab6"},
+    {file = "numpy-1.24.1-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:84e789a085aabef2f36c0515f45e459f02f570c4b4c4c108ac1179c34d475ed7"},
+    {file = "numpy-1.24.1-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:8e669fbdcdd1e945691079c2cae335f3e3a56554e06bbd45d7609a6cf568c700"},
+    {file = "numpy-1.24.1-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ef85cf1f693c88c1fd229ccd1055570cb41cdf4875873b7728b6301f12cd05bf"},
+    {file = "numpy-1.24.1-cp39-cp39-win32.whl", hash = "sha256:87a118968fba001b248aac90e502c0b13606721b1343cdaddbc6e552e8dfb56f"},
+    {file = "numpy-1.24.1-cp39-cp39-win_amd64.whl", hash = "sha256:ddc7ab52b322eb1e40521eb422c4e0a20716c271a306860979d450decbb51b8e"},
+    {file = "numpy-1.24.1-pp38-pypy38_pp73-macosx_10_9_x86_64.whl", hash = "sha256:ed5fb71d79e771ec930566fae9c02626b939e37271ec285e9efaf1b5d4370e7d"},
+    {file = "numpy-1.24.1-pp38-pypy38_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ad2925567f43643f51255220424c23d204024ed428afc5aad0f86f3ffc080086"},
+    {file = "numpy-1.24.1-pp38-pypy38_pp73-win_amd64.whl", hash = "sha256:cfa1161c6ac8f92dea03d625c2d0c05e084668f4a06568b77a25a89111621566"},
+    {file = "numpy-1.24.1.tar.gz", hash = "sha256:2386da9a471cc00a1f47845e27d916d5ec5346ae9696e01a8a34760858fe9dd2"},
+]
+pandas = [
+    {file = "pandas-1.5.2-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:e9dbacd22555c2d47f262ef96bb4e30880e5956169741400af8b306bbb24a273"},
+    {file = "pandas-1.5.2-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:e2b83abd292194f350bb04e188f9379d36b8dfac24dd445d5c87575f3beaf789"},
+    {file = "pandas-1.5.2-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:2552bffc808641c6eb471e55aa6899fa002ac94e4eebfa9ec058649122db5824"},
+    {file = "pandas-1.5.2-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:1fc87eac0541a7d24648a001d553406f4256e744d92df1df8ebe41829a915028"},
+    {file = "pandas-1.5.2-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d0d8fd58df5d17ddb8c72a5075d87cd80d71b542571b5f78178fb067fa4e9c72"},
+    {file = "pandas-1.5.2-cp310-cp310-win_amd64.whl", hash = "sha256:4aed257c7484d01c9a194d9a94758b37d3d751849c05a0050c087a358c41ad1f"},
+    {file = "pandas-1.5.2-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:375262829c8c700c3e7cbb336810b94367b9c4889818bbd910d0ecb4e45dc261"},
+    {file = "pandas-1.5.2-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:cc3cd122bea268998b79adebbb8343b735a5511ec14efb70a39e7acbc11ccbdc"},
+    {file = "pandas-1.5.2-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:b4f5a82afa4f1ff482ab8ded2ae8a453a2cdfde2001567b3ca24a4c5c5ca0db3"},
+    {file = "pandas-1.5.2-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:8092a368d3eb7116e270525329a3e5c15ae796ccdf7ccb17839a73b4f5084a39"},
+    {file = "pandas-1.5.2-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f6257b314fc14958f8122779e5a1557517b0f8e500cfb2bd53fa1f75a8ad0af2"},
+    {file = "pandas-1.5.2-cp311-cp311-win_amd64.whl", hash = "sha256:82ae615826da838a8e5d4d630eb70c993ab8636f0eff13cb28aafc4291b632b5"},
+    {file = "pandas-1.5.2-cp38-cp38-macosx_10_9_universal2.whl", hash = "sha256:457d8c3d42314ff47cc2d6c54f8fc0d23954b47977b2caed09cd9635cb75388b"},
+    {file = "pandas-1.5.2-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:c009a92e81ce836212ce7aa98b219db7961a8b95999b97af566b8dc8c33e9519"},
+    {file = "pandas-1.5.2-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:71f510b0efe1629bf2f7c0eadb1ff0b9cf611e87b73cd017e6b7d6adb40e2b3a"},
+    {file = "pandas-1.5.2-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a40dd1e9f22e01e66ed534d6a965eb99546b41d4d52dbdb66565608fde48203f"},
+    {file = "pandas-1.5.2-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:5ae7e989f12628f41e804847a8cc2943d362440132919a69429d4dea1f164da0"},
+    {file = "pandas-1.5.2-cp38-cp38-win32.whl", hash = "sha256:530948945e7b6c95e6fa7aa4be2be25764af53fba93fe76d912e35d1c9ee46f5"},
+    {file = "pandas-1.5.2-cp38-cp38-win_amd64.whl", hash = "sha256:73f219fdc1777cf3c45fde7f0708732ec6950dfc598afc50588d0d285fddaefc"},
+    {file = "pandas-1.5.2-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:9608000a5a45f663be6af5c70c3cbe634fa19243e720eb380c0d378666bc7702"},
+    {file = "pandas-1.5.2-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:315e19a3e5c2ab47a67467fc0362cb36c7c60a93b6457f675d7d9615edad2ebe"},
+    {file = "pandas-1.5.2-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:e18bc3764cbb5e118be139b3b611bc3fbc5d3be42a7e827d1096f46087b395eb"},
+    {file = "pandas-1.5.2-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0183cb04a057cc38fde5244909fca9826d5d57c4a5b7390c0cc3fa7acd9fa883"},
+    {file = "pandas-1.5.2-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:344021ed3e639e017b452aa8f5f6bf38a8806f5852e217a7594417fb9bbfa00e"},
+    {file = "pandas-1.5.2-cp39-cp39-win32.whl", hash = "sha256:e7469271497960b6a781eaa930cba8af400dd59b62ec9ca2f4d31a19f2f91090"},
+    {file = "pandas-1.5.2-cp39-cp39-win_amd64.whl", hash = "sha256:c218796d59d5abd8780170c937b812c9637e84c32f8271bbf9845970f8c1351f"},
+    {file = "pandas-1.5.2.tar.gz", hash = "sha256:220b98d15cee0b2cd839a6358bd1f273d0356bf964c1a1aeb32d47db0215488b"},
+]
+pathspec = [
+    {file = "pathspec-0.11.0-py3-none-any.whl", hash = "sha256:3a66eb970cbac598f9e5ccb5b2cf58930cd8e3ed86d393d541eaf2d8b1705229"},
+    {file = "pathspec-0.11.0.tar.gz", hash = "sha256:64d338d4e0914e91c1792321e6907b5a593f1ab1851de7fc269557a21b30ebbc"},
+]
+platformdirs = [
+    {file = "platformdirs-2.6.2-py3-none-any.whl", hash = "sha256:83c8f6d04389165de7c9b6f0c682439697887bca0aa2f1c87ef1826be3584490"},
+    {file = "platformdirs-2.6.2.tar.gz", hash = "sha256:e1fea1fe471b9ff8332e229df3cb7de4f53eeea4998d3b6bfff542115e998bd2"},
+]
+protobuf = [
+    {file = "protobuf-4.21.12-cp310-abi3-win32.whl", hash = "sha256:b135410244ebe777db80298297a97fbb4c862c881b4403b71bac9d4107d61fd1"},
+    {file = "protobuf-4.21.12-cp310-abi3-win_amd64.whl", hash = "sha256:89f9149e4a0169cddfc44c74f230d7743002e3aa0b9472d8c28f0388102fc4c2"},
+    {file = "protobuf-4.21.12-cp37-abi3-macosx_10_9_universal2.whl", hash = "sha256:299ea899484ee6f44604deb71f424234f654606b983cb496ea2a53e3c63ab791"},
+    {file = "protobuf-4.21.12-cp37-abi3-manylinux2014_aarch64.whl", hash = "sha256:d1736130bce8cf131ac7957fa26880ca19227d4ad68b4888b3be0dea1f95df97"},
+    {file = "protobuf-4.21.12-cp37-abi3-manylinux2014_x86_64.whl", hash = "sha256:78a28c9fa223998472886c77042e9b9afb6fe4242bd2a2a5aced88e3f4422aa7"},
+    {file = "protobuf-4.21.12-cp37-cp37m-win32.whl", hash = "sha256:3d164928ff0727d97022957c2b849250ca0e64777ee31efd7d6de2e07c494717"},
+    {file = "protobuf-4.21.12-cp37-cp37m-win_amd64.whl", hash = "sha256:f45460f9ee70a0ec1b6694c6e4e348ad2019275680bd68a1d9314b8c7e01e574"},
+    {file = "protobuf-4.21.12-cp38-cp38-win32.whl", hash = "sha256:6ab80df09e3208f742c98443b6166bcb70d65f52cfeb67357d52032ea1ae9bec"},
+    {file = "protobuf-4.21.12-cp38-cp38-win_amd64.whl", hash = "sha256:1f22ac0ca65bb70a876060d96d914dae09ac98d114294f77584b0d2644fa9c30"},
+    {file = "protobuf-4.21.12-cp39-cp39-win32.whl", hash = "sha256:27f4d15021da6d2b706ddc3860fac0a5ddaba34ab679dc182b60a8bb4e1121cc"},
+    {file = "protobuf-4.21.12-cp39-cp39-win_amd64.whl", hash = "sha256:237216c3326d46808a9f7c26fd1bd4b20015fb6867dc5d263a493ef9a539293b"},
+    {file = "protobuf-4.21.12-py2.py3-none-any.whl", hash = "sha256:a53fd3f03e578553623272dc46ac2f189de23862e68565e83dde203d41b76fc5"},
+    {file = "protobuf-4.21.12-py3-none-any.whl", hash = "sha256:b98d0148f84e3a3c569e19f52103ca1feacdac0d2df8d6533cf983d1fda28462"},
+    {file = "protobuf-4.21.12.tar.gz", hash = "sha256:7cd532c4566d0e6feafecc1059d04c7915aec8e182d1cf7adee8b24ef1e2e6ab"},
+]
+pylint = [
+    {file = "pylint-2.15.10-py3-none-any.whl", hash = "sha256:9df0d07e8948a1c3ffa3b6e2d7e6e63d9fb457c5da5b961ed63106594780cc7e"},
+    {file = "pylint-2.15.10.tar.gz", hash = "sha256:b3dc5ef7d33858f297ac0d06cc73862f01e4f2e74025ec3eff347ce0bc60baf5"},
+]
 python-dateutil = [
     {file = "python-dateutil-2.8.2.tar.gz", hash = "sha256:0123cacc1627ae19ddf3c27a5de5bd67ee4586fbdd6440d9748f8abb483d3e86"},
     {file = "python_dateutil-2.8.2-py2.py3-none-any.whl", hash = "sha256:961d03dc3453ebbc59dbdea9e4e11c5651520a876d0f4db161e8674aae935da9"},
 ]
-pytz = []
+pytz = [
+    {file = "pytz-2022.7-py2.py3-none-any.whl", hash = "sha256:93007def75ae22f7cd991c84e02d434876818661f8df9ad5df9e950ff4e52cfd"},
+    {file = "pytz-2022.7.tar.gz", hash = "sha256:7ccfae7b4b2c067464a6733c6261673fdb8fd1be905460396b97a073e9fa683a"},
+]
 six = [
     {file = "six-1.16.0-py2.py3-none-any.whl", hash = "sha256:8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254"},
     {file = "six-1.16.0.tar.gz", hash = "sha256:1e61c37477a1626458e36f7b1d82aa5c9b094fa4802892072e49de9c60c4c926"},
 ]
-toml = []
-tomli = []
-tomlkit = []
-typing-extensions = []
-wrapt = []
-yapf = []
+toml = [
+    {file = "toml-0.10.2-py2.py3-none-any.whl", hash = "sha256:806143ae5bfb6a3c6e736a764057db0e6a0e05e338b5630894a5f779cabb4f9b"},
+    {file = "toml-0.10.2.tar.gz", hash = "sha256:b3bda1d108d5dd99f4a20d24d9c348e91c4db7ab1b749200bded2f839ccbe68f"},
+]
+tomli = [
+    {file = "tomli-2.0.1-py3-none-any.whl", hash = "sha256:939de3e7a6161af0c887ef91b7d41a53e7c5a1ca976325f429cb46ea9bc30ecc"},
+    {file = "tomli-2.0.1.tar.gz", hash = "sha256:de526c12914f0c550d15924c62d72abc48d6fe7364aa87328337a31007fe8a4f"},
+]
+tomlkit = [
+    {file = "tomlkit-0.11.6-py3-none-any.whl", hash = "sha256:07de26b0d8cfc18f871aec595fda24d95b08fef89d147caa861939f37230bf4b"},
+    {file = "tomlkit-0.11.6.tar.gz", hash = "sha256:71b952e5721688937fb02cf9d354dbcf0785066149d2855e44531ebdd2b65d73"},
+]
+typing-extensions = [
+    {file = "typing_extensions-4.4.0-py3-none-any.whl", hash = "sha256:16fa4864408f655d35ec496218b85f79b3437c829e93320c7c9215ccfd92489e"},
+    {file = "typing_extensions-4.4.0.tar.gz", hash = "sha256:1511434bb92bf8dd198c12b1cc812e800d4181cfcb867674e0f8279cc93087aa"},
+]
+wrapt = [
+    {file = "wrapt-1.14.1-cp27-cp27m-macosx_10_9_x86_64.whl", hash = "sha256:1b376b3f4896e7930f1f772ac4b064ac12598d1c38d04907e696cc4d794b43d3"},
+    {file = "wrapt-1.14.1-cp27-cp27m-manylinux1_i686.whl", hash = "sha256:903500616422a40a98a5a3c4ff4ed9d0066f3b4c951fa286018ecdf0750194ef"},
+    {file = "wrapt-1.14.1-cp27-cp27m-manylinux1_x86_64.whl", hash = "sha256:5a9a0d155deafd9448baff28c08e150d9b24ff010e899311ddd63c45c2445e28"},
+    {file = "wrapt-1.14.1-cp27-cp27m-manylinux2010_i686.whl", hash = "sha256:ddaea91abf8b0d13443f6dac52e89051a5063c7d014710dcb4d4abb2ff811a59"},
+    {file = "wrapt-1.14.1-cp27-cp27m-manylinux2010_x86_64.whl", hash = "sha256:36f582d0c6bc99d5f39cd3ac2a9062e57f3cf606ade29a0a0d6b323462f4dd87"},
+    {file = "wrapt-1.14.1-cp27-cp27mu-manylinux1_i686.whl", hash = "sha256:7ef58fb89674095bfc57c4069e95d7a31cfdc0939e2a579882ac7d55aadfd2a1"},
+    {file = "wrapt-1.14.1-cp27-cp27mu-manylinux1_x86_64.whl", hash = "sha256:e2f83e18fe2f4c9e7db597e988f72712c0c3676d337d8b101f6758107c42425b"},
+    {file = "wrapt-1.14.1-cp27-cp27mu-manylinux2010_i686.whl", hash = "sha256:ee2b1b1769f6707a8a445162ea16dddf74285c3964f605877a20e38545c3c462"},
+    {file = "wrapt-1.14.1-cp27-cp27mu-manylinux2010_x86_64.whl", hash = "sha256:833b58d5d0b7e5b9832869f039203389ac7cbf01765639c7309fd50ef619e0b1"},
+    {file = "wrapt-1.14.1-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:80bb5c256f1415f747011dc3604b59bc1f91c6e7150bd7db03b19170ee06b320"},
+    {file = "wrapt-1.14.1-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:07f7a7d0f388028b2df1d916e94bbb40624c59b48ecc6cbc232546706fac74c2"},
+    {file = "wrapt-1.14.1-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:02b41b633c6261feff8ddd8d11c711df6842aba629fdd3da10249a53211a72c4"},
+    {file = "wrapt-1.14.1-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:2fe803deacd09a233e4762a1adcea5db5d31e6be577a43352936179d14d90069"},
+    {file = "wrapt-1.14.1-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:257fd78c513e0fb5cdbe058c27a0624c9884e735bbd131935fd49e9fe719d310"},
+    {file = "wrapt-1.14.1-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:4fcc4649dc762cddacd193e6b55bc02edca674067f5f98166d7713b193932b7f"},
+    {file = "wrapt-1.14.1-cp310-cp310-musllinux_1_1_i686.whl", hash = "sha256:11871514607b15cfeb87c547a49bca19fde402f32e2b1c24a632506c0a756656"},
+    {file = "wrapt-1.14.1-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:8ad85f7f4e20964db4daadcab70b47ab05c7c1cf2a7c1e51087bfaa83831854c"},
+    {file = "wrapt-1.14.1-cp310-cp310-win32.whl", hash = "sha256:a9a52172be0b5aae932bef82a79ec0a0ce87288c7d132946d645eba03f0ad8a8"},
+    {file = "wrapt-1.14.1-cp310-cp310-win_amd64.whl", hash = "sha256:6d323e1554b3d22cfc03cd3243b5bb815a51f5249fdcbb86fda4bf62bab9e164"},
+    {file = "wrapt-1.14.1-cp35-cp35m-manylinux1_i686.whl", hash = "sha256:43ca3bbbe97af00f49efb06e352eae40434ca9d915906f77def219b88e85d907"},
+    {file = "wrapt-1.14.1-cp35-cp35m-manylinux1_x86_64.whl", hash = "sha256:6b1a564e6cb69922c7fe3a678b9f9a3c54e72b469875aa8018f18b4d1dd1adf3"},
+    {file = "wrapt-1.14.1-cp35-cp35m-manylinux2010_i686.whl", hash = "sha256:00b6d4ea20a906c0ca56d84f93065b398ab74b927a7a3dbd470f6fc503f95dc3"},
+    {file = "wrapt-1.14.1-cp35-cp35m-manylinux2010_x86_64.whl", hash = "sha256:a85d2b46be66a71bedde836d9e41859879cc54a2a04fad1191eb50c2066f6e9d"},
+    {file = "wrapt-1.14.1-cp35-cp35m-win32.whl", hash = "sha256:dbcda74c67263139358f4d188ae5faae95c30929281bc6866d00573783c422b7"},
+    {file = "wrapt-1.14.1-cp35-cp35m-win_amd64.whl", hash = "sha256:b21bb4c09ffabfa0e85e3a6b623e19b80e7acd709b9f91452b8297ace2a8ab00"},
+    {file = "wrapt-1.14.1-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:9e0fd32e0148dd5dea6af5fee42beb949098564cc23211a88d799e434255a1f4"},
+    {file = "wrapt-1.14.1-cp36-cp36m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:9736af4641846491aedb3c3f56b9bc5568d92b0692303b5a305301a95dfd38b1"},
+    {file = "wrapt-1.14.1-cp36-cp36m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:5b02d65b9ccf0ef6c34cba6cf5bf2aab1bb2f49c6090bafeecc9cd81ad4ea1c1"},
+    {file = "wrapt-1.14.1-cp36-cp36m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:21ac0156c4b089b330b7666db40feee30a5d52634cc4560e1905d6529a3897ff"},
+    {file = "wrapt-1.14.1-cp36-cp36m-musllinux_1_1_aarch64.whl", hash = "sha256:9f3e6f9e05148ff90002b884fbc2a86bd303ae847e472f44ecc06c2cd2fcdb2d"},
+    {file = "wrapt-1.14.1-cp36-cp36m-musllinux_1_1_i686.whl", hash = "sha256:6e743de5e9c3d1b7185870f480587b75b1cb604832e380d64f9504a0535912d1"},
+    {file = "wrapt-1.14.1-cp36-cp36m-musllinux_1_1_x86_64.whl", hash = "sha256:d79d7d5dc8a32b7093e81e97dad755127ff77bcc899e845f41bf71747af0c569"},
+    {file = "wrapt-1.14.1-cp36-cp36m-win32.whl", hash = "sha256:81b19725065dcb43df02b37e03278c011a09e49757287dca60c5aecdd5a0b8ed"},
+    {file = "wrapt-1.14.1-cp36-cp36m-win_amd64.whl", hash = "sha256:b014c23646a467558be7da3d6b9fa409b2c567d2110599b7cf9a0c5992b3b471"},
+    {file = "wrapt-1.14.1-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:88bd7b6bd70a5b6803c1abf6bca012f7ed963e58c68d76ee20b9d751c74a3248"},
+    {file = "wrapt-1.14.1-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:b5901a312f4d14c59918c221323068fad0540e34324925c8475263841dbdfe68"},
+    {file = "wrapt-1.14.1-cp37-cp37m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:d77c85fedff92cf788face9bfa3ebaa364448ebb1d765302e9af11bf449ca36d"},
+    {file = "wrapt-1.14.1-cp37-cp37m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8d649d616e5c6a678b26d15ece345354f7c2286acd6db868e65fcc5ff7c24a77"},
+    {file = "wrapt-1.14.1-cp37-cp37m-musllinux_1_1_aarch64.whl", hash = "sha256:7d2872609603cb35ca513d7404a94d6d608fc13211563571117046c9d2bcc3d7"},
+    {file = "wrapt-1.14.1-cp37-cp37m-musllinux_1_1_i686.whl", hash = "sha256:ee6acae74a2b91865910eef5e7de37dc6895ad96fa23603d1d27ea69df545015"},
+    {file = "wrapt-1.14.1-cp37-cp37m-musllinux_1_1_x86_64.whl", hash = "sha256:2b39d38039a1fdad98c87279b48bc5dce2c0ca0d73483b12cb72aa9609278e8a"},
+    {file = "wrapt-1.14.1-cp37-cp37m-win32.whl", hash = "sha256:60db23fa423575eeb65ea430cee741acb7c26a1365d103f7b0f6ec412b893853"},
+    {file = "wrapt-1.14.1-cp37-cp37m-win_amd64.whl", hash = "sha256:709fe01086a55cf79d20f741f39325018f4df051ef39fe921b1ebe780a66184c"},
+    {file = "wrapt-1.14.1-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:8c0ce1e99116d5ab21355d8ebe53d9460366704ea38ae4d9f6933188f327b456"},
+    {file = "wrapt-1.14.1-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:e3fb1677c720409d5f671e39bac6c9e0e422584e5f518bfd50aa4cbbea02433f"},
+    {file = "wrapt-1.14.1-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:642c2e7a804fcf18c222e1060df25fc210b9c58db7c91416fb055897fc27e8cc"},
+    {file = "wrapt-1.14.1-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:7b7c050ae976e286906dd3f26009e117eb000fb2cf3533398c5ad9ccc86867b1"},
+    {file = "wrapt-1.14.1-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ef3f72c9666bba2bab70d2a8b79f2c6d2c1a42a7f7e2b0ec83bb2f9e383950af"},
+    {file = "wrapt-1.14.1-cp38-cp38-musllinux_1_1_aarch64.whl", hash = "sha256:01c205616a89d09827986bc4e859bcabd64f5a0662a7fe95e0d359424e0e071b"},
+    {file = "wrapt-1.14.1-cp38-cp38-musllinux_1_1_i686.whl", hash = "sha256:5a0f54ce2c092aaf439813735584b9537cad479575a09892b8352fea5e988dc0"},
+    {file = "wrapt-1.14.1-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:2cf71233a0ed05ccdabe209c606fe0bac7379fdcf687f39b944420d2a09fdb57"},
+    {file = "wrapt-1.14.1-cp38-cp38-win32.whl", hash = "sha256:aa31fdcc33fef9eb2552cbcbfee7773d5a6792c137b359e82879c101e98584c5"},
+    {file = "wrapt-1.14.1-cp38-cp38-win_amd64.whl", hash = "sha256:d1967f46ea8f2db647c786e78d8cc7e4313dbd1b0aca360592d8027b8508e24d"},
+    {file = "wrapt-1.14.1-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:3232822c7d98d23895ccc443bbdf57c7412c5a65996c30442ebe6ed3df335383"},
+    {file = "wrapt-1.14.1-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:988635d122aaf2bdcef9e795435662bcd65b02f4f4c1ae37fbee7401c440b3a7"},
+    {file = "wrapt-1.14.1-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:9cca3c2cdadb362116235fdbd411735de4328c61425b0aa9f872fd76d02c4e86"},
+    {file = "wrapt-1.14.1-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:d52a25136894c63de15a35bc0bdc5adb4b0e173b9c0d07a2be9d3ca64a332735"},
+    {file = "wrapt-1.14.1-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:40e7bc81c9e2b2734ea4bc1aceb8a8f0ceaac7c5299bc5d69e37c44d9081d43b"},
+    {file = "wrapt-1.14.1-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:b9b7a708dd92306328117d8c4b62e2194d00c365f18eff11a9b53c6f923b01e3"},
+    {file = "wrapt-1.14.1-cp39-cp39-musllinux_1_1_i686.whl", hash = "sha256:6a9a25751acb379b466ff6be78a315e2b439d4c94c1e99cb7266d40a537995d3"},
+    {file = "wrapt-1.14.1-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:34aa51c45f28ba7f12accd624225e2b1e5a3a45206aa191f6f9aac931d9d56fe"},
+    {file = "wrapt-1.14.1-cp39-cp39-win32.whl", hash = "sha256:dee0ce50c6a2dd9056c20db781e9c1cfd33e77d2d569f5d1d9321c641bb903d5"},
+    {file = "wrapt-1.14.1-cp39-cp39-win_amd64.whl", hash = "sha256:dee60e1de1898bde3b238f18340eec6148986da0455d8ba7848d50470a7a32fb"},
+    {file = "wrapt-1.14.1.tar.gz", hash = "sha256:380a85cf89e0e69b7cfbe2ea9f765f004ff419f34194018a6827ac0e3edfed4d"},
+]

--- a/poetry.lock
+++ b/poetry.lock
@@ -8,15 +8,15 @@ python-versions = ">=3.6"
 
 [[package]]
 name = "astroid"
-version = "2.13.2"
+version = "2.13.4"
 description = "An abstract syntax tree for Python with inference support."
-category = "main"
+category = "dev"
 optional = false
 python-versions = ">=3.7.2"
 
 [package.dependencies]
 lazy-object-proxy = ">=1.4.0"
-typing-extensions = ">=4.0.0"
+typing-extensions = {version = ">=4.0.0", markers = "python_version < \"3.11\""}
 wrapt = [
     {version = ">=1.11,<2", markers = "python_version < \"3.11\""},
     {version = ">=1.14,<2", markers = "python_version >= \"3.11\""},
@@ -59,7 +59,7 @@ colorama = {version = "*", markers = "platform_system == \"Windows\""}
 name = "colorama"
 version = "0.4.6"
 description = "Cross-platform colored terminal text."
-category = "main"
+category = "dev"
 optional = false
 python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,!=3.5.*,!=3.6.*,>=2.7"
 
@@ -67,7 +67,7 @@ python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,!=3.5.*,!=3.6.*,>=2.7
 name = "dill"
 version = "0.3.6"
 description = "serialize all of python"
-category = "main"
+category = "dev"
 optional = false
 python-versions = ">=3.7"
 
@@ -78,7 +78,7 @@ graph = ["objgraph (>=1.7.2)"]
 name = "isort"
 version = "5.12.0"
 description = "A Python utility / library to sort Python imports."
-category = "main"
+category = "dev"
 optional = false
 python-versions = ">=3.8.0"
 
@@ -92,7 +92,7 @@ requirements-deprecated-finder = ["pip-api", "pipreqs"]
 name = "lazy-object-proxy"
 version = "1.9.0"
 description = "A fast and thorough lazy object proxy."
-category = "main"
+category = "dev"
 optional = false
 python-versions = ">=3.7"
 
@@ -100,7 +100,7 @@ python-versions = ">=3.7"
 name = "mccabe"
 version = "0.7.0"
 description = "McCabe checker, plugin for flake8"
-category = "main"
+category = "dev"
 optional = false
 python-versions = ">=3.6"
 
@@ -152,7 +152,7 @@ python-versions = ">=3.7"
 name = "platformdirs"
 version = "2.6.2"
 description = "A small Python package for determining appropriate platform-specific dirs, e.g. a \"user data dir\"."
-category = "main"
+category = "dev"
 optional = false
 python-versions = ">=3.7"
 
@@ -172,7 +172,7 @@ python-versions = ">=3.7"
 name = "pylint"
 version = "2.15.10"
 description = "python code static checker"
-category = "main"
+category = "dev"
 optional = false
 python-versions = ">=3.7.2"
 
@@ -233,7 +233,7 @@ python-versions = ">=2.6, !=3.0.*, !=3.1.*, !=3.2.*"
 name = "tomli"
 version = "2.0.1"
 description = "A lil' TOML parser"
-category = "main"
+category = "dev"
 optional = false
 python-versions = ">=3.7"
 
@@ -241,7 +241,7 @@ python-versions = ">=3.7"
 name = "tomlkit"
 version = "0.11.6"
 description = "Style preserving TOML library"
-category = "main"
+category = "dev"
 optional = false
 python-versions = ">=3.6"
 
@@ -249,7 +249,7 @@ python-versions = ">=3.6"
 name = "typing-extensions"
 version = "4.4.0"
 description = "Backported and Experimental Type Hints for Python 3.7+"
-category = "main"
+category = "dev"
 optional = false
 python-versions = ">=3.7"
 
@@ -257,14 +257,14 @@ python-versions = ">=3.7"
 name = "wrapt"
 version = "1.14.1"
 description = "Module for decorators, wrappers and monkey patching."
-category = "main"
+category = "dev"
 optional = false
 python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,>=2.7"
 
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.9"
-content-hash = "e79c23685996caccfaddf82b849a986e6a9c2e6f57cdf6197924e2ccb69db2a4"
+content-hash = "61f36c6dda78f55137f606bcb8fffc3491d9e37c38e8dd987ed6793dcf332727"
 
 [metadata.files]
 absl-py = [
@@ -272,8 +272,8 @@ absl-py = [
     {file = "absl_py-1.4.0-py3-none-any.whl", hash = "sha256:0d3fe606adfa4f7db64792dd4c7aee4ee0c38ab75dfd353b7a83ed3e957fcb47"},
 ]
 astroid = [
-    {file = "astroid-2.13.2-py3-none-any.whl", hash = "sha256:8f6a8d40c4ad161d6fc419545ae4b2f275ed86d1c989c97825772120842ee0d2"},
-    {file = "astroid-2.13.2.tar.gz", hash = "sha256:3bc7834720e1a24ca797fd785d77efb14f7a28ee8e635ef040b6e2d80ccb3303"},
+    {file = "astroid-2.13.4-py3-none-any.whl", hash = "sha256:fe430a1dcc6af3abbccd29ba9f2544dcafc0610d37018b5102c232ff917e4bbf"},
+    {file = "astroid-2.13.4.tar.gz", hash = "sha256:805d47d685a490f4024e3744064e919998b0eef6619e6ea6d2052deec5333fd5"},
 ]
 black = [
     {file = "black-22.12.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9eedd20838bd5d75b80c9f5487dbcb06836a43833a37846cf1d8c1cc01cef59d"},

--- a/poetry.lock
+++ b/poetry.lock
@@ -264,7 +264,7 @@ python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,>=2.7"
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.9"
-content-hash = "d0617f68addb62cc00b09770bbf93ebf988d22062a4cf173a48bac1db51102c8"
+content-hash = "e79c23685996caccfaddf82b849a986e6a9c2e6f57cdf6197924e2ccb69db2a4"
 
 [metadata.files]
 absl-py = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,8 +3,8 @@ name = "temporian"
 version = "0.1.0"
 description = ""
 authors = [
-    "Guillermo Etchebarne <getchebarne@tryolabs.com>", 
-    "Ian Spektor <ispektor@tryolabs.com>", 
+    "Guillermo Etchebarne <getchebarne@tryolabs.com>",
+    "Ian Spektor <ispektor@tryolabs.com>",
     "Mathieu Guillame-Bert <gbm@google.com>",
     "Richard Stotz <richardstotz@google.com>"
 ]
@@ -17,18 +17,16 @@ pandas = "^1.5.2"
 pylint = "^2.15.10"
 
 [tool.poetry.dev-dependencies]
-yapf = "^0.32.0"
-isort = "^5.11.4"
 toml = "^0.10.2"
 
-[tool.yapf]
-based_on_style = "google"
-indent_width = 2
-blank_line_before_module_docstring = true
-column_limit = 80
+[tool.poetry.group.dev.dependencies]
+black = "^22.12.0"
+
+[tool.black]
+line-length = 80
+preview = true
 
 [tool.pylint]
-indent-string = '  '
 max-line-length = 80
 
 [build-system]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,11 +14,11 @@ python = "^3.9"
 absl-py = "^1.3.0"
 protobuf = "^4.21.12"
 pandas = "^1.5.2"
-pylint = "^2.15.10"
 
 [tool.poetry.group.dev.dependencies]
 black = "^22.12.0"
 toml = "^0.10.2"
+pylint = "^2.15.10"
 
 [tool.black]
 line-length = 80

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,11 +16,9 @@ protobuf = "^4.21.12"
 pandas = "^1.5.2"
 pylint = "^2.15.10"
 
-[tool.poetry.dev-dependencies]
-toml = "^0.10.2"
-
 [tool.poetry.group.dev.dependencies]
 black = "^22.12.0"
+toml = "^0.10.2"
 
 [tool.black]
 line-length = 80

--- a/temporian/core/__init__.py
+++ b/temporian/core/__init__.py
@@ -11,4 +11,3 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-

--- a/temporian/core/backends.py
+++ b/temporian/core/backends.py
@@ -22,12 +22,11 @@ def raise_(exception: Exception):
 
 BACKENDS = {
     "cpp": {
-        "event":
-            lambda: raise_(NotImplementedError()),
-        "evaluate_schedule_fn":
-            lambda data, schedule: raise_(NotImplementedError()),
-        "read_csv_fn":
-            lambda path: raise_(NotImplementedError()),
+        "event": lambda: raise_(NotImplementedError()),
+        "evaluate_schedule_fn": lambda data, schedule: raise_(
+            NotImplementedError()
+        ),
+        "read_csv_fn": lambda path: raise_(NotImplementedError()),
     },
     "pandas": {
         "event": pandas_event.PandasEvent,

--- a/temporian/core/backends.py
+++ b/temporian/core/backends.py
@@ -17,16 +17,17 @@ from temporian.implementation.pandas.data import event as pandas_event
 
 
 def raise_(exception: Exception):
-  raise exception
+    raise exception
 
 
 BACKENDS = {
     "cpp": {
-        "event": lambda: raise_(NotImplementedError()),
-        "evaluate_schedule_fn": lambda data, schedule: raise_(
-            NotImplementedError()
-        ),
-        "read_csv_fn": lambda path: raise_(NotImplementedError()),
+        "event":
+            lambda: raise_(NotImplementedError()),
+        "evaluate_schedule_fn":
+            lambda data, schedule: raise_(NotImplementedError()),
+        "read_csv_fn":
+            lambda path: raise_(NotImplementedError()),
     },
     "pandas": {
         "event": pandas_event.PandasEvent,

--- a/temporian/core/core.py
+++ b/temporian/core/core.py
@@ -20,11 +20,11 @@ from temporian.proto import core_pb2 as pb
 
 
 def does_nothing() -> None:
-  logging.info("Hello world")
+    logging.info("Hello world")
 
 
 def create_toy_processor() -> pb.Processor:
-  """Create a toy processor.
+    """Create a toy processor.
 
   Theoretical result of:
     x = t.read_event(table="sales_records")
@@ -34,64 +34,60 @@ def create_toy_processor() -> pb.Processor:
     Toy processor.
   """
 
-  p = pb.Processor()
+    p = pb.Processor()
 
-  # The INPUT_PLACEHOLDER op injects data in the processor based on some input
-  # data provided by the user.
-  feed_op = pb.Operator(
-      id="op_1",
-      operator_def_key="INPUT_PLACEHOLDER",
-      attributes=[pb.Operator.Attribute(key="table", str="sales_records")],
-      outputs=[pb.Operator.EventArgument(key="data", event_id="event_1")],
-  )
-  p.operators.append(feed_op)
+    # The INPUT_PLACEHOLDER op injects data in the processor based on some input
+    # data provided by the user.
+    feed_op = pb.Operator(
+        id="op_1",
+        operator_def_key="INPUT_PLACEHOLDER",
+        attributes=[pb.Operator.Attribute(key="table", str="sales_records")],
+        outputs=[pb.Operator.EventArgument(key="data", event_id="event_1")],
+    )
+    p.operators.append(feed_op)
 
-  # Definition of the feed op results.
-  p.samplings.append(pb.Sampling(id="sampling_1"))
+    # Definition of the feed op results.
+    p.samplings.append(pb.Sampling(id="sampling_1"))
 
-  p.events.append(
-      pb.Event(
-          id="event_1",
-          sampling_id="sampling_1",
-          feature_ids=["sales"],
-      )
-  )
+    p.events.append(
+        pb.Event(
+            id="event_1",
+            sampling_id="sampling_1",
+            feature_ids=["sales"],
+        ))
 
-  p.features.append(
-      pb.Feature(
-          id="sales",
-          type=pb.Feature.FLOAT,
-          sampling_id="sampling_1",
-      )
-  )
+    p.features.append(
+        pb.Feature(
+            id="sales",
+            type=pb.Feature.FLOAT,
+            sampling_id="sampling_1",
+        ))
 
-  # We apply a SMA on the "price" feature using the same sampling rate as the
-  # sales.
-  sma = pb.Operator(
-      id="op_2",
-      operator_def_key="SMA",
-      attributes=[],
-      inputs=[pb.Operator.EventArgument(key="data", event_id="event_1")],
-      outputs=[pb.Operator.EventArgument(key="result", event_id="event_2")],
-  )
-  p.operators.append(sma)
+    # We apply a SMA on the "price" feature using the same sampling rate as the
+    # sales.
+    sma = pb.Operator(
+        id="op_2",
+        operator_def_key="SMA",
+        attributes=[],
+        inputs=[pb.Operator.EventArgument(key="data", event_id="event_1")],
+        outputs=[pb.Operator.EventArgument(key="result", event_id="event_2")],
+    )
+    p.operators.append(sma)
 
-  # Definition of the SMA op results.
+    # Definition of the SMA op results.
 
-  p.events.append(
-      pb.Event(
-          id="event_2",
-          sampling_id="sampling_1",
-          feature_ids=["sma_sales"],
-      )
-  )
+    p.events.append(
+        pb.Event(
+            id="event_2",
+            sampling_id="sampling_1",
+            feature_ids=["sma_sales"],
+        ))
 
-  p.features.append(
-      pb.Feature(
-          id="sma_sales",
-          type=pb.Feature.FLOAT,
-          sampling_id="sampling_1",
-      )
-  )
+    p.features.append(
+        pb.Feature(
+            id="sma_sales",
+            type=pb.Feature.FLOAT,
+            sampling_id="sampling_1",
+        ))
 
-  return p
+    return p

--- a/temporian/core/core.py
+++ b/temporian/core/core.py
@@ -26,13 +26,13 @@ def does_nothing() -> None:
 def create_toy_processor() -> pb.Processor:
     """Create a toy processor.
 
-  Theoretical result of:
-    x = t.read_event(table="sales_records")
-    y = t.sma(x["sales"], windows=5)
+    Theoretical result of:
+      x = t.read_event(table="sales_records")
+      y = t.sma(x["sales"], windows=5)
 
-  Returns:
-    Toy processor.
-  """
+    Returns:
+      Toy processor.
+    """
 
     p = pb.Processor()
 
@@ -54,14 +54,16 @@ def create_toy_processor() -> pb.Processor:
             id="event_1",
             sampling_id="sampling_1",
             feature_ids=["sales"],
-        ))
+        )
+    )
 
     p.features.append(
         pb.Feature(
             id="sales",
             type=pb.Feature.FLOAT,
             sampling_id="sampling_1",
-        ))
+        )
+    )
 
     # We apply a SMA on the "price" feature using the same sampling rate as the
     # sales.
@@ -81,13 +83,15 @@ def create_toy_processor() -> pb.Processor:
             id="event_2",
             sampling_id="sampling_1",
             feature_ids=["sma_sales"],
-        ))
+        )
+    )
 
     p.features.append(
         pb.Feature(
             id="sma_sales",
             type=pb.Feature.FLOAT,
             sampling_id="sampling_1",
-        ))
+        )
+    )
 
     return p

--- a/temporian/core/data/__init__.py
+++ b/temporian/core/data/__init__.py
@@ -11,4 +11,3 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-

--- a/temporian/core/data/event.py
+++ b/temporian/core/data/event.py
@@ -21,7 +21,6 @@ from temporian.core.data.sampling import Sampling
 
 
 class Event(object):
-
     def __init__(
         self,
         features: List[Feature],
@@ -31,7 +30,7 @@ class Event(object):
         self._sampling = sampling
 
     def __repr__(self):
-        return f'Event<features:{self._features},sampling:{self._sampling},id:{id(self)}>'
+        return f"Event<features:{self._features},sampling:{self._sampling},id:{id(self)}>"
 
     def sampling(self):
         return self._sampling

--- a/temporian/core/data/event.py
+++ b/temporian/core/data/event.py
@@ -22,19 +22,19 @@ from temporian.core.data.sampling import Sampling
 
 class Event(object):
 
-  def __init__(
-      self,
-      features: List[Feature],
-      sampling: Sampling,
-  ):
-    self._features = features
-    self._sampling = sampling
+    def __init__(
+        self,
+        features: List[Feature],
+        sampling: Sampling,
+    ):
+        self._features = features
+        self._sampling = sampling
 
-  def __repr__(self):
-    return f'Event<features:{self._features},sampling:{self._sampling},id:{id(self)}>'
+    def __repr__(self):
+        return f'Event<features:{self._features},sampling:{self._sampling},id:{id(self)}>'
 
-  def sampling(self):
-    return self._sampling
+    def sampling(self):
+        return self._sampling
 
-  def features(self):
-    return self._features
+    def features(self):
+        return self._features

--- a/temporian/core/data/feature.py
+++ b/temporian/core/data/feature.py
@@ -21,32 +21,32 @@ from temporian.core.data import sampling as sampling_lib
 
 class Feature(object):
 
-  def __init__(
-      self,
-      name: str,
-      dtype: Any,
-      sampling: Optional[sampling_lib.Sampling] = None,
-      creator: Optional[Any] = None,
-  ):
-    self._name = name
-    self._sampling = sampling
-    self._dtype = dtype
-    self._creator = creator
+    def __init__(
+        self,
+        name: str,
+        dtype: Any,
+        sampling: Optional[sampling_lib.Sampling] = None,
+        creator: Optional[Any] = None,
+    ):
+        self._name = name
+        self._sampling = sampling
+        self._dtype = dtype
+        self._creator = creator
 
-  def __repr__(self):
-    return f'Feature<name:{self._name},dtype:{self._dtype},sampling:{self._sampling},creator:{self.creator()},id:{id(self)}>'
+    def __repr__(self):
+        return f'Feature<name:{self._name},dtype:{self._dtype},sampling:{self._sampling},creator:{self.creator()},id:{id(self)}>'
 
-  def name(self):
-    return self._name
+    def name(self):
+        return self._name
 
-  def dtype(self):
-    return self._dtype
+    def dtype(self):
+        return self._dtype
 
-  def sampling(self) -> Optional[sampling_lib.Sampling]:
-    return self._sampling
+    def sampling(self) -> Optional[sampling_lib.Sampling]:
+        return self._sampling
 
-  def creator(self):
-    return self._creator
+    def creator(self):
+        return self._creator
 
-  def set_sampling(self, sampling: sampling_lib.Sampling):
-    self._sampling = sampling
+    def set_sampling(self, sampling: sampling_lib.Sampling):
+        self._sampling = sampling

--- a/temporian/core/data/feature.py
+++ b/temporian/core/data/feature.py
@@ -20,7 +20,6 @@ from temporian.core.data import sampling as sampling_lib
 
 
 class Feature(object):
-
     def __init__(
         self,
         name: str,
@@ -34,7 +33,7 @@ class Feature(object):
         self._creator = creator
 
     def __repr__(self):
-        return f'Feature<name:{self._name},dtype:{self._dtype},sampling:{self._sampling},creator:{self.creator()},id:{id(self)}>'
+        return f"Feature<name:{self._name},dtype:{self._dtype},sampling:{self._sampling},creator:{self.creator()},id:{id(self)}>"
 
     def name(self):
         return self._name

--- a/temporian/core/data/sampling.py
+++ b/temporian/core/data/sampling.py
@@ -18,9 +18,8 @@ from typing import List
 
 
 class Sampling(object):
-
     def __init__(self, index: List[str]):
         self._index = index
 
     def __repr__(self):
-        return f'Sampling<index:{self._index},id:{id(self)}>'
+        return f"Sampling<index:{self._index},id:{id(self)}>"

--- a/temporian/core/data/sampling.py
+++ b/temporian/core/data/sampling.py
@@ -19,8 +19,8 @@ from typing import List
 
 class Sampling(object):
 
-  def __init__(self, index: List[str]):
-    self._index = index
+    def __init__(self, index: List[str]):
+        self._index = index
 
-  def __repr__(self):
-    return f'Sampling<index:{self._index},id:{id(self)}>'
+    def __repr__(self):
+        return f'Sampling<index:{self._index},id:{id(self)}>'

--- a/temporian/core/evaluator.py
+++ b/temporian/core/evaluator.py
@@ -49,11 +49,14 @@ def evaluate(
         # TODO: improve error message
         raise TypeError(
             f"schedule_graph query argument must be one of {Query}. Received"
-            f" {type(query)}.")
+            f" {type(query)}."
+        )
 
     # get features from events
     features_to_compute = [
-        feature for event in events_to_compute for feature in event.features()  # pytype: disable=attribute-error
+        feature
+        for event in events_to_compute
+        for feature in event.features()  # pytype: disable=attribute-error
     ]
 
     # get backend
@@ -69,8 +72,9 @@ def evaluate(
     materialized_input_data = {}
     for input_event, input_event_spec in input_data.items():
         if not isinstance(input_event_spec, event):
-            input_event_spec = read_csv_fn(input_event_spec,
-                                           input_event.sampling())
+            input_event_spec = read_csv_fn(
+                input_event_spec, input_event.sampling()
+            )
         materialized_input_data[input_event] = input_event_spec
 
     # evaluate schedule

--- a/temporian/core/evaluator.py
+++ b/temporian/core/evaluator.py
@@ -34,84 +34,86 @@ def evaluate(
     input_data: Data,
     backend: AvailableBackends = "pandas",
 ) -> Dict[Event, Any]:
-  """Evaluates a query on data."""
+    """Evaluates a query on data."""
 
-  if isinstance(query, Event):
-    events_to_compute = [query]
+    if isinstance(query, Event):
+        events_to_compute = [query]
 
-  elif isinstance(query, list):
-    events_to_compute = query
+    elif isinstance(query, list):
+        events_to_compute = query
 
-  elif isinstance(query, dict):
-    raise NotImplementedError()
+    elif isinstance(query, dict):
+        raise NotImplementedError()
 
-  else:
-    # TODO: improve error message
-    raise TypeError(
-        f"schedule_graph query argument must be one of {Query}. Received"
-        f" {type(query)}.")
+    else:
+        # TODO: improve error message
+        raise TypeError(
+            f"schedule_graph query argument must be one of {Query}. Received"
+            f" {type(query)}.")
 
-  # get features from events
-  features_to_compute = [
-      feature for event in events_to_compute for feature in event.features()  # pytype: disable=attribute-error
-  ]
+    # get features from events
+    features_to_compute = [
+        feature for event in events_to_compute for feature in event.features()  # pytype: disable=attribute-error
+    ]
 
-  # get backend
-  selected_backend = backends.BACKENDS[backend]
-  event = selected_backend["event"]
-  evaluate_schedule_fn = selected_backend["evaluate_schedule_fn"]
-  read_csv_fn = selected_backend["read_csv_fn"]
+    # get backend
+    selected_backend = backends.BACKENDS[backend]
+    event = selected_backend["event"]
+    evaluate_schedule_fn = selected_backend["evaluate_schedule_fn"]
+    read_csv_fn = selected_backend["read_csv_fn"]
 
-  # calculate opeartor schedule
-  schedule = get_operator_schedule(features_to_compute)
+    # calculate opeartor schedule
+    schedule = get_operator_schedule(features_to_compute)
 
-  # materialize input data. TODO: separate this logic
-  materialized_input_data = {}
-  for input_event, input_event_spec in input_data.items():
-    if not isinstance(input_event_spec, event):
-      input_event_spec = read_csv_fn(input_event_spec, input_event.sampling())
-    materialized_input_data[input_event] = input_event_spec
+    # materialize input data. TODO: separate this logic
+    materialized_input_data = {}
+    for input_event, input_event_spec in input_data.items():
+        if not isinstance(input_event_spec, event):
+            input_event_spec = read_csv_fn(input_event_spec,
+                                           input_event.sampling())
+        materialized_input_data[input_event] = input_event_spec
 
-  # evaluate schedule
-  outputs = evaluate_schedule_fn(materialized_input_data, schedule)
+    # evaluate schedule
+    outputs = evaluate_schedule_fn(materialized_input_data, schedule)
 
-  return {event: outputs[event] for event in events_to_compute}
+    return {event: outputs[event] for event in events_to_compute}
 
 
 def get_operator_schedule(query: List[Feature]) -> List[base.Operator]:
-  # TODO: add depth calculation for parallelization
-  # TODO: Make "query" a Set
+    # TODO: add depth calculation for parallelization
+    # TODO: Make "query" a Set
 
-  operators_to_compute = []  # TODO: implement as ordered set
-  visited_features = set()
-  pending_features = list(query.copy())  # TODO: implement as ordered set
-  while pending_features:
-    feature = next(iter(pending_features))
-    visited_features.add(feature)
+    operators_to_compute = []  # TODO: implement as ordered set
+    visited_features = set()
+    pending_features = list(query.copy())  # TODO: implement as ordered set
+    while pending_features:
+        feature = next(iter(pending_features))
+        visited_features.add(feature)
 
-    if feature.creator() is None:
-      # is input feature
-      pending_features.remove(feature)
-      continue
+        if feature.creator() is None:
+            # is input feature
+            pending_features.remove(feature)
+            continue
 
-    # required input features to compute this feature
-    creator_input_features = {
-        input_feature for input_event in feature.creator().inputs().values()
-        for input_feature in input_event.features()
-    }
+        # required input features to compute this feature
+        creator_input_features = {
+            input_feature
+            for input_event in feature.creator().inputs().values()
+            for input_feature in input_event.features()
+        }
 
-    # check if all required input features have already been visited
-    if creator_input_features.issubset(visited_features):
-      # feature can be computed - remove it from pending_features
-      pending_features.remove(feature)
+        # check if all required input features have already been visited
+        if creator_input_features.issubset(visited_features):
+            # feature can be computed - remove it from pending_features
+            pending_features.remove(feature)
 
-      # add operator at the end of operators_to_compute
-      if feature.creator() not in operators_to_compute:
-        operators_to_compute.append(feature.creator())
+            # add operator at the end of operators_to_compute
+            if feature.creator() not in operators_to_compute:
+                operators_to_compute.append(feature.creator())
 
-      continue
+            continue
 
-    # add required input features at the beginning of pending_features
-    pending_features = list(creator_input_features) + pending_features
+        # add required input features at the beginning of pending_features
+        pending_features = list(creator_input_features) + pending_features
 
-  return operators_to_compute
+    return operators_to_compute

--- a/temporian/core/operator_lib.py
+++ b/temporian/core/operator_lib.py
@@ -18,9 +18,9 @@ _OPERATORS = {}
 
 
 def register_operator(operator_class):
-  """Registers an operator."""
+    """Registers an operator."""
 
-  definition = operator_class.build_op_definition()
-  if definition.key in _OPERATORS:
-    raise ValueError("Operator already registered")
-  _OPERATORS[definition.key] = operator_class
+    definition = operator_class.build_op_definition()
+    if definition.key in _OPERATORS:
+        raise ValueError("Operator already registered")
+    _OPERATORS[definition.key] = operator_class

--- a/temporian/core/operators/assign.py
+++ b/temporian/core/operators/assign.py
@@ -22,41 +22,41 @@ from temporian.proto import core_pb2 as pb
 
 
 class AssignOperator(Operator):
-  """Simple moving average operator."""
+    """Simple moving average operator."""
 
-  def __init__(
-      self,
-      assignee_event: Event,
-      assigned_event: Event,
-  ):
-    super().__init__()
+    def __init__(
+        self,
+        assignee_event: Event,
+        assigned_event: Event,
+    ):
+        super().__init__()
 
-    # inputs
-    self.add_input("assignee_event", assignee_event)
-    self.add_input("assigned_event", assigned_event)
+        # inputs
+        self.add_input("assignee_event", assignee_event)
+        self.add_input("assigned_event", assigned_event)
 
-    # outputs
-    output_features = assignee_event.features() + [
-        Feature(name=feature.name(), dtype=feature.dtype(), creator=self)
-        for feature in assigned_event.features()
-    ]
-    output_sampling = assignee_event.sampling()
-    self.add_output(
-        "output",
-        Event(features=output_features, sampling=output_sampling),
-    )
-    self.check()
+        # outputs
+        output_features = assignee_event.features() + [
+            Feature(name=feature.name(), dtype=feature.dtype(), creator=self)
+            for feature in assigned_event.features()
+        ]
+        output_sampling = assignee_event.sampling()
+        self.add_output(
+            "output",
+            Event(features=output_features, sampling=output_sampling),
+        )
+        self.check()
 
-  @classmethod
-  def build_op_definition(cls) -> pb.OperatorDef:
-    return pb.OperatorDef(
-        key="ASSIGN",
-        inputs=[
-            pb.OperatorDef.Input(key="assignee_event"),
-            pb.OperatorDef.Input(key="assigned_event"),
-        ],
-        outputs=[pb.OperatorDef.Output(key="output")],
-    )
+    @classmethod
+    def build_op_definition(cls) -> pb.OperatorDef:
+        return pb.OperatorDef(
+            key="ASSIGN",
+            inputs=[
+                pb.OperatorDef.Input(key="assignee_event"),
+                pb.OperatorDef.Input(key="assigned_event"),
+            ],
+            outputs=[pb.OperatorDef.Output(key="output")],
+        )
 
 
 operator_lib.register_operator(AssignOperator)
@@ -66,4 +66,4 @@ def assign(
     assignee_event: Event,
     assigned_event: Event,
 ) -> Event:
-  return AssignOperator(assignee_event, assigned_event).outputs()["output"]
+    return AssignOperator(assignee_event, assigned_event).outputs()["output"]

--- a/temporian/core/operators/base.py
+++ b/temporian/core/operators/base.py
@@ -24,14 +24,14 @@ from temporian.proto import core_pb2 as pb
 class OperatorExceptionDecorator(object):
     """Adds details about an operator to exceptions raised in a block.
 
-  Usage example:
-    with OperatorExceptionDecorator(operator):
-      raise ValueError("Something is wrong")
+    Usage example:
+      with OperatorExceptionDecorator(operator):
+        raise ValueError("Something is wrong")
 
-    Will print
-      Something is wrong
-      In operator NAME_OF_THE_OPERATOR
-  """
+      Will print
+        Something is wrong
+        In operator NAME_OF_THE_OPERATOR
+    """
 
     def __init__(self, operator):
         self._operator = operator
@@ -46,9 +46,12 @@ class OperatorExceptionDecorator(object):
 
         if exc_val:
             # Add operator details in the exception.
-            exc_val.args += ((
-                'In operator'
-                f' "{self._operator.__class__.build_op_definition().key}".'),)
+            exc_val.args += (
+                (
+                    "In operator"
+                    f' "{self._operator.__class__.build_op_definition().key}".'
+                ),
+            )
         return False
 
 
@@ -61,7 +64,10 @@ class Operator(ABC):
         self._attributes: dict[str, Union[str, int]] = {}
 
     def __str__(self):
-        return f'Operator<key: {self.definition().key}, id: {id(self)}, attributes: {self.attributes()}>'
+        return (
+            f"Operator<key: {self.definition().key}, id: {id(self)},"
+            f" attributes: {self.attributes()}>"
+        )
 
     def is_placeholder(self) -> bool:
         return self.definition().place_holder
@@ -83,8 +89,10 @@ class Operator(ABC):
         with OperatorExceptionDecorator(self):
             # Check that expected inputs are present
             for expected_input in definition.inputs:
-                if (not expected_input.is_optional and
-                        expected_input.key not in self._inputs):
+                if (
+                    not expected_input.is_optional
+                    and expected_input.key not in self._inputs
+                ):
                     raise ValueError(f'Missing input "{expected_input.key}".')
 
             # Check that no unexpected inputs are present

--- a/temporian/core/operators/base.py
+++ b/temporian/core/operators/base.py
@@ -22,7 +22,7 @@ from temporian.proto import core_pb2 as pb
 
 
 class OperatorExceptionDecorator(object):
-  """Adds details about an operator to exceptions raised in a block.
+    """Adds details about an operator to exceptions raised in a block.
 
   Usage example:
     with OperatorExceptionDecorator(operator):
@@ -33,97 +33,97 @@ class OperatorExceptionDecorator(object):
       In operator NAME_OF_THE_OPERATOR
   """
 
-  def __init__(self, operator):
-    self._operator = operator
+    def __init__(self, operator):
+        self._operator = operator
 
-  def __enter__(self):
-    pass
+    def __enter__(self):
+        pass
 
-  def __exit__(self, exc_type, exc_val, traceback):
-    if not exc_type:
-      # No exceptions
-      return True
+    def __exit__(self, exc_type, exc_val, traceback):
+        if not exc_type:
+            # No exceptions
+            return True
 
-    if exc_val:
-      # Add operator details in the exception.
-      exc_val.args += ((
-          'In operator'
-          f' "{self._operator.__class__.build_op_definition().key}".'),)
-    return False
+        if exc_val:
+            # Add operator details in the exception.
+            exc_val.args += ((
+                'In operator'
+                f' "{self._operator.__class__.build_op_definition().key}".'),)
+        return False
 
 
 class Operator(ABC):
-  """Operator interface."""
+    """Operator interface."""
 
-  def __init__(self):
-    self._inputs = {}
-    self._outputs = {}
-    self._attributes: dict[str, Union[str, int]] = {}
+    def __init__(self):
+        self._inputs = {}
+        self._outputs = {}
+        self._attributes: dict[str, Union[str, int]] = {}
 
-  def __str__(self):
-    return f'Operator<key: {self.definition().key}, id: {id(self)}, attributes: {self.attributes()}>'
+    def __str__(self):
+        return f'Operator<key: {self.definition().key}, id: {id(self)}, attributes: {self.attributes()}>'
 
-  def is_placeholder(self) -> bool:
-    return self.definition().place_holder
+    def is_placeholder(self) -> bool:
+        return self.definition().place_holder
 
-  def outputs(self) -> dict[str, Event]:
-    return self._outputs
+    def outputs(self) -> dict[str, Event]:
+        return self._outputs
 
-  def inputs(self) -> dict[str, Event]:
-    return self._inputs
+    def inputs(self) -> dict[str, Event]:
+        return self._inputs
 
-  def attributes(self) -> dict[str, Any]:
-    return self._attributes
+    def attributes(self) -> dict[str, Any]:
+        return self._attributes
 
-  def check(self) -> None:
-    """Ensures that the operator is valid."""
+    def check(self) -> None:
+        """Ensures that the operator is valid."""
 
-    definition = self.definition()
+        definition = self.definition()
 
-    with OperatorExceptionDecorator(self):
-      # Check that expected inputs are present
-      for expected_input in definition.inputs:
-        if (not expected_input.is_optional and
-            expected_input.key not in self._inputs):
-          raise ValueError(f'Missing input "{expected_input.key}".')
+        with OperatorExceptionDecorator(self):
+            # Check that expected inputs are present
+            for expected_input in definition.inputs:
+                if (not expected_input.is_optional and
+                        expected_input.key not in self._inputs):
+                    raise ValueError(f'Missing input "{expected_input.key}".')
 
-      # Check that no unexpected inputs are present
-      for available_input in self._inputs:
-        if available_input not in [v.key for v in definition.inputs]:
-          raise ValueError(f'Unexpected input "{available_input}".')
+            # Check that no unexpected inputs are present
+            for available_input in self._inputs:
+                if available_input not in [v.key for v in definition.inputs]:
+                    raise ValueError(f'Unexpected input "{available_input}".')
 
-      # Check that expected outputs are present
-      for expected_output in definition.outputs:
-        if expected_output.key not in self._outputs:
-          raise ValueError(f'Missing output "{expected_output.key}".')
+            # Check that expected outputs are present
+            for expected_output in definition.outputs:
+                if expected_output.key not in self._outputs:
+                    raise ValueError(f'Missing output "{expected_output.key}".')
 
-      # Check that no unexpected outputs are present
-      for available_output in self._outputs:
-        if available_output not in [v.key for v in definition.outputs]:
-          raise ValueError(f'Unexpected output "{available_output}".')
+            # Check that no unexpected outputs are present
+            for available_output in self._outputs:
+                if available_output not in [v.key for v in definition.outputs]:
+                    raise ValueError(f'Unexpected output "{available_output}".')
 
-  def add_input(self, key: str, event: Event) -> None:
-    with OperatorExceptionDecorator(self):
-      if key in self._inputs:
-        raise ValueError(f'Already existing input "{key}".')
-      self._inputs[key] = event
+    def add_input(self, key: str, event: Event) -> None:
+        with OperatorExceptionDecorator(self):
+            if key in self._inputs:
+                raise ValueError(f'Already existing input "{key}".')
+            self._inputs[key] = event
 
-  def add_output(self, key: str, event: Event) -> None:
-    with OperatorExceptionDecorator(self):
-      if key in self._outputs:
-        raise ValueError(f'Already existing output "{key}".')
-      self._outputs[key] = event
+    def add_output(self, key: str, event: Event) -> None:
+        with OperatorExceptionDecorator(self):
+            if key in self._outputs:
+                raise ValueError(f'Already existing output "{key}".')
+            self._outputs[key] = event
 
-  def add_attribute(self, key: str, value: Any) -> None:
-    with OperatorExceptionDecorator(self):
-      if key in self._attributes:
-        raise ValueError(f'Already existing attribute "{key}".')
-      self._attributes[key] = value
-    print(str(self))
+    def add_attribute(self, key: str, value: Any) -> None:
+        with OperatorExceptionDecorator(self):
+            if key in self._attributes:
+                raise ValueError(f'Already existing attribute "{key}".')
+            self._attributes[key] = value
+        print(str(self))
 
-  @classmethod
-  def build_op_definition(cls) -> pb.OperatorDef:
-    raise NotImplementedError()
+    @classmethod
+    def build_op_definition(cls) -> pb.OperatorDef:
+        raise NotImplementedError()
 
-  def definition(self):
-    return self.__class__.build_op_definition()
+    def definition(self):
+        return self.__class__.build_op_definition()

--- a/temporian/core/operators/place_holder.py
+++ b/temporian/core/operators/place_holder.py
@@ -25,41 +25,41 @@ from temporian.proto import core_pb2 as pb
 
 
 class PlaceHolder(base.Operator):
-  """Place holder operator."""
+    """Place holder operator."""
 
-  def __init__(self, features: List[feature_lib.Feature], index: List[str]):
-    super().__init__()
+    def __init__(self, features: List[feature_lib.Feature], index: List[str]):
+        super().__init__()
 
-    sampling = sampling_lib.Sampling(index=index)
+        sampling = sampling_lib.Sampling(index=index)
 
-    for feature in features:
-      if feature.sampling() is not None:
-        raise ValueError("Cannot create a placeholder on existing features.")
-      feature.set_sampling(sampling)
+        for feature in features:
+            if feature.sampling() is not None:
+                raise ValueError(
+                    "Cannot create a placeholder on existing features.")
+            feature.set_sampling(sampling)
 
-    self.add_output(
-        "output",
-        event_lib.Event(
-            features=features,
-            sampling=sampling,
-        ),
-    )
+        self.add_output(
+            "output",
+            event_lib.Event(
+                features=features,
+                sampling=sampling,
+            ),
+        )
 
-    self.check()
+        self.check()
 
-  @classmethod
-  def build_op_definition(cls) -> pb.OperatorDef:
-    return pb.OperatorDef(
-        key="PLACE_HOLDER",
-        place_holder=True,
-        outputs=[pb.OperatorDef.Output(key="output")],
-    )
+    @classmethod
+    def build_op_definition(cls) -> pb.OperatorDef:
+        return pb.OperatorDef(
+            key="PLACE_HOLDER",
+            place_holder=True,
+            outputs=[pb.OperatorDef.Output(key="output")],
+        )
 
 
 operator_lib.register_operator(PlaceHolder)
 
 
-def place_holder(
-    features: List[feature_lib.Feature], index: List[str]
-) -> event_lib.Event:
-  return PlaceHolder(features=features, index=index).outputs()["output"]
+def place_holder(features: List[feature_lib.Feature],
+                 index: List[str]) -> event_lib.Event:
+    return PlaceHolder(features=features, index=index).outputs()["output"]

--- a/temporian/core/operators/place_holder.py
+++ b/temporian/core/operators/place_holder.py
@@ -35,7 +35,8 @@ class PlaceHolder(base.Operator):
         for feature in features:
             if feature.sampling() is not None:
                 raise ValueError(
-                    "Cannot create a placeholder on existing features.")
+                    "Cannot create a placeholder on existing features."
+                )
             feature.set_sampling(sampling)
 
         self.add_output(
@@ -60,6 +61,7 @@ class PlaceHolder(base.Operator):
 operator_lib.register_operator(PlaceHolder)
 
 
-def place_holder(features: List[feature_lib.Feature],
-                 index: List[str]) -> event_lib.Event:
+def place_holder(
+    features: List[feature_lib.Feature], index: List[str]
+) -> event_lib.Event:
     return PlaceHolder(features=features, index=index).outputs()["output"]

--- a/temporian/core/operators/simple_moving_average.py
+++ b/temporian/core/operators/simple_moving_average.py
@@ -44,10 +44,13 @@ class SimpleMovingAverage(Operator):
         self.add_input("data", data)
 
         output_features = [  # pylint: disable=g-complex-comprehension
-            Feature(name=f"sma_{f.name()}",
-                    dtype=f.dtype(),
-                    sampling=sampling,
-                    creator=self) for f in data.features()
+            Feature(
+                name=f"sma_{f.name()}",
+                dtype=f.dtype(),
+                sampling=sampling,
+                creator=self,
+            )
+            for f in data.features()
         ]
 
         self.add_output(

--- a/temporian/core/operators/simple_moving_average.py
+++ b/temporian/core/operators/simple_moving_average.py
@@ -24,59 +24,59 @@ from temporian.proto import core_pb2 as pb
 
 
 class SimpleMovingAverage(Operator):
-  """Simple moving average operator."""
+    """Simple moving average operator."""
 
-  def __init__(
-      self,
-      data: Event,
-      window_length: str,
-      sampling: Optional[Event] = None,
-  ):
-    super().__init__()
+    def __init__(
+        self,
+        data: Event,
+        window_length: str,
+        sampling: Optional[Event] = None,
+    ):
+        super().__init__()
 
-    self.add_attribute("window_length", window_length)
+        self.add_attribute("window_length", window_length)
 
-    if sampling is not None:
-      self.add_input("sampling", sampling)
-    else:
-      sampling = data.sampling()
+        if sampling is not None:
+            self.add_input("sampling", sampling)
+        else:
+            sampling = data.sampling()
 
-    self.add_input("data", data)
+        self.add_input("data", data)
 
-    output_features = [  # pylint: disable=g-complex-comprehension
-        Feature(name=f"sma_{f.name()}",
-                dtype=f.dtype(),
+        output_features = [  # pylint: disable=g-complex-comprehension
+            Feature(name=f"sma_{f.name()}",
+                    dtype=f.dtype(),
+                    sampling=sampling,
+                    creator=self) for f in data.features()
+        ]
+
+        self.add_output(
+            "output",
+            Event(
+                features=output_features,
                 sampling=sampling,
-                creator=self) for f in data.features()
-    ]
-
-    self.add_output(
-        "output",
-        Event(
-            features=output_features,
-            sampling=sampling,
-        ),
-    )
-
-    self.check()
-
-  @classmethod
-  def build_op_definition(cls) -> pb.OperatorDef:
-    return pb.OperatorDef(
-        key="SIMPLE_MOVING_AVERAGE",
-        attributes=[
-            pb.OperatorDef.Attribute(
-                key="window_length",
-                type=pb.OperatorDef.Attribute.Type.STRING,
-                is_optional=False,
             ),
-        ],
-        inputs=[
-            pb.OperatorDef.Input(key="data"),
-            pb.OperatorDef.Input(key="sampling", is_optional=True),
-        ],
-        outputs=[pb.OperatorDef.Output(key="output")],
-    )
+        )
+
+        self.check()
+
+    @classmethod
+    def build_op_definition(cls) -> pb.OperatorDef:
+        return pb.OperatorDef(
+            key="SIMPLE_MOVING_AVERAGE",
+            attributes=[
+                pb.OperatorDef.Attribute(
+                    key="window_length",
+                    type=pb.OperatorDef.Attribute.Type.STRING,
+                    is_optional=False,
+                ),
+            ],
+            inputs=[
+                pb.OperatorDef.Input(key="data"),
+                pb.OperatorDef.Input(key="sampling", is_optional=True),
+            ],
+            outputs=[pb.OperatorDef.Output(key="output")],
+        )
 
 
 operator_lib.register_operator(SimpleMovingAverage)
@@ -87,8 +87,8 @@ def sma(
     window_length: str,
     sampling: Optional[Event] = None,
 ) -> Event:
-  return SimpleMovingAverage(
-      data=data,
-      window_length=window_length,
-      sampling=sampling,
-  ).outputs()["output"]
+    return SimpleMovingAverage(
+        data=data,
+        window_length=window_length,
+        sampling=sampling,
+    ).outputs()["output"]

--- a/temporian/core/processor.py
+++ b/temporian/core/processor.py
@@ -23,53 +23,53 @@ from temporian.core.operators import base
 
 
 class Preprocessor(object):
-  """A set of operators, events, features and samplings."""
+    """A set of operators, events, features and samplings."""
 
-  def __init__(self):
-    self._operators: Set[base.Operator] = set()
-    self._features: Set[Feature] = set()
+    def __init__(self):
+        self._operators: Set[base.Operator] = set()
+        self._features: Set[Feature] = set()
 
-  def samplings(self) -> Set[Sampling]:
-    samplings = set()
-    for feature in self._features:
-      if feature.sampling() is not None:
-        samplings.add(feature.sampling())
-    return samplings
+    def samplings(self) -> Set[Sampling]:
+        samplings = set()
+        for feature in self._features:
+            if feature.sampling() is not None:
+                samplings.add(feature.sampling())
+        return samplings
 
-  def events(self) -> Set[Event]:
-    events = set()
-    for operator in self._operators:
-      for event in operator.inputs().values():
-        events.add(event)
-      for event in operator.outputs().values():
-        events.add(event)
-    return events
+    def events(self) -> Set[Event]:
+        events = set()
+        for operator in self._operators:
+            for event in operator.inputs().values():
+                events.add(event)
+            for event in operator.outputs().values():
+                events.add(event)
+        return events
 
-  def features(self):
-    return self._features
+    def features(self):
+        return self._features
 
-  def operators(self):
-    return self._operators
+    def operators(self):
+        return self._operators
 
-  def __repr__(self):
-    s = "Preprocessor\n============\n"
+    def __repr__(self):
+        s = "Preprocessor\n============\n"
 
-    def p(title, elements):
-      nonlocal s
-      s += f"{title} ({len(elements)}):\n"
-      for e in elements:
-        s += f"\t{e}\n"
-      s += "\n"
+        def p(title, elements):
+            nonlocal s
+            s += f"{title} ({len(elements)}):\n"
+            for e in elements:
+                s += f"\t{e}\n"
+            s += "\n"
 
-    p("Operators", self._operators)
-    p("Features", self._features)
-    p("Samplings", self.samplings())
-    p("Events", self.events())
-    return s
+        p("Operators", self._operators)
+        p("Features", self._features)
+        p("Samplings", self.samplings())
+        p("Events", self.events())
+        return s
 
 
 def infer_processor(inputs: List[Event], outputs: List[Event]) -> Preprocessor:
-  """Create a self contained processor.
+    """Create a self contained processor.
 
   Fails if some inputs are missing.
 
@@ -81,74 +81,73 @@ def infer_processor(inputs: List[Event], outputs: List[Event]) -> Preprocessor:
     A preprocessor.
   """
 
-  p = Preprocessor()
+    p = Preprocessor()
 
-  # The following algorithm lists all the intermediate and missing input
-  # features of a computation graph.
-  #
-  # The algorithm works as follows:
-  #
-  # pending_features <= List of outputs
-  # done_features <= empty
-  #
-  # While pending feature not empty:
-  #   Extract a feature from pending_features
-  #   if feature is part of the provided input features => Continue
-  #   if feature has a creator operator
-  #     Adds all the features, of all the inputs of this operator to
-  #     pending_features. Skip the features already in pending_features or
-  #     done_features.
-  #   else:
-  #     add feature to the list of missing input features (will raise an error)
+    # The following algorithm lists all the intermediate and missing input
+    # features of a computation graph.
+    #
+    # The algorithm works as follows:
+    #
+    # pending_features <= List of outputs
+    # done_features <= empty
+    #
+    # While pending feature not empty:
+    #   Extract a feature from pending_features
+    #   if feature is part of the provided input features => Continue
+    #   if feature has a creator operator
+    #     Adds all the features, of all the inputs of this operator to
+    #     pending_features. Skip the features already in pending_features or
+    #     done_features.
+    #   else:
+    #     add feature to the list of missing input features (will raise an error)
 
-  pending_features: Set[Feature] = set()
-  for output_event in outputs:
-    pending_features.update(output_event.features())
+    pending_features: Set[Feature] = set()
+    for output_event in outputs:
+        pending_features.update(output_event.features())
 
-  input_features: Set[Feature] = set()
-  for input_event in inputs:
-    input_features.update(input_event.features())
+    input_features: Set[Feature] = set()
+    for input_event in inputs:
+        input_features.update(input_event.features())
 
-  done_features: Set[Feature] = set()
+    done_features: Set[Feature] = set()
 
-  # Text description of the missing features
-  missing_features: Set[str] = set()
+    # Text description of the missing features
+    missing_features: Set[str] = set()
 
-  while pending_features:
-    # Select a feature from pending_features
-    feature = next(iter(pending_features))
-    pending_features.remove(feature)
+    while pending_features:
+        # Select a feature from pending_features
+        feature = next(iter(pending_features))
+        pending_features.remove(feature)
 
-    p.features().add(feature)
+        p.features().add(feature)
 
-    assert feature not in done_features
+        assert feature not in done_features
 
-    if feature in input_features:
-      # The feature is provided by the user.
-      continue
-
-    if feature.creator() is None:
-      # The feature is missing.
-      missing_features.add(repr(feature))
-
-    elif feature.creator().is_placeholder():
-      # The user is expected to see the input of placeholders.
-      missing_features.add(
-          f"{repr(feature)} from placeholder {feature.creator()}"
-      )
-
-    else:
-      p.operators().add(feature.creator())
-      # Add the parent features
-      for input_event in feature.creator().inputs().values():
-        for input_feature in input_event.features():
-          if input_feature in done_features:
+        if feature in input_features:
+            # The feature is provided by the user.
             continue
-          if input_feature in pending_features:
-            continue
-          pending_features.add(input_feature)
 
-  if missing_features:
-    raise ValueError(f"Missing input features: {missing_features}")
+        if feature.creator() is None:
+            # The feature is missing.
+            missing_features.add(repr(feature))
 
-  return p
+        elif feature.creator().is_placeholder():
+            # The user is expected to see the input of placeholders.
+            missing_features.add(
+                f"{repr(feature)} from placeholder {feature.creator()}")
+
+        else:
+            p.operators().add(feature.creator())
+            # Add the parent features
+            for input_event in feature.creator().inputs().values():
+                for input_feature in input_event.features():
+                    if input_feature in done_features:
+                        continue
+                    if input_feature in pending_features:
+                        continue
+                    pending_features.add(input_feature)
+
+    if missing_features:
+        raise ValueError(f"Missing input features: {missing_features}")
+
+    return p

--- a/temporian/core/processor.py
+++ b/temporian/core/processor.py
@@ -71,15 +71,15 @@ class Preprocessor(object):
 def infer_processor(inputs: List[Event], outputs: List[Event]) -> Preprocessor:
     """Create a self contained processor.
 
-  Fails if some inputs are missing.
+    Fails if some inputs are missing.
 
-  Args:
-    inputs: List of available inputs.
-    outputs: List of requested outputs.
+    Args:
+      inputs: List of available inputs.
+      outputs: List of requested outputs.
 
-  Returns:
-    A preprocessor.
-  """
+    Returns:
+      A preprocessor.
+    """
 
     p = Preprocessor()
 
@@ -134,7 +134,8 @@ def infer_processor(inputs: List[Event], outputs: List[Event]) -> Preprocessor:
         elif feature.creator().is_placeholder():
             # The user is expected to see the input of placeholders.
             missing_features.add(
-                f"{repr(feature)} from placeholder {feature.creator()}")
+                f"{repr(feature)} from placeholder {feature.creator()}"
+            )
 
         else:
             p.operators().add(feature.creator())

--- a/temporian/core/test/operator_test.py
+++ b/temporian/core/test/operator_test.py
@@ -22,49 +22,52 @@ from temporian.proto import core_pb2 as pb
 
 class OperatorTest(absltest.TestCase):
 
-  def test_check_operator(self):
-    class ToyOperator(base.Operator):
+    def test_check_operator(self):
 
-      @classmethod
-      def build_op_definition(cls) -> pb.OperatorDef:
-        return pb.OperatorDef(
-            key="TOY",
-            inputs=[
-                pb.OperatorDef.Input(key="input"),
-                pb.OperatorDef.Input(key="optional_input", is_optional=True),
-            ],
-            outputs=[pb.OperatorDef.Output(key="output")],
-        )
+        class ToyOperator(base.Operator):
 
-      def _get_pandas_implementation(self):
-        raise NotImplementedError()
+            @classmethod
+            def build_op_definition(cls) -> pb.OperatorDef:
+                return pb.OperatorDef(
+                    key="TOY",
+                    inputs=[
+                        pb.OperatorDef.Input(key="input"),
+                        pb.OperatorDef.Input(key="optional_input",
+                                             is_optional=True),
+                    ],
+                    outputs=[pb.OperatorDef.Output(key="output")],
+                )
 
-    def build_fake_event():
-      return Event(features=[], sampling=Sampling(index=[]))
+            def _get_pandas_implementation(self):
+                raise NotImplementedError()
 
-    t = ToyOperator()
-    with self.assertRaisesRegex(ValueError, 'Missing input "input"'):
-      t.check()
+        def build_fake_event():
+            return Event(features=[], sampling=Sampling(index=[]))
 
-    t.add_input("input", build_fake_event())
-    with self.assertRaisesRegex(ValueError, 'Missing output "output"'):
-      t.check()
+        t = ToyOperator()
+        with self.assertRaisesRegex(ValueError, 'Missing input "input"'):
+            t.check()
 
-    with self.assertRaisesRegex(ValueError, 'Already existing input "input"'):
-      t.add_input("input", build_fake_event())
+        t.add_input("input", build_fake_event())
+        with self.assertRaisesRegex(ValueError, 'Missing output "output"'):
+            t.check()
 
-    t.add_output("output", build_fake_event())
-    t.check()
+        with self.assertRaisesRegex(ValueError,
+                                    'Already existing input "input"'):
+            t.add_input("input", build_fake_event())
 
-    with self.assertRaisesRegex(ValueError, 'Already existing output "output"'):
-      t.add_output("output", build_fake_event())
+        t.add_output("output", build_fake_event())
+        t.check()
 
-    t.add_output("unexpected_output", build_fake_event())
-    with self.assertRaisesRegex(
-        ValueError, 'Unexpected output "unexpected_output"'
-    ):
-      t.check()
+        with self.assertRaisesRegex(ValueError,
+                                    'Already existing output "output"'):
+            t.add_output("output", build_fake_event())
+
+        t.add_output("unexpected_output", build_fake_event())
+        with self.assertRaisesRegex(ValueError,
+                                    'Unexpected output "unexpected_output"'):
+            t.check()
 
 
 if __name__ == "__main__":
-  absltest.main()
+    absltest.main()

--- a/temporian/core/test/operator_test.py
+++ b/temporian/core/test/operator_test.py
@@ -21,19 +21,17 @@ from temporian.proto import core_pb2 as pb
 
 
 class OperatorTest(absltest.TestCase):
-
     def test_check_operator(self):
-
         class ToyOperator(base.Operator):
-
             @classmethod
             def build_op_definition(cls) -> pb.OperatorDef:
                 return pb.OperatorDef(
                     key="TOY",
                     inputs=[
                         pb.OperatorDef.Input(key="input"),
-                        pb.OperatorDef.Input(key="optional_input",
-                                             is_optional=True),
+                        pb.OperatorDef.Input(
+                            key="optional_input", is_optional=True
+                        ),
                     ],
                     outputs=[pb.OperatorDef.Output(key="output")],
                 )
@@ -52,20 +50,23 @@ class OperatorTest(absltest.TestCase):
         with self.assertRaisesRegex(ValueError, 'Missing output "output"'):
             t.check()
 
-        with self.assertRaisesRegex(ValueError,
-                                    'Already existing input "input"'):
+        with self.assertRaisesRegex(
+            ValueError, 'Already existing input "input"'
+        ):
             t.add_input("input", build_fake_event())
 
         t.add_output("output", build_fake_event())
         t.check()
 
-        with self.assertRaisesRegex(ValueError,
-                                    'Already existing output "output"'):
+        with self.assertRaisesRegex(
+            ValueError, 'Already existing output "output"'
+        ):
             t.add_output("output", build_fake_event())
 
         t.add_output("unexpected_output", build_fake_event())
-        with self.assertRaisesRegex(ValueError,
-                                    'Unexpected output "unexpected_output"'):
+        with self.assertRaisesRegex(
+            ValueError, 'Unexpected output "unexpected_output"'
+        ):
             t.check()
 
 

--- a/temporian/core/test/processor_test.py
+++ b/temporian/core/test/processor_test.py
@@ -29,181 +29,182 @@ from temporian.proto import core_pb2 as pb
 
 class OpO1(base.Operator):
 
-  @classmethod
-  def build_op_definition(cls) -> pb.OperatorDef:
-    return pb.OperatorDef(
-        key="OpO1",
-        place_holder=True,
-        outputs=[pb.OperatorDef.Output(key="output")],
-    )
+    @classmethod
+    def build_op_definition(cls) -> pb.OperatorDef:
+        return pb.OperatorDef(
+            key="OpO1",
+            place_holder=True,
+            outputs=[pb.OperatorDef.Output(key="output")],
+        )
 
-  def __init__(self):
-    super().__init__()
-    sampling = Sampling(index=[])
-    self.add_output(
-        "output",
-        Event(
-            features=[
-                Feature("f1", dtype.FLOAT, sampling=sampling, creator=self),
-                Feature("f2", dtype.FLOAT, sampling=sampling, creator=self),
-            ],
-            sampling=sampling,
-        ),
-    )
-    self.check()
+    def __init__(self):
+        super().__init__()
+        sampling = Sampling(index=[])
+        self.add_output(
+            "output",
+            Event(
+                features=[
+                    Feature("f1", dtype.FLOAT, sampling=sampling, creator=self),
+                    Feature("f2", dtype.FLOAT, sampling=sampling, creator=self),
+                ],
+                sampling=sampling,
+            ),
+        )
+        self.check()
 
-  def _get_pandas_implementation(self):
-    raise NotImplementedError()
+    def _get_pandas_implementation(self):
+        raise NotImplementedError()
 
 
 class OpI1O1(base.Operator):
 
-  @classmethod
-  def build_op_definition(cls) -> pb.OperatorDef:
-    return pb.OperatorDef(
-        key="OpI1O1",
-        inputs=[pb.OperatorDef.Input(key="input")],
-        outputs=[pb.OperatorDef.Output(key="output")],
-    )
+    @classmethod
+    def build_op_definition(cls) -> pb.OperatorDef:
+        return pb.OperatorDef(
+            key="OpI1O1",
+            inputs=[pb.OperatorDef.Input(key="input")],
+            outputs=[pb.OperatorDef.Output(key="output")],
+        )
 
-  def __init__(self, data: Event):
-    super().__init__()
-    self.add_input("input", data)
-    self.add_output(
-        "output",
-        Event(
-            features=[
-                Feature("f1",
-                        dtype.FLOAT,
-                        sampling=data.sampling(),
-                        creator=self)
-            ],
-            sampling=data.sampling(),
-        ),
-    )
-    self.check()
+    def __init__(self, data: Event):
+        super().__init__()
+        self.add_input("input", data)
+        self.add_output(
+            "output",
+            Event(
+                features=[
+                    Feature("f1",
+                            dtype.FLOAT,
+                            sampling=data.sampling(),
+                            creator=self)
+                ],
+                sampling=data.sampling(),
+            ),
+        )
+        self.check()
 
-  def _get_pandas_implementation(self):
-    raise NotImplementedError()
+    def _get_pandas_implementation(self):
+        raise NotImplementedError()
 
 
 class OpI2O1(base.Operator):
 
-  @classmethod
-  def build_op_definition(cls) -> pb.OperatorDef:
-    return pb.OperatorDef(
-        key="OpI2O1",
-        inputs=[
-            pb.OperatorDef.Input(key="input_1"),
-            pb.OperatorDef.Input(key="input_2"),
-        ],
-        outputs=[pb.OperatorDef.Output(key="output")],
-    )
-
-  def __init__(self, input_1: Event, input_2: Event):
-    super().__init__()
-    self.add_input("input_1", input_1)
-    self.add_input("input_2", input_2)
-    self.add_output(
-        "output",
-        Event(
-            features=[
-                Feature("f1",
-                        dtype.FLOAT,
-                        sampling=input_1.sampling(),
-                        creator=self)
+    @classmethod
+    def build_op_definition(cls) -> pb.OperatorDef:
+        return pb.OperatorDef(
+            key="OpI2O1",
+            inputs=[
+                pb.OperatorDef.Input(key="input_1"),
+                pb.OperatorDef.Input(key="input_2"),
             ],
-            sampling=input_1.sampling(),
-        ),
-    )
-    self.check()
+            outputs=[pb.OperatorDef.Output(key="output")],
+        )
 
-  def _get_pandas_implementation(self):
-    raise NotImplementedError()
+    def __init__(self, input_1: Event, input_2: Event):
+        super().__init__()
+        self.add_input("input_1", input_1)
+        self.add_input("input_2", input_2)
+        self.add_output(
+            "output",
+            Event(
+                features=[
+                    Feature("f1",
+                            dtype.FLOAT,
+                            sampling=input_1.sampling(),
+                            creator=self)
+                ],
+                sampling=input_1.sampling(),
+            ),
+        )
+        self.check()
+
+    def _get_pandas_implementation(self):
+        raise NotImplementedError()
 
 
 class OpI1O2(base.Operator):
 
-  @classmethod
-  def build_op_definition(cls) -> pb.OperatorDef:
-    return pb.OperatorDef(
-        key="OpI1O2",
-        inputs=[
-            pb.OperatorDef.Input(key="input"),
-        ],
-        outputs=[
-            pb.OperatorDef.Output(key="output_1"),
-            pb.OperatorDef.Output(key="output_2"),
-        ],
-    )
-
-  def __init__(self, data: Event):
-    super().__init__()
-    self.add_input("input", data)
-    self.add_output(
-        "output_1",
-        Event(
-            features=[
-                Feature("f1",
-                        dtype.FLOAT,
-                        sampling=data.sampling(),
-                        creator=self)
+    @classmethod
+    def build_op_definition(cls) -> pb.OperatorDef:
+        return pb.OperatorDef(
+            key="OpI1O2",
+            inputs=[
+                pb.OperatorDef.Input(key="input"),
             ],
-            sampling=data.sampling(),
-        ),
-    )
-    self.add_output(
-        "output_2",
-        Event(
-            features=[
-                Feature("f1",
-                        dtype.FLOAT,
-                        sampling=data.sampling(),
-                        creator=self)
+            outputs=[
+                pb.OperatorDef.Output(key="output_1"),
+                pb.OperatorDef.Output(key="output_2"),
             ],
-            sampling=data.sampling(),
-        ),
-    )
-    self.check()
+        )
 
-  def _get_pandas_implementation(self):
-    raise NotImplementedError()
+    def __init__(self, data: Event):
+        super().__init__()
+        self.add_input("input", data)
+        self.add_output(
+            "output_1",
+            Event(
+                features=[
+                    Feature("f1",
+                            dtype.FLOAT,
+                            sampling=data.sampling(),
+                            creator=self)
+                ],
+                sampling=data.sampling(),
+            ),
+        )
+        self.add_output(
+            "output_2",
+            Event(
+                features=[
+                    Feature("f1",
+                            dtype.FLOAT,
+                            sampling=data.sampling(),
+                            creator=self)
+                ],
+                sampling=data.sampling(),
+            ),
+        )
+        self.check()
+
+    def _get_pandas_implementation(self):
+        raise NotImplementedError()
 
 
 class ProcessorTest(absltest.TestCase):
 
-  def test_dependency_basic(self):
-    o1 = OpO1()
-    o2 = OpI1O1(o1.outputs()["output"])
-    o3 = OpO1()
-    o4 = OpI2O1(o2.outputs()["output"], o3.outputs()["output"])
-    o5 = OpI1O2(o4.outputs()["output"])
+    def test_dependency_basic(self):
+        o1 = OpO1()
+        o2 = OpI1O1(o1.outputs()["output"])
+        o3 = OpO1()
+        o4 = OpI2O1(o2.outputs()["output"], o3.outputs()["output"])
+        o5 = OpI1O2(o4.outputs()["output"])
 
-    p = processor.infer_processor(
-        [o1.outputs()["output"], o3.outputs()["output"]],
-        [o5.outputs()["output_1"],
-         o4.outputs()["output"]],
-    )
-    logging.info("Processor:\n%s", p)
+        p = processor.infer_processor(
+            [o1.outputs()["output"],
+             o3.outputs()["output"]],
+            [o5.outputs()["output_1"],
+             o4.outputs()["output"]],
+        )
+        logging.info("Processor:\n%s", p)
 
-    # The two input operators are not listed.
-    self.assertLen(p.operators(), 3)
+        # The two input operators are not listed.
+        self.assertLen(p.operators(), 3)
 
-    # The two samplings created by the two input operators.
-    self.assertLen(p.samplings(), 2)
-    self.assertLen(p.events(), 6)
-    self.assertLen(p.features(), 7)
+        # The two samplings created by the two input operators.
+        self.assertLen(p.samplings(), 2)
+        self.assertLen(p.events(), 6)
+        self.assertLen(p.features(), 7)
 
-  def test_dependency_missing_input(self):
-    o1 = OpO1()
-    o2 = OpI1O1(o1.outputs()["output"])
+    def test_dependency_missing_input(self):
+        o1 = OpO1()
+        o2 = OpI1O1(o1.outputs()["output"])
 
-    with self.assertRaisesRegex(
-        ValueError,
-        "Missing input features.*from placeholder Operator<key: OpO1,",
-    ):
-      processor.infer_processor([], [o2.outputs()["output"]])
+        with self.assertRaisesRegex(
+                ValueError,
+                "Missing input features.*from placeholder Operator<key: OpO1,",
+        ):
+            processor.infer_processor([], [o2.outputs()["output"]])
 
 
 if __name__ == "__main__":
-  absltest.main()
+    absltest.main()

--- a/temporian/core/test/processor_test.py
+++ b/temporian/core/test/processor_test.py
@@ -28,7 +28,6 @@ from temporian.proto import core_pb2 as pb
 
 
 class OpO1(base.Operator):
-
     @classmethod
     def build_op_definition(cls) -> pb.OperatorDef:
         return pb.OperatorDef(
@@ -57,7 +56,6 @@ class OpO1(base.Operator):
 
 
 class OpI1O1(base.Operator):
-
     @classmethod
     def build_op_definition(cls) -> pb.OperatorDef:
         return pb.OperatorDef(
@@ -73,10 +71,12 @@ class OpI1O1(base.Operator):
             "output",
             Event(
                 features=[
-                    Feature("f1",
-                            dtype.FLOAT,
-                            sampling=data.sampling(),
-                            creator=self)
+                    Feature(
+                        "f1",
+                        dtype.FLOAT,
+                        sampling=data.sampling(),
+                        creator=self,
+                    )
                 ],
                 sampling=data.sampling(),
             ),
@@ -88,7 +88,6 @@ class OpI1O1(base.Operator):
 
 
 class OpI2O1(base.Operator):
-
     @classmethod
     def build_op_definition(cls) -> pb.OperatorDef:
         return pb.OperatorDef(
@@ -108,10 +107,12 @@ class OpI2O1(base.Operator):
             "output",
             Event(
                 features=[
-                    Feature("f1",
-                            dtype.FLOAT,
-                            sampling=input_1.sampling(),
-                            creator=self)
+                    Feature(
+                        "f1",
+                        dtype.FLOAT,
+                        sampling=input_1.sampling(),
+                        creator=self,
+                    )
                 ],
                 sampling=input_1.sampling(),
             ),
@@ -123,7 +124,6 @@ class OpI2O1(base.Operator):
 
 
 class OpI1O2(base.Operator):
-
     @classmethod
     def build_op_definition(cls) -> pb.OperatorDef:
         return pb.OperatorDef(
@@ -144,10 +144,12 @@ class OpI1O2(base.Operator):
             "output_1",
             Event(
                 features=[
-                    Feature("f1",
-                            dtype.FLOAT,
-                            sampling=data.sampling(),
-                            creator=self)
+                    Feature(
+                        "f1",
+                        dtype.FLOAT,
+                        sampling=data.sampling(),
+                        creator=self,
+                    )
                 ],
                 sampling=data.sampling(),
             ),
@@ -156,10 +158,12 @@ class OpI1O2(base.Operator):
             "output_2",
             Event(
                 features=[
-                    Feature("f1",
-                            dtype.FLOAT,
-                            sampling=data.sampling(),
-                            creator=self)
+                    Feature(
+                        "f1",
+                        dtype.FLOAT,
+                        sampling=data.sampling(),
+                        creator=self,
+                    )
                 ],
                 sampling=data.sampling(),
             ),
@@ -171,7 +175,6 @@ class OpI1O2(base.Operator):
 
 
 class ProcessorTest(absltest.TestCase):
-
     def test_dependency_basic(self):
         o1 = OpO1()
         o2 = OpI1O1(o1.outputs()["output"])
@@ -180,10 +183,8 @@ class ProcessorTest(absltest.TestCase):
         o5 = OpI1O2(o4.outputs()["output"])
 
         p = processor.infer_processor(
-            [o1.outputs()["output"],
-             o3.outputs()["output"]],
-            [o5.outputs()["output_1"],
-             o4.outputs()["output"]],
+            [o1.outputs()["output"], o3.outputs()["output"]],
+            [o5.outputs()["output_1"], o4.outputs()["output"]],
         )
         logging.info("Processor:\n%s", p)
 
@@ -200,8 +201,8 @@ class ProcessorTest(absltest.TestCase):
         o2 = OpI1O1(o1.outputs()["output"])
 
         with self.assertRaisesRegex(
-                ValueError,
-                "Missing input features.*from placeholder Operator<key: OpO1,",
+            ValueError,
+            "Missing input features.*from placeholder Operator<key: OpO1,",
         ):
             processor.infer_processor([], [o2.outputs()["output"]])
 

--- a/temporian/implementation/__init__.py
+++ b/temporian/implementation/__init__.py
@@ -11,4 +11,3 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-

--- a/temporian/implementation/pandas/__init__.py
+++ b/temporian/implementation/pandas/__init__.py
@@ -11,4 +11,3 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-

--- a/temporian/implementation/pandas/data/__init__.py
+++ b/temporian/implementation/pandas/data/__init__.py
@@ -11,4 +11,3 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-

--- a/temporian/implementation/pandas/data/event.py
+++ b/temporian/implementation/pandas/data/event.py
@@ -20,7 +20,6 @@ from temporian.core.data.sampling import Sampling
 
 
 class PandasFeature(pd.Series):
-
     @property
     def _constructor(self):
         return PandasFeature
@@ -30,13 +29,12 @@ class PandasFeature(pd.Series):
         return PandasEvent
 
     def schema(self) -> Feature:
-        return Feature(name=self.name,
-                       dtype=self.dtype,
-                       sampling=self.index.names)
+        return Feature(
+            name=self.name, dtype=self.dtype, sampling=self.index.names
+        )
 
 
 class PandasEvent(pd.DataFrame):
-
     @property
     def _constructor(self):
         return PandasEvent
@@ -54,5 +52,7 @@ class PandasEvent(pd.DataFrame):
 
 def pandas_event_from_csv(path: str, sampling: Sampling) -> PandasEvent:
     return PandasEvent(
-        pd.read_csv(path, parse_dates=[sampling._index[-1]])).set_index(
-            sampling._index)  # TODO: improve index setting and parse_dates
+        pd.read_csv(path, parse_dates=[sampling._index[-1]])
+    ).set_index(
+        sampling._index
+    )  # TODO: improve index setting and parse_dates

--- a/temporian/implementation/pandas/data/event.py
+++ b/temporian/implementation/pandas/data/event.py
@@ -21,36 +21,38 @@ from temporian.core.data.sampling import Sampling
 
 class PandasFeature(pd.Series):
 
-  @property
-  def _constructor(self):
-    return PandasFeature
+    @property
+    def _constructor(self):
+        return PandasFeature
 
-  @property
-  def _constructor_expanddim(self):
-    return PandasEvent
+    @property
+    def _constructor_expanddim(self):
+        return PandasEvent
 
-  def schema(self) -> Feature:
-    return Feature(name=self.name, dtype=self.dtype, sampling=self.index.names)
+    def schema(self) -> Feature:
+        return Feature(name=self.name,
+                       dtype=self.dtype,
+                       sampling=self.index.names)
 
 
 class PandasEvent(pd.DataFrame):
 
-  @property
-  def _constructor(self):
-    return PandasEvent
+    @property
+    def _constructor(self):
+        return PandasEvent
 
-  @property
-  def _constructor_sliced(self):
-    return PandasFeature
+    @property
+    def _constructor_sliced(self):
+        return PandasFeature
 
-  def schema(self) -> Event:
-    return Event(
-        features=[self[col].schema() for col in self.columns],
-        sampling=self.index.names,
-    )
+    def schema(self) -> Event:
+        return Event(
+            features=[self[col].schema() for col in self.columns],
+            sampling=self.index.names,
+        )
 
 
 def pandas_event_from_csv(path: str, sampling: Sampling) -> PandasEvent:
-  return PandasEvent(pd.read_csv(path, parse_dates=[
-      sampling._index[-1]
-  ])).set_index(sampling._index)  # TODO: improve index setting and parse_dates
+    return PandasEvent(
+        pd.read_csv(path, parse_dates=[sampling._index[-1]])).set_index(
+            sampling._index)  # TODO: improve index setting and parse_dates

--- a/temporian/implementation/pandas/data/sampling.py
+++ b/temporian/implementation/pandas/data/sampling.py
@@ -20,4 +20,4 @@ import pandas as pd
 
 
 class PandasSampling(pd.MultiIndex):
-  pass
+    pass

--- a/temporian/implementation/pandas/evaluator.py
+++ b/temporian/implementation/pandas/evaluator.py
@@ -24,23 +24,23 @@ def evaluate_schedule(
     data: Dict[event.Event, pandas_event.PandasEvent],
     schedule: List[base.Operator],
 ) -> Dict[event.Event, pandas_event.PandasEvent]:
-  for operator in schedule:
-    operator_def = operator.definition()
-    # get implementation
-    implementation = core_mapping.OPERATOR_IMPLEMENTATIONS[operator_def.key](
-        **operator.attributes())
+    for operator in schedule:
+        operator_def = operator.definition()
+        # get implementation
+        implementation = core_mapping.OPERATOR_IMPLEMENTATIONS[
+            operator_def.key](**operator.attributes())
 
-    # construct operator inputs
-    operator_inputs = {
-        input_key: data[input_event]
-        for input_key, input_event in operator.inputs().items()
-    }
+        # construct operator inputs
+        operator_inputs = {
+            input_key: data[input_event]
+            for input_key, input_event in operator.inputs().items()
+        }
 
-    # compute output
-    operator_outputs = implementation(**operator_inputs)
+        # compute output
+        operator_outputs = implementation(**operator_inputs)
 
-    # materialize data in output events
-    for output_key, output_event in operator.outputs().items():
-      data[output_event] = operator_outputs[output_key]
+        # materialize data in output events
+        for output_key, output_event in operator.outputs().items():
+            data[output_event] = operator_outputs[output_key]
 
-  return data
+    return data

--- a/temporian/implementation/pandas/evaluator.py
+++ b/temporian/implementation/pandas/evaluator.py
@@ -28,7 +28,8 @@ def evaluate_schedule(
         operator_def = operator.definition()
         # get implementation
         implementation = core_mapping.OPERATOR_IMPLEMENTATIONS[
-            operator_def.key](**operator.attributes())
+            operator_def.key
+        ](**operator.attributes())
 
         # construct operator inputs
         operator_inputs = {

--- a/temporian/implementation/pandas/operators/__init__.py
+++ b/temporian/implementation/pandas/operators/__init__.py
@@ -11,4 +11,3 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-

--- a/temporian/implementation/pandas/operators/assign.py
+++ b/temporian/implementation/pandas/operators/assign.py
@@ -20,42 +20,49 @@ from temporian.implementation.pandas import utils
 
 
 class PandasAssignOperator(PandasOperator):
-
-    def __call__(self, assignee_event: PandasEvent,
-                 assigned_event: PandasEvent) -> PandasEvent:
+    def __call__(
+        self, assignee_event: PandasEvent, assigned_event: PandasEvent
+    ) -> PandasEvent:
         """Assign features to an event.
 
-    Input event and features must have same index. Features cannot have more
-    than one row for a single index + timestamp occurence. Output event will
-    have same exact index and timestamps as input one. Assignment can be
-    understood as a left join on the index and timestamp columns.
+        Input event and features must have same index. Features cannot have more
+        than one row for a single index + timestamp occurence. Output event will
+        have same exact index and timestamps as input one. Assignment can be
+        understood as a left join on the index and timestamp columns.
 
-    Args:
-        assignee_event (PandasEvent): event to assign the feature to.
-        assigned_event (PandasEvent): features to assign to the event.
+        Args:
+            assignee_event (PandasEvent): event to assign the feature to.
+            assigned_event (PandasEvent): features to assign to the event.
 
-    Returns:
-        PandasEvent: a new event with the features assigned.
-    """
+        Returns:
+            PandasEvent: a new event with the features assigned.
+        """
         # assert indexes are the same
         if assignee_event.index.names != assigned_event.index.names:
             raise IndexError("Assign sequences must have the same index names.")
 
         # get index column names
         index, timestamp = utils.get_index_and_timestamp_column_names(
-            assignee_event)
+            assignee_event
+        )
 
         # check there's no repeated timestamps index-wise in the assigned sequence
         if index:
-            max_timestamps = (assigned_event.reset_index().groupby(index)
-                              [timestamp].value_counts().max())
+            max_timestamps = (
+                assigned_event.reset_index()
+                .groupby(index)[timestamp]
+                .value_counts()
+                .max()
+            )
         else:
             max_timestamps = (
-                assigned_event.reset_index()[timestamp].value_counts().max())
+                assigned_event.reset_index()[timestamp].value_counts().max()
+            )
 
         if max_timestamps > 1:
             raise ValueError(
-                "Cannot have repeated timestamps in assigned EventSequence.")
+                "Cannot have repeated timestamps in assigned EventSequence."
+            )
 
         # make assignment
         output = assignee_event.join(assigned_event, how="left", rsuffix="y")

--- a/temporian/implementation/pandas/operators/assign.py
+++ b/temporian/implementation/pandas/operators/assign.py
@@ -21,9 +21,9 @@ from temporian.implementation.pandas import utils
 
 class PandasAssignOperator(PandasOperator):
 
-  def __call__(self, assignee_event: PandasEvent,
-               assigned_event: PandasEvent) -> PandasEvent:
-    """Assign features to an event.
+    def __call__(self, assignee_event: PandasEvent,
+                 assigned_event: PandasEvent) -> PandasEvent:
+        """Assign features to an event.
 
     Input event and features must have same index. Features cannot have more
     than one row for a single index + timestamp occurence. Output event will
@@ -37,26 +37,26 @@ class PandasAssignOperator(PandasOperator):
     Returns:
         PandasEvent: a new event with the features assigned.
     """
-    # assert indexes are the same
-    if assignee_event.index.names != assigned_event.index.names:
-      raise IndexError("Assign sequences must have the same index names.")
+        # assert indexes are the same
+        if assignee_event.index.names != assigned_event.index.names:
+            raise IndexError("Assign sequences must have the same index names.")
 
-    # get index column names
-    index, timestamp = utils.get_index_and_timestamp_column_names(
-        assignee_event)
+        # get index column names
+        index, timestamp = utils.get_index_and_timestamp_column_names(
+            assignee_event)
 
-    # check there's no repeated timestamps index-wise in the assigned sequence
-    if index:
-      max_timestamps = (assigned_event.reset_index().groupby(index)
-                        [timestamp].value_counts().max())
-    else:
-      max_timestamps = (
-          assigned_event.reset_index()[timestamp].value_counts().max())
+        # check there's no repeated timestamps index-wise in the assigned sequence
+        if index:
+            max_timestamps = (assigned_event.reset_index().groupby(index)
+                              [timestamp].value_counts().max())
+        else:
+            max_timestamps = (
+                assigned_event.reset_index()[timestamp].value_counts().max())
 
-    if max_timestamps > 1:
-      raise ValueError(
-          "Cannot have repeated timestamps in assigned EventSequence.")
+        if max_timestamps > 1:
+            raise ValueError(
+                "Cannot have repeated timestamps in assigned EventSequence.")
 
-    # make assignment
-    output = assignee_event.join(assigned_event, how="left", rsuffix="y")
-    return {"output": output}
+        # make assignment
+        output = assignee_event.join(assigned_event, how="left", rsuffix="y")
+        return {"output": output}

--- a/temporian/implementation/pandas/operators/base.py
+++ b/temporian/implementation/pandas/operators/base.py
@@ -21,11 +21,11 @@ from temporian.implementation.pandas.data.event import PandasEvent
 
 
 class PandasOperator(ABC):
-  """Base class to define an operator's interface."""
+    """Base class to define an operator's interface."""
 
-  @abstractmethod
-  def __call__(self, *args: Any, **kwargs: Any) -> Dict[str, PandasEvent]:
-    """Apply the operator to its inputs.
+    @abstractmethod
+    def __call__(self, *args: Any, **kwargs: Any) -> Dict[str, PandasEvent]:
+        """Apply the operator to its inputs.
 
     Returns:
         Dict[str, PandasEvent]: the output event of the operator.

--- a/temporian/implementation/pandas/operators/base.py
+++ b/temporian/implementation/pandas/operators/base.py
@@ -27,6 +27,6 @@ class PandasOperator(ABC):
     def __call__(self, *args: Any, **kwargs: Any) -> Dict[str, PandasEvent]:
         """Apply the operator to its inputs.
 
-    Returns:
-        Dict[str, PandasEvent]: the output event of the operator.
-    """
+        Returns:
+            Dict[str, PandasEvent]: the output event of the operator.
+        """

--- a/temporian/implementation/pandas/operators/core_mapping.py
+++ b/temporian/implementation/pandas/operators/core_mapping.py
@@ -13,11 +13,11 @@
 # limitations under the License.
 
 from temporian.implementation.pandas.operators import assign
-from temporian.implementation.pandas.operators.window import simple_moving_average
+from temporian.implementation.pandas.operators.window import (
+    simple_moving_average,
+)
 
 OPERATOR_IMPLEMENTATIONS = {
-    "ASSIGN":
-        assign.PandasAssignOperator,
-    "SIMPLE_MOVING_AVERAGE":
-        simple_moving_average.PandasSimpleMovingAverageOperator
+    "ASSIGN": assign.PandasAssignOperator,
+    "SIMPLE_MOVING_AVERAGE": simple_moving_average.PandasSimpleMovingAverageOperator,
 }

--- a/temporian/implementation/pandas/operators/tests/__init__.py
+++ b/temporian/implementation/pandas/operators/tests/__init__.py
@@ -11,4 +11,3 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-

--- a/temporian/implementation/pandas/operators/tests/assign/__init__.py
+++ b/temporian/implementation/pandas/operators/tests/assign/__init__.py
@@ -11,4 +11,3 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-

--- a/temporian/implementation/pandas/operators/tests/assign/assign_test.py
+++ b/temporian/implementation/pandas/operators/tests/assign/assign_test.py
@@ -15,14 +15,21 @@
 from absl.testing import absltest
 
 from temporian.implementation.pandas.operators import assign
-from temporian.implementation.pandas.operators.tests.assign.test_data import different_index
-from temporian.implementation.pandas.operators.tests.assign.test_data import repeated_timestamps
-from temporian.implementation.pandas.operators.tests.assign.test_data import with_idx_more_timestamps
-from temporian.implementation.pandas.operators.tests.assign.test_data import with_idx_same_timestamps
+from temporian.implementation.pandas.operators.tests.assign.test_data import (
+    different_index,
+)
+from temporian.implementation.pandas.operators.tests.assign.test_data import (
+    repeated_timestamps,
+)
+from temporian.implementation.pandas.operators.tests.assign.test_data import (
+    with_idx_more_timestamps,
+)
+from temporian.implementation.pandas.operators.tests.assign.test_data import (
+    with_idx_same_timestamps,
+)
 
 
 class AssignOperatorTest(absltest.TestCase):
-
     def setUp(self) -> None:
         self.operator = assign.PandasAssignOperator()
 
@@ -45,18 +52,22 @@ class AssignOperatorTest(absltest.TestCase):
         )
 
     def test_with_idx_same_timestamps(self) -> None:
-        operator_output = self.operator(with_idx_same_timestamps.INPUT_1,
-                                        with_idx_same_timestamps.INPUT_2)
+        operator_output = self.operator(
+            with_idx_same_timestamps.INPUT_1, with_idx_same_timestamps.INPUT_2
+        )
         self.assertEqual(
             True,
-            with_idx_same_timestamps.OUTPUT.equals(operator_output["output"]))
+            with_idx_same_timestamps.OUTPUT.equals(operator_output["output"]),
+        )
 
     def test_with_idx_more_timestamps(self) -> None:
-        operator_output = self.operator(with_idx_more_timestamps.INPUT_1,
-                                        with_idx_more_timestamps.INPUT_2)
+        operator_output = self.operator(
+            with_idx_more_timestamps.INPUT_1, with_idx_more_timestamps.INPUT_2
+        )
         self.assertEqual(
             True,
-            with_idx_more_timestamps.OUTPUT.equals(operator_output["output"]))
+            with_idx_more_timestamps.OUTPUT.equals(operator_output["output"]),
+        )
 
 
 if __name__ == "__main__":

--- a/temporian/implementation/pandas/operators/tests/assign/assign_test.py
+++ b/temporian/implementation/pandas/operators/tests/assign/assign_test.py
@@ -23,39 +23,41 @@ from temporian.implementation.pandas.operators.tests.assign.test_data import wit
 
 class AssignOperatorTest(absltest.TestCase):
 
-  def setUp(self) -> None:
-    self.operator = assign.PandasAssignOperator()
+    def setUp(self) -> None:
+        self.operator = assign.PandasAssignOperator()
 
-  def test_different_index(self) -> None:
-    self.assertRaisesRegex(
-        IndexError,
-        "Assign sequences must have the same index names.",
-        self.operator,
-        different_index.INPUT_1,
-        different_index.INPUT_2,
-    )
+    def test_different_index(self) -> None:
+        self.assertRaisesRegex(
+            IndexError,
+            "Assign sequences must have the same index names.",
+            self.operator,
+            different_index.INPUT_1,
+            different_index.INPUT_2,
+        )
 
-  def test_repeated_timestamps(self) -> None:
-    self.assertRaisesRegex(
-        ValueError,
-        "Cannot have repeated timestamps in assigned EventSequence.",
-        self.operator,
-        repeated_timestamps.INPUT_1,
-        repeated_timestamps.INPUT_1,
-    )
+    def test_repeated_timestamps(self) -> None:
+        self.assertRaisesRegex(
+            ValueError,
+            "Cannot have repeated timestamps in assigned EventSequence.",
+            self.operator,
+            repeated_timestamps.INPUT_1,
+            repeated_timestamps.INPUT_1,
+        )
 
-  def test_with_idx_same_timestamps(self) -> None:
-    operator_output = self.operator(with_idx_same_timestamps.INPUT_1,
-                                    with_idx_same_timestamps.INPUT_2)
-    self.assertEqual(
-        True, with_idx_same_timestamps.OUTPUT.equals(operator_output["output"]))
+    def test_with_idx_same_timestamps(self) -> None:
+        operator_output = self.operator(with_idx_same_timestamps.INPUT_1,
+                                        with_idx_same_timestamps.INPUT_2)
+        self.assertEqual(
+            True,
+            with_idx_same_timestamps.OUTPUT.equals(operator_output["output"]))
 
-  def test_with_idx_more_timestamps(self) -> None:
-    operator_output = self.operator(with_idx_more_timestamps.INPUT_1,
-                                    with_idx_more_timestamps.INPUT_2)
-    self.assertEqual(
-        True, with_idx_more_timestamps.OUTPUT.equals(operator_output["output"]))
+    def test_with_idx_more_timestamps(self) -> None:
+        operator_output = self.operator(with_idx_more_timestamps.INPUT_1,
+                                        with_idx_more_timestamps.INPUT_2)
+        self.assertEqual(
+            True,
+            with_idx_more_timestamps.OUTPUT.equals(operator_output["output"]))
 
 
 if __name__ == "__main__":
-  absltest.main()
+    absltest.main()

--- a/temporian/implementation/pandas/operators/tests/assign/test_data/__init__.py
+++ b/temporian/implementation/pandas/operators/tests/assign/test_data/__init__.py
@@ -11,4 +11,3 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-

--- a/temporian/implementation/pandas/operators/tests/assign/test_data/different_index.py
+++ b/temporian/implementation/pandas/operators/tests/assign/test_data/different_index.py
@@ -20,32 +20,40 @@ import pandas as pd
 
 from temporian.implementation.pandas.data.event import PandasEvent
 
-INPUT_1 = PandasEvent({
-    "user_id": [
-        151591562,
-        193285921,
-    ],
-    "timestamp": [
-        pd.Timestamp("2020-11-09"),
-        pd.Timestamp("2020-11-10"),
-    ],
-    "price": [
-        63.49,
-        55.12,
-    ],
-}).set_index(["user_id", "timestamp"])  # index is user_id
+INPUT_1 = PandasEvent(
+    {
+        "user_id": [
+            151591562,
+            193285921,
+        ],
+        "timestamp": [
+            pd.Timestamp("2020-11-09"),
+            pd.Timestamp("2020-11-10"),
+        ],
+        "price": [
+            63.49,
+            55.12,
+        ],
+    }
+).set_index(
+    ["user_id", "timestamp"]
+)  # index is user_id
 
-INPUT_2 = PandasEvent({
-    "product_id": [
-        666964,
-        574016,
-    ],
-    "timestamp": [
-        pd.Timestamp("2020-11-09"),
-        pd.Timestamp("2020-11-10"),
-    ],
-    "price": [
-        126.98,
-        266.42,
-    ],
-}).set_index(["product_id", "timestamp"])  # index is product_id
+INPUT_2 = PandasEvent(
+    {
+        "product_id": [
+            666964,
+            574016,
+        ],
+        "timestamp": [
+            pd.Timestamp("2020-11-09"),
+            pd.Timestamp("2020-11-10"),
+        ],
+        "price": [
+            126.98,
+            266.42,
+        ],
+    }
+).set_index(
+    ["product_id", "timestamp"]
+)  # index is product_id

--- a/temporian/implementation/pandas/operators/tests/assign/test_data/repeated_timestamps.py
+++ b/temporian/implementation/pandas/operators/tests/assign/test_data/repeated_timestamps.py
@@ -22,42 +22,46 @@ import pandas as pd
 
 from temporian.implementation.pandas.data.event import PandasEvent
 
-INPUT_1 = PandasEvent({
-    "user_id": [
-        151591562,
-        151591562,
-        191562515,
-    ],
-    "timestamp": [
-        pd.Timestamp("2020-12-20"),
-        pd.Timestamp(
-            "2020-12-20"
-        ),  # repeated timestamp on assingee event for user_id = 151591562
-        pd.Timestamp("2020-12-22"),
-    ],
-    "price": [
-        63.49,
-        133.21,
-        148.67,
-    ],
-}).set_index(["user_id", "timestamp"])
+INPUT_1 = PandasEvent(
+    {
+        "user_id": [
+            151591562,
+            151591562,
+            191562515,
+        ],
+        "timestamp": [
+            pd.Timestamp("2020-12-20"),
+            pd.Timestamp(
+                "2020-12-20"
+            ),  # repeated timestamp on assingee event for user_id = 151591562
+            pd.Timestamp("2020-12-22"),
+        ],
+        "price": [
+            63.49,
+            133.21,
+            148.67,
+        ],
+    }
+).set_index(["user_id", "timestamp"])
 
-INPUT_2 = PandasEvent({
-    "user_id": [
-        151591562,
-        191562515,
-        191562515,
-    ],
-    "timestamp": [
-        pd.Timestamp("2020-11-15"),
-        pd.Timestamp("2020-11-18"),
-        pd.Timestamp(
-            "2020-11-18"
-        ),  # repeated timestamp on assinged event for user_id = 191562515
-    ],
-    "price": [
-        190.47,
-        399.63,
-        446.01,
-    ],
-}).set_index(["user_id", "timestamp"])
+INPUT_2 = PandasEvent(
+    {
+        "user_id": [
+            151591562,
+            191562515,
+            191562515,
+        ],
+        "timestamp": [
+            pd.Timestamp("2020-11-15"),
+            pd.Timestamp("2020-11-18"),
+            pd.Timestamp(
+                "2020-11-18"
+            ),  # repeated timestamp on assinged event for user_id = 191562515
+        ],
+        "price": [
+            190.47,
+            399.63,
+            446.01,
+        ],
+    }
+).set_index(["user_id", "timestamp"])

--- a/temporian/implementation/pandas/operators/tests/assign/test_data/with_idx_more_timestamps.py
+++ b/temporian/implementation/pandas/operators/tests/assign/test_data/with_idx_more_timestamps.py
@@ -22,56 +22,64 @@ import pandas as pd
 
 from temporian.implementation.pandas.data.event import PandasEvent
 
-INPUT_1 = PandasEvent({
-    "product_id": [
-        666964,
-        372306,
-    ],
-    "timestamp": [
-        pd.Timestamp("2013-01-01"),
-        pd.Timestamp("2013-01-05"),
-    ],
-    "sales": [
-        0.0,
-        1160.0,
-    ],
-}).set_index(["product_id", "timestamp"])
+INPUT_1 = PandasEvent(
+    {
+        "product_id": [
+            666964,
+            372306,
+        ],
+        "timestamp": [
+            pd.Timestamp("2013-01-01"),
+            pd.Timestamp("2013-01-05"),
+        ],
+        "sales": [
+            0.0,
+            1160.0,
+        ],
+    }
+).set_index(["product_id", "timestamp"])
 
-INPUT_2 = PandasEvent({
-    "product_id": [
-        666964,
-        372306,
-        372306,
-    ],
-    "timestamp": [
-        pd.Timestamp("2013-01-01"),
-        pd.Timestamp("2013-01-05"),
-        pd.Timestamp(
-            "2013-01-07"
-        ),  # more timestamps than assignee event for porudct_id = 372306
-    ],
-    "costs": [
-        0.0,
-        508.0,
-        573.0,
-    ],
-}).set_index(["product_id", "timestamp"])
+INPUT_2 = PandasEvent(
+    {
+        "product_id": [
+            666964,
+            372306,
+            372306,
+        ],
+        "timestamp": [
+            pd.Timestamp("2013-01-01"),
+            pd.Timestamp("2013-01-05"),
+            pd.Timestamp(
+                "2013-01-07"
+            ),  # more timestamps than assignee event for porudct_id = 372306
+        ],
+        "costs": [
+            0.0,
+            508.0,
+            573.0,
+        ],
+    }
+).set_index(["product_id", "timestamp"])
 
-OUTPUT = PandasEvent({
-    "product_id": [
-        666964,
-        372306,
-    ],
-    "timestamp": [
-        pd.Timestamp("2013-01-01"),
-        pd.Timestamp("2013-01-05"),  # assignee event's timestamps are preserved
-    ],
-    "sales": [
-        0.0,
-        1160.0,
-    ],
-    "costs": [
-        0.0,
-        508.0,
-    ],
-}).set_index(["product_id", "timestamp"])
+OUTPUT = PandasEvent(
+    {
+        "product_id": [
+            666964,
+            372306,
+        ],
+        "timestamp": [
+            pd.Timestamp("2013-01-01"),
+            pd.Timestamp(
+                "2013-01-05"
+            ),  # assignee event's timestamps are preserved
+        ],
+        "sales": [
+            0.0,
+            1160.0,
+        ],
+        "costs": [
+            0.0,
+            508.0,
+        ],
+    }
+).set_index(["product_id", "timestamp"])

--- a/temporian/implementation/pandas/operators/tests/assign/test_data/with_idx_same_timestamps.py
+++ b/temporian/implementation/pandas/operators/tests/assign/test_data/with_idx_same_timestamps.py
@@ -22,61 +22,71 @@ import pandas as pd
 
 from temporian.implementation.pandas.data.event import PandasEvent
 
-INPUT_1 = PandasEvent({
-    "product_id": [
-        666964,
-        666964,
-        574016,
-    ],
-    "timestamp": [
-        pd.Timestamp("2013-01-02"),
-        pd.Timestamp("2013-01-03"),
-        pd.Timestamp("2013-01-04"),  # identical timestamps for each index value
-    ],
-    "sales": [
-        1091.0,
-        919.0,
-        953.0,
-    ],
-}).set_index(["product_id", "timestamp"])
+INPUT_1 = PandasEvent(
+    {
+        "product_id": [
+            666964,
+            666964,
+            574016,
+        ],
+        "timestamp": [
+            pd.Timestamp("2013-01-02"),
+            pd.Timestamp("2013-01-03"),
+            pd.Timestamp(
+                "2013-01-04"
+            ),  # identical timestamps for each index value
+        ],
+        "sales": [
+            1091.0,
+            919.0,
+            953.0,
+        ],
+    }
+).set_index(["product_id", "timestamp"])
 
-INPUT_2 = PandasEvent({
-    "product_id": [
-        666964,
-        666964,
-        574016,
-    ],
-    "timestamp": [
-        pd.Timestamp("2013-01-02"),
-        pd.Timestamp("2013-01-03"),
-        pd.Timestamp("2013-01-04"),  # identical timestamps for each index value
-    ],
-    "costs": [
-        740.0,
-        508.0,
-        573.0,
-    ],
-}).set_index(["product_id", "timestamp"])
+INPUT_2 = PandasEvent(
+    {
+        "product_id": [
+            666964,
+            666964,
+            574016,
+        ],
+        "timestamp": [
+            pd.Timestamp("2013-01-02"),
+            pd.Timestamp("2013-01-03"),
+            pd.Timestamp(
+                "2013-01-04"
+            ),  # identical timestamps for each index value
+        ],
+        "costs": [
+            740.0,
+            508.0,
+            573.0,
+        ],
+    }
+).set_index(["product_id", "timestamp"])
 
-OUTPUT = PandasEvent({
-    "product_id": [
-        666964,
-        666964,
-        574016,
-    ],
-    "timestamp": [
-        pd.Timestamp("2013-01-02"),
-        pd.Timestamp("2013-01-03"),
-        pd.Timestamp("2013-01-04"),
-    ],
-    "sales": [
-        1091.0,
-        919.0,
-        953.0,
-    ],
-    "costs": [
-        740.0,
-        508.0,
-        573.0,
-    ],
-}).set_index(["product_id", "timestamp"])
+OUTPUT = PandasEvent(
+    {
+        "product_id": [
+            666964,
+            666964,
+            574016,
+        ],
+        "timestamp": [
+            pd.Timestamp("2013-01-02"),
+            pd.Timestamp("2013-01-03"),
+            pd.Timestamp("2013-01-04"),
+        ],
+        "sales": [
+            1091.0,
+            919.0,
+            953.0,
+        ],
+        "costs": [
+            740.0,
+            508.0,
+            573.0,
+        ],
+    }
+).set_index(["product_id", "timestamp"])

--- a/temporian/implementation/pandas/operators/window/__init__.py
+++ b/temporian/implementation/pandas/operators/window/__init__.py
@@ -11,4 +11,3 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-

--- a/temporian/implementation/pandas/operators/window/base.py
+++ b/temporian/implementation/pandas/operators/window/base.py
@@ -18,8 +18,8 @@ from temporian.implementation.pandas.operators.base import PandasOperator
 
 
 class PandasWindowOperator(PandasOperator):
-  """Base class for pandas window operator implementations."""
+    """Base class for pandas window operator implementations."""
 
-  def __init__(self, window_length: str) -> None:
-    super().__init__()
-    self.window_length = window_length
+    def __init__(self, window_length: str) -> None:
+        super().__init__()
+        self.window_length = window_length

--- a/temporian/implementation/pandas/operators/window/simple_moving_average.py
+++ b/temporian/implementation/pandas/operators/window/simple_moving_average.py
@@ -20,7 +20,9 @@ import pandas as pd
 
 from temporian.implementation.pandas.data.event import PandasEvent
 from temporian.implementation.pandas.data.sampling import PandasSampling
-from temporian.implementation.pandas.operators.window.base import PandasWindowOperator
+from temporian.implementation.pandas.operators.window.base import (
+    PandasWindowOperator,
+)
 from temporian.implementation.pandas import utils
 
 
@@ -37,17 +39,17 @@ class PandasSimpleMovingAverageOperator(PandasWindowOperator):
     ) -> Dict[str, PandasEvent]:
         """Apply a simple moving average to an event.
 
-    If input has more than one feature, the moving average will be computed for
-    each of its features independently.
+        If input has more than one feature, the moving average will be computed for
+        each of its features independently.
 
-    Args:
-      data: the input event to apply a simple moving average to.
-      sampling: an event with the desired sampling for the output event.
-          If None, the original sampling of `data` will be used.
+        Args:
+          data: the input event to apply a simple moving average to.
+          sampling: an event with the desired sampling for the output event.
+              If None, the original sampling of `data` will be used.
 
-    Returns:
-      Dict[str, PandasEvent]: the output event of the operator.
-    """
+        Returns:
+          Dict[str, PandasEvent]: the output event of the operator.
+        """
         # remove index to be able to filter using index values
         data_no_index = data.reset_index()
 
@@ -55,8 +57,10 @@ class PandasSimpleMovingAverageOperator(PandasWindowOperator):
             sampling = data
 
         # get index columns and name of timestamp column
-        index_columns, timestamp_column = utils.get_index_and_timestamp_column_names(
-            sampling)
+        (
+            index_columns,
+            timestamp_column,
+        ) = utils.get_index_and_timestamp_column_names(sampling)
 
         # create output event with desired sampling
         output = PandasEvent(
@@ -71,19 +75,29 @@ class PandasSimpleMovingAverageOperator(PandasWindowOperator):
             timestamp = values[-1]
 
             # filter by index_value
-            data_filtered = (data_no_index[(data_no_index[index_columns]
-                                            == index_value).squeeze()]
-                             if index_columns else data_no_index)
+            data_filtered = (
+                data_no_index[
+                    (data_no_index[index_columns] == index_value).squeeze()
+                ]
+                if index_columns
+                else data_no_index
+            )
 
             # filter by window start/end dates
             data_filtered = data_filtered[
-                (data_filtered[timestamp_column] <= timestamp) &
-                (data_filtered[timestamp_column] >= timestamp -
-                 pd.Timedelta(self.window_length))]
+                (data_filtered[timestamp_column] <= timestamp)
+                & (
+                    data_filtered[timestamp_column]
+                    >= timestamp - pd.Timedelta(self.window_length)
+                )
+            ]
 
             # calculate average of window
-            mean = data_filtered.set_index(
-                sampling.index.names).mean(axis=0).values
+            mean = (
+                data_filtered.set_index(sampling.index.names)
+                .mean(axis=0)
+                .values
+            )
 
             # set result in output event
             loc = index_value + (timestamp,)

--- a/temporian/implementation/pandas/operators/window/simple_moving_average.py
+++ b/temporian/implementation/pandas/operators/window/simple_moving_average.py
@@ -25,17 +25,17 @@ from temporian.implementation.pandas import utils
 
 
 class PandasSimpleMovingAverageOperator(PandasWindowOperator):
-  """Pandas implementation for the simple moving average operator."""
+    """Pandas implementation for the simple moving average operator."""
 
-  def __init__(self, window_length: str) -> None:
-    super().__init__(window_length=window_length)
+    def __init__(self, window_length: str) -> None:
+        super().__init__(window_length=window_length)
 
-  def __call__(
-      self,
-      data: PandasEvent,
-      sampling: Optional[PandasEvent] = None,
-  ) -> Dict[str, PandasEvent]:
-    """Apply a simple moving average to an event.
+    def __call__(
+        self,
+        data: PandasEvent,
+        sampling: Optional[PandasEvent] = None,
+    ) -> Dict[str, PandasEvent]:
+        """Apply a simple moving average to an event.
 
     If input has more than one feature, the moving average will be computed for
     each of its features independently.
@@ -48,44 +48,45 @@ class PandasSimpleMovingAverageOperator(PandasWindowOperator):
     Returns:
       Dict[str, PandasEvent]: the output event of the operator.
     """
-    # remove index to be able to filter using index values
-    data_no_index = data.reset_index()
+        # remove index to be able to filter using index values
+        data_no_index = data.reset_index()
 
-    if sampling is None:
-      sampling = data
+        if sampling is None:
+            sampling = data
 
-    # get index columns and name of timestamp column
-    index_columns, timestamp_column = utils.get_index_and_timestamp_column_names(
-        sampling)
+        # get index columns and name of timestamp column
+        index_columns, timestamp_column = utils.get_index_and_timestamp_column_names(
+            sampling)
 
-    # create output event with desired sampling
-    output = PandasEvent(
-        {f"sma_{col}": [None] * len(sampling) for col in data.columns},
-        dtype=float,
-    ).set_index(sampling.index)
+        # create output event with desired sampling
+        output = PandasEvent(
+            {f"sma_{col}": [None] * len(sampling) for col in data.columns},
+            dtype=float,
+        ).set_index(sampling.index)
 
-    # manual rolling window since pandas doesn't support custom sampling in .rolling()
-    # TODO: optimize window calculation
-    for values in sampling.index:
-      index_value = values[:-1]
-      timestamp = values[-1]
+        # manual rolling window since pandas doesn't support custom sampling in .rolling()
+        # TODO: optimize window calculation
+        for values in sampling.index:
+            index_value = values[:-1]
+            timestamp = values[-1]
 
-      # filter by index_value
-      data_filtered = (data_no_index[(data_no_index[index_columns]
-                                      == index_value).squeeze()]
-                       if index_columns else data_no_index)
+            # filter by index_value
+            data_filtered = (data_no_index[(data_no_index[index_columns]
+                                            == index_value).squeeze()]
+                             if index_columns else data_no_index)
 
-      # filter by window start/end dates
-      data_filtered = data_filtered[
-          (data_filtered[timestamp_column] <= timestamp) &
-          (data_filtered[timestamp_column] >= timestamp -
-           pd.Timedelta(self.window_length))]
+            # filter by window start/end dates
+            data_filtered = data_filtered[
+                (data_filtered[timestamp_column] <= timestamp) &
+                (data_filtered[timestamp_column] >= timestamp -
+                 pd.Timedelta(self.window_length))]
 
-      # calculate average of window
-      mean = data_filtered.set_index(sampling.index.names).mean(axis=0).values
+            # calculate average of window
+            mean = data_filtered.set_index(
+                sampling.index.names).mean(axis=0).values
 
-      # set result in output event
-      loc = index_value + (timestamp,)
-      output.loc[loc] = mean
+            # set result in output event
+            loc = index_value + (timestamp,)
+            output.loc[loc] = mean
 
-    return {"output": output}
+        return {"output": output}

--- a/temporian/implementation/pandas/operators/window/tests/__init__.py
+++ b/temporian/implementation/pandas/operators/window/tests/__init__.py
@@ -11,4 +11,3 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-

--- a/temporian/implementation/pandas/operators/window/tests/simple_moving_average/__init__.py
+++ b/temporian/implementation/pandas/operators/window/tests/simple_moving_average/__init__.py
@@ -11,4 +11,3 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-

--- a/temporian/implementation/pandas/operators/window/tests/simple_moving_average/data/__init__.py
+++ b/temporian/implementation/pandas/operators/window/tests/simple_moving_average/data/__init__.py
@@ -11,4 +11,3 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-

--- a/temporian/implementation/pandas/operators/window/tests/simple_moving_average/data/diff_sampling.py
+++ b/temporian/implementation/pandas/operators/window/tests/simple_moving_average/data/diff_sampling.py
@@ -35,27 +35,29 @@ INPUT = PandasEvent(
 ).set_index(["id", "timestamp"])
 
 # sampling covering daily range of dates for each id independently
-SAMPLING = PandasEvent(index=PandasSampling.from_tuples(
-    [
-        (1, pd.Timestamp("2013-01-01")),
-        (1, pd.Timestamp("2013-01-02")),
-        (1, pd.Timestamp("2013-01-03")),
-        (1, pd.Timestamp("2013-01-04")),
-        (1, pd.Timestamp("2013-01-05")),
-        (1, pd.Timestamp("2013-01-06")),
-        (1, pd.Timestamp("2013-01-07")),
-        (1, pd.Timestamp("2013-01-08")),
-        (1, pd.Timestamp("2013-01-09")),
-        (1, pd.Timestamp("2013-01-10")),
-        (1, pd.Timestamp("2013-01-11")),
-        (1, pd.Timestamp("2013-01-12")),
-        (2, pd.Timestamp("2013-01-11")),
-        (2, pd.Timestamp("2013-01-12")),
-        (2, pd.Timestamp("2013-01-13")),
-        (2, pd.Timestamp("2013-01-14")),
-    ],
-    names=["id", "timestamp"],
-))
+SAMPLING = PandasEvent(
+    index=PandasSampling.from_tuples(
+        [
+            (1, pd.Timestamp("2013-01-01")),
+            (1, pd.Timestamp("2013-01-02")),
+            (1, pd.Timestamp("2013-01-03")),
+            (1, pd.Timestamp("2013-01-04")),
+            (1, pd.Timestamp("2013-01-05")),
+            (1, pd.Timestamp("2013-01-06")),
+            (1, pd.Timestamp("2013-01-07")),
+            (1, pd.Timestamp("2013-01-08")),
+            (1, pd.Timestamp("2013-01-09")),
+            (1, pd.Timestamp("2013-01-10")),
+            (1, pd.Timestamp("2013-01-11")),
+            (1, pd.Timestamp("2013-01-12")),
+            (2, pd.Timestamp("2013-01-11")),
+            (2, pd.Timestamp("2013-01-12")),
+            (2, pd.Timestamp("2013-01-13")),
+            (2, pd.Timestamp("2013-01-14")),
+        ],
+        names=["id", "timestamp"],
+    )
+)
 
 OUTPUT = PandasEvent(
     [

--- a/temporian/implementation/pandas/operators/window/tests/simple_moving_average/data/many_events_per_day.py
+++ b/temporian/implementation/pandas/operators/window/tests/simple_moving_average/data/many_events_per_day.py
@@ -32,17 +32,21 @@ INPUT = PandasEvent(
     columns=["timestamp", "value"],
 ).set_index(["timestamp"])
 
-SAMPLING = PandasEvent(index=PandasSampling.from_arrays(
-    [[
-        pd.Timestamp("2013-01-01"),
-        pd.Timestamp("2013-01-02"),
-        pd.Timestamp("2013-01-03"),
-        # range goes up until day 04 since we have events during day 03
-        # that wouldn't get processed otherwise
-        pd.Timestamp("2013-01-04"),
-    ]],
-    names=["timestamp"],
-))
+SAMPLING = PandasEvent(
+    index=PandasSampling.from_arrays(
+        [
+            [
+                pd.Timestamp("2013-01-01"),
+                pd.Timestamp("2013-01-02"),
+                pd.Timestamp("2013-01-03"),
+                # range goes up until day 04 since we have events during day 03
+                # that wouldn't get processed otherwise
+                pd.Timestamp("2013-01-04"),
+            ]
+        ],
+        names=["timestamp"],
+    )
+)
 
 OUTPUT = PandasEvent(
     [

--- a/temporian/implementation/pandas/operators/window/tests/simple_moving_average/data/many_features.py
+++ b/temporian/implementation/pandas/operators/window/tests/simple_moving_average/data/many_features.py
@@ -31,23 +31,27 @@ INPUT = PandasEvent(
 ).set_index(["timestamp"])
 
 # sampling covering daily range of dates
-SAMPLING = PandasEvent(index=PandasSampling.from_arrays(
-    [[
-        pd.Timestamp("2013-01-01"),
-        pd.Timestamp("2013-01-02"),
-        pd.Timestamp("2013-01-03"),
-        pd.Timestamp("2013-01-04"),
-        pd.Timestamp("2013-01-05"),
-        pd.Timestamp("2013-01-06"),
-        pd.Timestamp("2013-01-07"),
-        pd.Timestamp("2013-01-08"),
-        pd.Timestamp("2013-01-09"),
-        pd.Timestamp("2013-01-10"),
-        pd.Timestamp("2013-01-11"),
-        pd.Timestamp("2013-01-12"),
-    ]],
-    names=["timestamp"],
-))
+SAMPLING = PandasEvent(
+    index=PandasSampling.from_arrays(
+        [
+            [
+                pd.Timestamp("2013-01-01"),
+                pd.Timestamp("2013-01-02"),
+                pd.Timestamp("2013-01-03"),
+                pd.Timestamp("2013-01-04"),
+                pd.Timestamp("2013-01-05"),
+                pd.Timestamp("2013-01-06"),
+                pd.Timestamp("2013-01-07"),
+                pd.Timestamp("2013-01-08"),
+                pd.Timestamp("2013-01-09"),
+                pd.Timestamp("2013-01-10"),
+                pd.Timestamp("2013-01-11"),
+                pd.Timestamp("2013-01-12"),
+            ]
+        ],
+        names=["timestamp"],
+    )
+)
 
 OUTPUT = PandasEvent(
     [

--- a/temporian/implementation/pandas/operators/window/tests/simple_moving_average/data/no_index.py
+++ b/temporian/implementation/pandas/operators/window/tests/simple_moving_average/data/no_index.py
@@ -31,23 +31,27 @@ INPUT = PandasEvent(
 ).set_index(["timestamp"])
 
 # sampling covering daily range of dates
-SAMPLING = PandasEvent(index=PandasSampling.from_arrays(
-    [[
-        pd.Timestamp("2013-01-01"),
-        pd.Timestamp("2013-01-02"),
-        pd.Timestamp("2013-01-03"),
-        pd.Timestamp("2013-01-04"),
-        pd.Timestamp("2013-01-05"),
-        pd.Timestamp("2013-01-06"),
-        pd.Timestamp("2013-01-07"),
-        pd.Timestamp("2013-01-08"),
-        pd.Timestamp("2013-01-09"),
-        pd.Timestamp("2013-01-10"),
-        pd.Timestamp("2013-01-11"),
-        pd.Timestamp("2013-01-12"),
-    ]],
-    names=["timestamp"],
-))
+SAMPLING = PandasEvent(
+    index=PandasSampling.from_arrays(
+        [
+            [
+                pd.Timestamp("2013-01-01"),
+                pd.Timestamp("2013-01-02"),
+                pd.Timestamp("2013-01-03"),
+                pd.Timestamp("2013-01-04"),
+                pd.Timestamp("2013-01-05"),
+                pd.Timestamp("2013-01-06"),
+                pd.Timestamp("2013-01-07"),
+                pd.Timestamp("2013-01-08"),
+                pd.Timestamp("2013-01-09"),
+                pd.Timestamp("2013-01-10"),
+                pd.Timestamp("2013-01-11"),
+                pd.Timestamp("2013-01-12"),
+            ]
+        ],
+        names=["timestamp"],
+    )
+)
 
 OUTPUT = PandasEvent(
     [

--- a/temporian/implementation/pandas/operators/window/tests/simple_moving_average/data/same_sampling.py
+++ b/temporian/implementation/pandas/operators/window/tests/simple_moving_average/data/same_sampling.py
@@ -35,35 +35,37 @@ INPUT = PandasEvent(
 ).set_index(["id", "timestamp"])
 
 # sampling covering daily range of dates
-SAMPLING = PandasEvent(index=PandasSampling.from_tuples(
-    [
-        (1, pd.Timestamp("2013-01-01")),
-        (1, pd.Timestamp("2013-01-02")),
-        (1, pd.Timestamp("2013-01-03")),
-        (1, pd.Timestamp("2013-01-04")),
-        (1, pd.Timestamp("2013-01-05")),
-        (1, pd.Timestamp("2013-01-06")),
-        (1, pd.Timestamp("2013-01-07")),
-        (1, pd.Timestamp("2013-01-08")),
-        (1, pd.Timestamp("2013-01-09")),
-        (1, pd.Timestamp("2013-01-10")),
-        (1, pd.Timestamp("2013-01-11")),
-        (1, pd.Timestamp("2013-01-12")),
-        (2, pd.Timestamp("2013-01-01")),
-        (2, pd.Timestamp("2013-01-02")),
-        (2, pd.Timestamp("2013-01-03")),
-        (2, pd.Timestamp("2013-01-04")),
-        (2, pd.Timestamp("2013-01-05")),
-        (2, pd.Timestamp("2013-01-06")),
-        (2, pd.Timestamp("2013-01-07")),
-        (2, pd.Timestamp("2013-01-08")),
-        (2, pd.Timestamp("2013-01-09")),
-        (2, pd.Timestamp("2013-01-10")),
-        (2, pd.Timestamp("2013-01-11")),
-        (2, pd.Timestamp("2013-01-12")),
-    ],
-    names=["id", "timestamp"],
-))
+SAMPLING = PandasEvent(
+    index=PandasSampling.from_tuples(
+        [
+            (1, pd.Timestamp("2013-01-01")),
+            (1, pd.Timestamp("2013-01-02")),
+            (1, pd.Timestamp("2013-01-03")),
+            (1, pd.Timestamp("2013-01-04")),
+            (1, pd.Timestamp("2013-01-05")),
+            (1, pd.Timestamp("2013-01-06")),
+            (1, pd.Timestamp("2013-01-07")),
+            (1, pd.Timestamp("2013-01-08")),
+            (1, pd.Timestamp("2013-01-09")),
+            (1, pd.Timestamp("2013-01-10")),
+            (1, pd.Timestamp("2013-01-11")),
+            (1, pd.Timestamp("2013-01-12")),
+            (2, pd.Timestamp("2013-01-01")),
+            (2, pd.Timestamp("2013-01-02")),
+            (2, pd.Timestamp("2013-01-03")),
+            (2, pd.Timestamp("2013-01-04")),
+            (2, pd.Timestamp("2013-01-05")),
+            (2, pd.Timestamp("2013-01-06")),
+            (2, pd.Timestamp("2013-01-07")),
+            (2, pd.Timestamp("2013-01-08")),
+            (2, pd.Timestamp("2013-01-09")),
+            (2, pd.Timestamp("2013-01-10")),
+            (2, pd.Timestamp("2013-01-11")),
+            (2, pd.Timestamp("2013-01-12")),
+        ],
+        names=["id", "timestamp"],
+    )
+)
 
 OUTPUT = PandasEvent(
     [

--- a/temporian/implementation/pandas/operators/window/tests/simple_moving_average/test.py
+++ b/temporian/implementation/pandas/operators/window/tests/simple_moving_average/test.py
@@ -25,46 +25,48 @@ from temporian.implementation.pandas.operators.window.tests.simple_moving_averag
 
 class SimpleMovingAverageOperatorTest(absltest.TestCase):
 
-  def disabled_test_no_index(self) -> None:
-    """Test no specified index in the input data."""
-    operator = simple_moving_average.PandasSimpleMovingAverageOperator(
-        window_length="7d")
-    output = operator(no_index.INPUT, no_index.SAMPLING)
-    pd.testing.assert_frame_equal(no_index.OUTPUT, output["output"])
-    self.assertTrue(no_index.OUTPUT.equals(output["output"]))
+    def disabled_test_no_index(self) -> None:
+        """Test no specified index in the input data."""
+        operator = simple_moving_average.PandasSimpleMovingAverageOperator(
+            window_length="7d")
+        output = operator(no_index.INPUT, no_index.SAMPLING)
+        pd.testing.assert_frame_equal(no_index.OUTPUT, output["output"])
+        self.assertTrue(no_index.OUTPUT.equals(output["output"]))
 
-  def test_same_sampling(self) -> None:
-    """Test same sampling for all index values."""
-    operator = simple_moving_average.PandasSimpleMovingAverageOperator(
-        window_length="7d")
-    output = operator(same_sampling.INPUT, same_sampling.SAMPLING)
-    pd.testing.assert_frame_equal(same_sampling.OUTPUT, output["output"])
-    self.assertTrue(same_sampling.OUTPUT.equals(output["output"]))
+    def test_same_sampling(self) -> None:
+        """Test same sampling for all index values."""
+        operator = simple_moving_average.PandasSimpleMovingAverageOperator(
+            window_length="7d")
+        output = operator(same_sampling.INPUT, same_sampling.SAMPLING)
+        pd.testing.assert_frame_equal(same_sampling.OUTPUT, output["output"])
+        self.assertTrue(same_sampling.OUTPUT.equals(output["output"]))
 
-  def test_diff_sampling(self) -> None:
-    """Test different sampling for each index value."""
-    operator = simple_moving_average.PandasSimpleMovingAverageOperator(
-        window_length="7d")
-    output = operator(diff_sampling.INPUT, diff_sampling.SAMPLING)
-    pd.testing.assert_frame_equal(diff_sampling.OUTPUT, output["output"])
-    self.assertTrue(diff_sampling.OUTPUT.equals(output["output"]))
+    def test_diff_sampling(self) -> None:
+        """Test different sampling for each index value."""
+        operator = simple_moving_average.PandasSimpleMovingAverageOperator(
+            window_length="7d")
+        output = operator(diff_sampling.INPUT, diff_sampling.SAMPLING)
+        pd.testing.assert_frame_equal(diff_sampling.OUTPUT, output["output"])
+        self.assertTrue(diff_sampling.OUTPUT.equals(output["output"]))
 
-  def disabled_test_many_events_per_day(self) -> None:
-    """Test several events occuring per day."""
-    operator = simple_moving_average.PandasSimpleMovingAverageOperator(
-        window_length="7d")
-    output = operator(many_events_per_day.INPUT, many_events_per_day.SAMPLING)
-    pd.testing.assert_frame_equal(many_events_per_day.OUTPUT, output["output"])
-    self.assertTrue(many_events_per_day.OUTPUT.equals(output["output"]))
+    def disabled_test_many_events_per_day(self) -> None:
+        """Test several events occuring per day."""
+        operator = simple_moving_average.PandasSimpleMovingAverageOperator(
+            window_length="7d")
+        output = operator(many_events_per_day.INPUT,
+                          many_events_per_day.SAMPLING)
+        pd.testing.assert_frame_equal(many_events_per_day.OUTPUT,
+                                      output["output"])
+        self.assertTrue(many_events_per_day.OUTPUT.equals(output["output"]))
 
-  def disabled_test_many_features(self) -> None:
-    """Test several events occuring per day."""
-    operator = simple_moving_average.PandasSimpleMovingAverageOperator(
-        window_length="7d")
-    output = operator(many_features.INPUT, many_features.SAMPLING)
-    pd.testing.assert_frame_equal(many_features.OUTPUT, output["output"])
-    self.assertTrue(many_features.OUTPUT.equals(output["output"]))
+    def disabled_test_many_features(self) -> None:
+        """Test several events occuring per day."""
+        operator = simple_moving_average.PandasSimpleMovingAverageOperator(
+            window_length="7d")
+        output = operator(many_features.INPUT, many_features.SAMPLING)
+        pd.testing.assert_frame_equal(many_features.OUTPUT, output["output"])
+        self.assertTrue(many_features.OUTPUT.equals(output["output"]))
 
 
 if __name__ == "__main__":
-  absltest.main()
+    absltest.main()

--- a/temporian/implementation/pandas/operators/window/tests/simple_moving_average/test.py
+++ b/temporian/implementation/pandas/operators/window/tests/simple_moving_average/test.py
@@ -15,20 +15,32 @@
 from absl.testing import absltest
 import pandas as pd
 
-from temporian.implementation.pandas.operators.window import simple_moving_average
-from temporian.implementation.pandas.operators.window.tests.simple_moving_average.data import diff_sampling
-from temporian.implementation.pandas.operators.window.tests.simple_moving_average.data import many_events_per_day
-from temporian.implementation.pandas.operators.window.tests.simple_moving_average.data import many_features
-from temporian.implementation.pandas.operators.window.tests.simple_moving_average.data import no_index
-from temporian.implementation.pandas.operators.window.tests.simple_moving_average.data import same_sampling
+from temporian.implementation.pandas.operators.window import (
+    simple_moving_average,
+)
+from temporian.implementation.pandas.operators.window.tests.simple_moving_average.data import (
+    diff_sampling,
+)
+from temporian.implementation.pandas.operators.window.tests.simple_moving_average.data import (
+    many_events_per_day,
+)
+from temporian.implementation.pandas.operators.window.tests.simple_moving_average.data import (
+    many_features,
+)
+from temporian.implementation.pandas.operators.window.tests.simple_moving_average.data import (
+    no_index,
+)
+from temporian.implementation.pandas.operators.window.tests.simple_moving_average.data import (
+    same_sampling,
+)
 
 
 class SimpleMovingAverageOperatorTest(absltest.TestCase):
-
     def disabled_test_no_index(self) -> None:
         """Test no specified index in the input data."""
         operator = simple_moving_average.PandasSimpleMovingAverageOperator(
-            window_length="7d")
+            window_length="7d"
+        )
         output = operator(no_index.INPUT, no_index.SAMPLING)
         pd.testing.assert_frame_equal(no_index.OUTPUT, output["output"])
         self.assertTrue(no_index.OUTPUT.equals(output["output"]))
@@ -36,7 +48,8 @@ class SimpleMovingAverageOperatorTest(absltest.TestCase):
     def test_same_sampling(self) -> None:
         """Test same sampling for all index values."""
         operator = simple_moving_average.PandasSimpleMovingAverageOperator(
-            window_length="7d")
+            window_length="7d"
+        )
         output = operator(same_sampling.INPUT, same_sampling.SAMPLING)
         pd.testing.assert_frame_equal(same_sampling.OUTPUT, output["output"])
         self.assertTrue(same_sampling.OUTPUT.equals(output["output"]))
@@ -44,7 +57,8 @@ class SimpleMovingAverageOperatorTest(absltest.TestCase):
     def test_diff_sampling(self) -> None:
         """Test different sampling for each index value."""
         operator = simple_moving_average.PandasSimpleMovingAverageOperator(
-            window_length="7d")
+            window_length="7d"
+        )
         output = operator(diff_sampling.INPUT, diff_sampling.SAMPLING)
         pd.testing.assert_frame_equal(diff_sampling.OUTPUT, output["output"])
         self.assertTrue(diff_sampling.OUTPUT.equals(output["output"]))
@@ -52,17 +66,21 @@ class SimpleMovingAverageOperatorTest(absltest.TestCase):
     def disabled_test_many_events_per_day(self) -> None:
         """Test several events occuring per day."""
         operator = simple_moving_average.PandasSimpleMovingAverageOperator(
-            window_length="7d")
-        output = operator(many_events_per_day.INPUT,
-                          many_events_per_day.SAMPLING)
-        pd.testing.assert_frame_equal(many_events_per_day.OUTPUT,
-                                      output["output"])
+            window_length="7d"
+        )
+        output = operator(
+            many_events_per_day.INPUT, many_events_per_day.SAMPLING
+        )
+        pd.testing.assert_frame_equal(
+            many_events_per_day.OUTPUT, output["output"]
+        )
         self.assertTrue(many_events_per_day.OUTPUT.equals(output["output"]))
 
     def disabled_test_many_features(self) -> None:
         """Test several events occuring per day."""
         operator = simple_moving_average.PandasSimpleMovingAverageOperator(
-            window_length="7d")
+            window_length="7d"
+        )
         output = operator(many_features.INPUT, many_features.SAMPLING)
         pd.testing.assert_frame_equal(many_features.OUTPUT, output["output"])
         self.assertTrue(many_features.OUTPUT.equals(output["output"]))

--- a/temporian/implementation/pandas/utils.py
+++ b/temporian/implementation/pandas/utils.py
@@ -22,15 +22,15 @@ def get_index_and_timestamp_column_names(
     obj: Union[event.PandasEvent, sampling.PandasSampling]
 ) -> tuple[list[str], str]:
     """Get the names of the index columns and the timestamp column from a
-  PandasEvent or PandasSampling.
+    PandasEvent or PandasSampling.
 
-  Args:
-      obj (Union[event.PandasEvent, sampling.PandasSampling]): the event or
-      sampling to get the index names of.
+    Args:
+        obj (Union[event.PandasEvent, sampling.PandasSampling]): the event or
+        sampling to get the index names of.
 
-  Returns:
-      Tuple[List[str], str]: output index and timestamp column names.
-  """
+    Returns:
+        Tuple[List[str], str]: output index and timestamp column names.
+    """
     if isinstance(obj, event.PandasEvent):
         obj = obj.index
 

--- a/temporian/implementation/pandas/utils.py
+++ b/temporian/implementation/pandas/utils.py
@@ -21,7 +21,7 @@ from temporian.implementation.pandas.data import sampling
 def get_index_and_timestamp_column_names(
     obj: Union[event.PandasEvent, sampling.PandasSampling]
 ) -> tuple[list[str], str]:
-  """Get the names of the index columns and the timestamp column from a
+    """Get the names of the index columns and the timestamp column from a
   PandasEvent or PandasSampling.
 
   Args:
@@ -31,10 +31,10 @@ def get_index_and_timestamp_column_names(
   Returns:
       Tuple[List[str], str]: output index and timestamp column names.
   """
-  if isinstance(obj, event.PandasEvent):
-    obj = obj.index
+    if isinstance(obj, event.PandasEvent):
+        obj = obj.index
 
-  index_cols = obj.names[:-1]
-  timestamp_col = obj.names[-1]
+    index_cols = obj.names[:-1]
+    timestamp_col = obj.names[-1]
 
-  return index_cols, timestamp_col
+    return index_cols, timestamp_col

--- a/temporian/test/api_test.py
+++ b/temporian/test/api_test.py
@@ -21,7 +21,6 @@ from temporian.implementation.pandas.data.event import PandasEvent
 
 
 class TFPTest(absltest.TestCase):
-
     def test_does_nothing(self):
         logging.info("Running a test")
         t.does_nothing()
@@ -42,11 +41,13 @@ class TFPTest(absltest.TestCase):
 
         b = t.sma(data=a, window_length=7)
 
-        input_signal_data = PandasEvent({
-            "time": [0, 2, 4, 6],
-            "f1": [1, 2, 3, 4],
-            "f2": [5, 6, 7, 8],
-        })
+        input_signal_data = PandasEvent(
+            {
+                "time": [0, 2, 4, 6],
+                "f1": [1, 2, 3, 4],
+                "f2": [5, 6, 7, 8],
+            }
+        )
 
         results = t.evaluate(
             query={"b": b},

--- a/temporian/test/api_test.py
+++ b/temporian/test/api_test.py
@@ -22,41 +22,41 @@ from temporian.implementation.pandas.data.event import PandasEvent
 
 class TFPTest(absltest.TestCase):
 
-  def test_does_nothing(self):
-    logging.info("Running a test")
-    t.does_nothing()
-    self.assertEqual(1, 1)
+    def test_does_nothing(self):
+        logging.info("Running a test")
+        t.does_nothing()
+        self.assertEqual(1, 1)
 
-  def test_create_toy_processor(self):
-    p = t.create_toy_processor()
-    logging.info("Processor:\n%s", p)
+    def test_create_toy_processor(self):
+        p = t.create_toy_processor()
+        logging.info("Processor:\n%s", p)
 
-  def disabled_test_create_processor(self):
-    a = t.place_holder(
-        features=[
-            t.Feature(name="f1", dtype=t.dtype.FLOAT),
-            t.Feature(name="f2", dtype=t.dtype.FLOAT),
-        ],
-        index=[],
-    )
+    def disabled_test_create_processor(self):
+        a = t.place_holder(
+            features=[
+                t.Feature(name="f1", dtype=t.dtype.FLOAT),
+                t.Feature(name="f2", dtype=t.dtype.FLOAT),
+            ],
+            index=[],
+        )
 
-    b = t.sma(data=a, window_length=7)
+        b = t.sma(data=a, window_length=7)
 
-    input_signal_data = PandasEvent({
-        "time": [0, 2, 4, 6],
-        "f1": [1, 2, 3, 4],
-        "f2": [5, 6, 7, 8],
-    })
+        input_signal_data = PandasEvent({
+            "time": [0, 2, 4, 6],
+            "f1": [1, 2, 3, 4],
+            "f2": [5, 6, 7, 8],
+        })
 
-    results = t.evaluate(
-        query={"b": b},
-        input_data={
-            a: input_signal_data,
-        },
-    )
+        results = t.evaluate(
+            query={"b": b},
+            input_data={
+                a: input_signal_data,
+            },
+        )
 
-    logging.info("results: %s", results)
+        logging.info("results: %s", results)
 
 
 if __name__ == "__main__":
-  absltest.main()
+    absltest.main()

--- a/temporian/test/prototype_test.py
+++ b/temporian/test/prototype_test.py
@@ -24,10 +24,10 @@ from temporian.implementation.pandas.data import event as pandas_event
 
 
 class PrototypeTest(absltest.TestCase):
-
     def setUp(self) -> None:
         self.assignee_event = (
-            "temporian/test/test_data/prototype/assignee_event.csv")
+            "temporian/test/test_data/prototype/assignee_event.csv"
+        )
 
         self.assigned_event = pandas_event.PandasEvent(
             [
@@ -40,12 +40,9 @@ class PrototypeTest(absltest.TestCase):
 
         self.expected_output_event = pandas_event.PandasEvent(
             [
-                [666964,
-                 pd.Timestamp("2013-01-02"), 1091.0, 740.0, 740.0],
-                [666964,
-                 pd.Timestamp("2013-01-03"), 919.0, 508.0, 624.0],
-                [574016,
-                 pd.Timestamp("2013-01-04"), 953.0, 573.0, 573.0],
+                [666964, pd.Timestamp("2013-01-02"), 1091.0, 740.0, 740.0],
+                [666964, pd.Timestamp("2013-01-03"), 919.0, 508.0, 624.0],
+                [574016, pd.Timestamp("2013-01-04"), 953.0, 573.0, 573.0],
             ],
             columns=["product_id", "timestamp", "sales", "costs", "sma_costs"],
         ).set_index(["product_id", "timestamp"])
@@ -65,9 +62,9 @@ class PrototypeTest(absltest.TestCase):
         output_event = assign(assignee_event, assigned_event)
 
         # call sma operator
-        sma_assigned_event = sma(assigned_event,
-                                 window_length="7d",
-                                 sampling=assigned_event)
+        sma_assigned_event = sma(
+            assigned_event, window_length="7d", sampling=assigned_event
+        )
 
         # call assign operator with result of sma
         output_event = assign(output_event, sma_assigned_event)
@@ -88,7 +85,8 @@ class PrototypeTest(absltest.TestCase):
         self.assertEqual(
             True,
             self.expected_output_event.equals(
-                output_event_pandas[output_event]),
+                output_event_pandas[output_event]
+            ),
         )
 
 

--- a/temporian/test/prototype_test.py
+++ b/temporian/test/prototype_test.py
@@ -25,68 +25,72 @@ from temporian.implementation.pandas.data import event as pandas_event
 
 class PrototypeTest(absltest.TestCase):
 
-  def setUp(self) -> None:
-    self.assignee_event = (
-        "temporian/test/test_data/prototype/assignee_event.csv")
+    def setUp(self) -> None:
+        self.assignee_event = (
+            "temporian/test/test_data/prototype/assignee_event.csv")
 
-    self.assigned_event = pandas_event.PandasEvent(
-        [
-            [666964, pd.Timestamp("2013-01-02"), 740.0],
-            [666964, pd.Timestamp("2013-01-03"), 508.0],
-            [574016, pd.Timestamp("2013-01-04"), 573.0],
-        ],
-        columns=["product_id", "timestamp", "costs"],
-    ).set_index(["product_id", "timestamp"])
+        self.assigned_event = pandas_event.PandasEvent(
+            [
+                [666964, pd.Timestamp("2013-01-02"), 740.0],
+                [666964, pd.Timestamp("2013-01-03"), 508.0],
+                [574016, pd.Timestamp("2013-01-04"), 573.0],
+            ],
+            columns=["product_id", "timestamp", "costs"],
+        ).set_index(["product_id", "timestamp"])
 
-    self.expected_output_event = pandas_event.PandasEvent(
-        [
-            [666964, pd.Timestamp("2013-01-02"), 1091.0, 740.0, 740.0],
-            [666964, pd.Timestamp("2013-01-03"), 919.0, 508.0, 624.0],
-            [574016, pd.Timestamp("2013-01-04"), 953.0, 573.0, 573.0],
-        ],
-        columns=["product_id", "timestamp", "sales", "costs", "sma_costs"],
-    ).set_index(["product_id", "timestamp"])
+        self.expected_output_event = pandas_event.PandasEvent(
+            [
+                [666964,
+                 pd.Timestamp("2013-01-02"), 1091.0, 740.0, 740.0],
+                [666964,
+                 pd.Timestamp("2013-01-03"), 919.0, 508.0, 624.0],
+                [574016,
+                 pd.Timestamp("2013-01-04"), 953.0, 573.0, 573.0],
+            ],
+            columns=["product_id", "timestamp", "sales", "costs", "sma_costs"],
+        ).set_index(["product_id", "timestamp"])
 
-  def test_prototoype(self) -> None:
-    # instance input events
-    assignee_event = Event(
-        features=[Feature(name="sales", dtype=float)],
-        sampling=Sampling(["product_id", "timestamp"]),
-    )
-    assigned_event = Event(
-        features=[Feature(name="costs", dtype=float)],
-        sampling=Sampling(["product_id", "timestamp"]),
-    )
+    def test_prototoype(self) -> None:
+        # instance input events
+        assignee_event = Event(
+            features=[Feature(name="sales", dtype=float)],
+            sampling=Sampling(["product_id", "timestamp"]),
+        )
+        assigned_event = Event(
+            features=[Feature(name="costs", dtype=float)],
+            sampling=Sampling(["product_id", "timestamp"]),
+        )
 
-    # call assign operator
-    output_event = assign(assignee_event, assigned_event)
+        # call assign operator
+        output_event = assign(assignee_event, assigned_event)
 
-    # call sma operator
-    sma_assigned_event = sma(assigned_event,
-                             window_length="7d",
-                             sampling=assigned_event)
+        # call sma operator
+        sma_assigned_event = sma(assigned_event,
+                                 window_length="7d",
+                                 sampling=assigned_event)
 
-    # call assign operator with result of sma
-    output_event = assign(output_event, sma_assigned_event)
+        # call assign operator with result of sma
+        output_event = assign(output_event, sma_assigned_event)
 
-    # evaluate output
-    output_event_pandas = evaluator.evaluate(
-        output_event,
-        input_data={
-            # assignee event specified from disk
-            assignee_event: self.assignee_event,
-            # assigned event loaded in ram
-            assigned_event: self.assigned_event,
-        },
-        backend="pandas",
-    )
+        # evaluate output
+        output_event_pandas = evaluator.evaluate(
+            output_event,
+            input_data={
+                # assignee event specified from disk
+                assignee_event: self.assignee_event,
+                # assigned event loaded in ram
+                assigned_event: self.assigned_event,
+            },
+            backend="pandas",
+        )
 
-    # validate
-    self.assertEqual(
-        True,
-        self.expected_output_event.equals(output_event_pandas[output_event]),
-    )
+        # validate
+        self.assertEqual(
+            True,
+            self.expected_output_event.equals(
+                output_event_pandas[output_event]),
+        )
 
 
 if __name__ == "__main__":
-  absltest.main()
+    absltest.main()


### PR DESCRIPTION
Swapped `yapf` for [black](https://black.readthedocs.io/en/stable/) formatter.

> Black aims for consistency, generality, readability and reducing git diffs. Similar language constructs are formatted with similar rules. Style configuration options are deliberately limited and rarely added. Previous formatting is taken into account as little as possible, with rare exceptions like the magic trailing comma. The coding style used by Black can be viewed as a strict subset of PEP 8.

Split the reformatting of the whole project into two different commits so that black's modifications are more visible and not hidden between thousands of lines changing indentation only:
- First changed 2 to 4 indentation spaces with yapf
- Then reformatted with black

All tests pass.