### PR TITLE
Improve graph schedule

### DIFF
--- a/temporian/core/data/event.py
+++ b/temporian/core/data/event.py
@@ -14,7 +14,7 @@
 
 """An event is a collection (possibly empty) of timesampled feature values."""
 
-from typing import List
+from typing import Any, List, Optional
 
 from temporian.core.data.feature import Feature
 from temporian.core.data.sampling import Sampling
@@ -25,9 +25,13 @@ class Event(object):
         self,
         features: List[Feature],
         sampling: Sampling,
+        # TODO: make Operator the creator's type. I don't know how to circumvent
+        # the cyclical import error
+        creator: Optional[Any] = None,
     ):
         self._features = features
         self._sampling = sampling
+        self._creator = creator
 
     def __repr__(self):
         return f"Event<features:{self._features},sampling:{self._sampling},id:{id(self)}>"
@@ -37,3 +41,6 @@ class Event(object):
 
     def features(self):
         return self._features
+
+    def creator(self):
+        return self._creator

--- a/temporian/core/data/feature.py
+++ b/temporian/core/data/feature.py
@@ -14,7 +14,7 @@
 
 """A feature."""
 
-from typing import Any, Optional, Set
+from typing import Any, Optional
 
 from temporian.core.data import sampling as sampling_lib
 
@@ -49,13 +49,3 @@ class Feature(object):
 
     def set_sampling(self, sampling: sampling_lib.Sampling):
         self._sampling = sampling
-
-    def parent_features(self) -> Set["Feature"]:
-        if self.creator() is None:
-            return {}
-
-        return {
-            input_feature
-            for input_event in self.creator().inputs().values()
-            for input_feature in input_event.features()
-        }

--- a/temporian/core/data/feature.py
+++ b/temporian/core/data/feature.py
@@ -14,7 +14,7 @@
 
 """A feature."""
 
-from typing import Any, Optional
+from typing import Any, Optional, Set
 
 from temporian.core.data import sampling as sampling_lib
 
@@ -49,3 +49,13 @@ class Feature(object):
 
     def set_sampling(self, sampling: sampling_lib.Sampling):
         self._sampling = sampling
+
+    def parent_features(self) -> Set["Feature"]:
+        if self.creator() is None:
+            return {}
+
+        return {
+            input_feature
+            for input_event in self.creator().inputs().values()
+            for input_feature in input_event.features()
+        }

--- a/temporian/core/evaluator.py
+++ b/temporian/core/evaluator.py
@@ -84,8 +84,19 @@ def evaluate(
 
 
 def get_operator_schedule(query: Set[Feature]) -> Dict[base.Operator, int]:
-    # start features. Depth initialized as 0. Depth is measured from bottom to
-    # top, i.e. 0 depth corresponds to the output features
+    """Calculates which operators need to be executed in which order to
+    compute a set of query features.
+
+    Args:
+        query: set of query features to be computed.
+
+    Returns:
+        Dict[base.Operator, int]: dictionary mapping operators to their respective
+        depths in the compute graph. Depth is measured from bottom to top, i.e.
+        0 depth corresponds to the output features (query). Operators with the
+        same depth can be computed in parallel.
+    """
+    # start features. Depth initialized as 0
     feature_depth = [(feature, 0) for feature in query]
 
     # get all features and depths required to compute the query. One feature can

--- a/temporian/core/evaluator.py
+++ b/temporian/core/evaluator.py
@@ -15,7 +15,7 @@
 """Evaluator module."""
 
 import pathlib
-from typing import Any, Dict, List, Union
+from typing import Any, Dict, List, Set, Union
 
 from temporian.core import backends
 from temporian.core.data.event import Event
@@ -52,72 +52,65 @@ def evaluate(
             f" {type(query)}."
         )
 
-    # get features from events
-    features_to_compute = [
-        feature
-        for event in events_to_compute
-        for feature in event.features()  # pytype: disable=attribute-error
-    ]
-
     # get backend
     selected_backend = backends.BACKENDS[backend]
     event = selected_backend["event"]
     evaluate_schedule_fn = selected_backend["evaluate_schedule_fn"]
     read_csv_fn = selected_backend["read_csv_fn"]
 
-    # calculate opeartor schedule
-    schedule = get_operator_schedule(features_to_compute)
+    # get features from events
+    features_to_compute = {
+        feature
+        for event in events_to_compute
+        for feature in event.features()  # pytype: disable=attribute-error
+    }
+    # calculate opeartor schedule. Only using keys (operators) for now, discarding
+    # depth
+    schedule = get_operator_schedule(features_to_compute).keys()
 
     # materialize input data. TODO: separate this logic
-    materialized_input_data = {}
-    for input_event, input_event_spec in input_data.items():
-        if not isinstance(input_event_spec, event):
-            input_event_spec = read_csv_fn(
-                input_event_spec, input_event.sampling()
-            )
-        materialized_input_data[input_event] = input_event_spec
-
+    materialized_input_data = {
+        input_event: (
+            input_event_spec
+            if isinstance(input_event_spec, event)
+            else read_csv_fn(input_event_spec, input_event.sampling())
+        )
+        for input_event, input_event_spec in input_data.items()
+    }
     # evaluate schedule
     outputs = evaluate_schedule_fn(materialized_input_data, schedule)
 
     return {event: outputs[event] for event in events_to_compute}
 
 
-def get_operator_schedule(query: List[Feature]) -> List[base.Operator]:
-    # TODO: add depth calculation for parallelization
-    # TODO: Make "query" a Set
+def get_operator_schedule(query: Set[Feature]) -> Dict[base.Operator, int]:
+    # start features. Depth initialized as 0. Depth is measured from bottom to
+    # top, i.e. 0 depth corresponds to the output features
+    feature_depth = [(feature, 0) for feature in query]
 
-    operators_to_compute = []  # TODO: implement as ordered set
-    visited_features = set()
-    pending_features = list(query.copy())  # TODO: implement as ordered set
-    while pending_features:
-        feature = next(iter(pending_features))
-        visited_features.add(feature)
+    # get all features and depths required to compute the query. One feature can
+    # have multiple depths in this set (if it appears in more than one feature's
+    # compute path at different depths)
+    for feature, depth in feature_depth:
+        this_depth = depth + 1
+        for parent_feature in feature.parent_features():
+            feature_depth.append((parent_feature, this_depth))
 
-        if feature.creator() is None:
-            # is input feature
-            pending_features.remove(feature)
-            continue
+    # refine previous set - get max depth for each feature, which ensures we
+    # compute the feature as soon as it's needed (most depth)
+    feature_max_depth = {feature: 0 for feature, _ in feature_depth}
+    for feature, depth in feature_depth:
+        feature_max_depth[feature] = max(feature_max_depth[feature], depth)
 
-        # required input features to compute this feature
-        creator_input_features = {
-            input_feature
-            for input_event in feature.creator().inputs().values()
-            for input_feature in input_event.features()
-        }
+    # sort features according to their max depth, from deepest to shallowest
+    feature_sorted = dict(
+        sorted(feature_max_depth.items(), key=lambda item: -1 * item[1])
+    )
 
-        # check if all required input features have already been visited
-        if creator_input_features.issubset(visited_features):
-            # feature can be computed - remove it from pending_features
-            pending_features.remove(feature)
-
-            # add operator at the end of operators_to_compute
-            if feature.creator() not in operators_to_compute:
-                operators_to_compute.append(feature.creator())
-
-            continue
-
-        # add required input features at the beginning of pending_features
-        pending_features = list(creator_input_features) + pending_features
-
-    return operators_to_compute
+    # get operators from features
+    operator_sorted = {
+        feature.creator(): depth
+        for feature, depth in feature_sorted.items()
+        if feature.creator() is not None
+    }
+    return operator_sorted

--- a/temporian/core/operators/assign.py
+++ b/temporian/core/operators/assign.py
@@ -43,7 +43,9 @@ class AssignOperator(Operator):
         output_sampling = assignee_event.sampling()
         self.add_output(
             "output",
-            Event(features=output_features, sampling=output_sampling),
+            Event(
+                features=output_features, sampling=output_sampling, creator=self
+            ),
         )
         self.check()
 

--- a/temporian/core/operators/place_holder.py
+++ b/temporian/core/operators/place_holder.py
@@ -44,6 +44,7 @@ class PlaceHolder(base.Operator):
             event_lib.Event(
                 features=features,
                 sampling=sampling,
+                creator=self,
             ),
         )
 

--- a/temporian/core/operators/simple_moving_average.py
+++ b/temporian/core/operators/simple_moving_average.py
@@ -58,6 +58,7 @@ class SimpleMovingAverage(Operator):
             Event(
                 features=output_features,
                 sampling=sampling,
+                creator=self,
             ),
         )
 

--- a/temporian/test/prototype_test.py
+++ b/temporian/test/prototype_test.py
@@ -21,7 +21,6 @@ from temporian.core.data.event import Event
 from temporian.core.data.event import Feature
 from temporian.core.data.sampling import Sampling
 from temporian.core.operators.assign import assign
-from temporian.core.operators.select import select
 from temporian.core.operators.simple_moving_average import sma
 from temporian.implementation.pandas.data import event as pandas_event
 
@@ -92,13 +91,10 @@ class PrototypeTest(absltest.TestCase):
             features=[Feature(name="costs", dtype=float)],
             sampling=Sampling(["product_id", "timestamp"]),
         )
-        # call assign operator
-        output_event = assign(assignee_event, assigned_event)
-
         # call assign operators
         assign_output_1 = assign(assignee_event, assigned_event)
         assign_output_2 = assign(assignee_event, assigned_event)
-        final_assign_output = assign(assign_output_1, assign_output_2)
+        assign_assign_event = assign(assign_output_1, assign_output_2)
 
         # call sma operator
         sma_assigned_event = sma(
@@ -106,7 +102,7 @@ class PrototypeTest(absltest.TestCase):
         )
 
         # call assign operator with result of sma
-        output_event = assign(final_assign_output, sma_assigned_event)
+        output_event = assign(assign_assign_event, sma_assigned_event)
 
         # evaluate output
         output_event_pandas = evaluator.evaluate(
@@ -126,6 +122,7 @@ class PrototypeTest(absltest.TestCase):
                 output_event_pandas[output_event]
             ),
         )
+        logging.info(output_event_pandas)
 
 
 if __name__ == "__main__":

--- a/temporian/test/prototype_test.py
+++ b/temporian/test/prototype_test.py
@@ -21,6 +21,7 @@ from temporian.core.data.event import Event
 from temporian.core.data.event import Feature
 from temporian.core.data.sampling import Sampling
 from temporian.core.operators.assign import assign
+from temporian.core.operators.select import select
 from temporian.core.operators.simple_moving_average import sma
 from temporian.implementation.pandas.data import event as pandas_event
 
@@ -91,7 +92,6 @@ class PrototypeTest(absltest.TestCase):
             features=[Feature(name="costs", dtype=float)],
             sampling=Sampling(["product_id", "timestamp"]),
         )
-
         # call assign operator
         output_event = assign(assignee_event, assigned_event)
 
@@ -119,10 +119,6 @@ class PrototypeTest(absltest.TestCase):
             },
             backend="pandas",
         )
-
-        # log output
-        logging.info(output_event_pandas.values())
-
         # validate
         self.assertEqual(
             True,


### PR DESCRIPTION
This PR improves the graph scheduling algorithm by:

Removing previous never ending loop bug
- Adding operator depth calculation (for parallelization purposes)
- I've extended the prototype_test.py with a more complex example in which there's 3 different depths (2, 1, & 0). The depth for each operator is:
```
{
    <temporian.core.operators.assign.AssignOperator object at 0x12b108820>: 2,      # assign_output_1
    <temporian.core.operators.assign.AssignOperator object at 0x12b1086d0>: 2,     # assign_output_2
    <temporian.core.operators.assign.AssignOperator object at 0x11fd87670>: 1,      # final_assign_output
    <temporian.core.operators.simple_moving_average.SimpleMovingAverage object at 0x12b13ff40>: 1,    # sma_assigned_event
    <temporian.core.operators.assign.AssignOperator object at 0x11e757520>: 0  # output_event
}
```
Operators with the same depth can be parallelized. **The depth calculation isn't finished though; it can be improved**. In the `prototype_test.py` example, the sma operator should have a depth of 2 (same as the first two assigns). This could be fixed by doing a second pass of the graph, from top to bottom. I'm still investigating the best way of implementing this.

All tests pass.