### PR TITLE
Check sampling dtype

### DIFF
--- a/temporian/implementation/pandas/data/sampling.py
+++ b/temporian/implementation/pandas/data/sampling.py
@@ -20,4 +20,29 @@ import pandas as pd
 
 
 class PandasSampling(pd.MultiIndex):
-    pass
+    def __new__(
+        cls,
+        levels=None,
+        codes=None,
+        sortorder=None,
+        names=None,
+        dtype=None,
+        copy=False,
+        name=None,
+        verify_integrity: bool = True,
+    ) -> pd.MultiIndex:
+        if not isinstance(levels[-1], pd.DatetimeIndex):
+            raise ValueError(
+                "The last level of a PandasSampling must be a DatetimeIndex."
+            )
+        return super().__new__(
+            cls,
+            levels,
+            codes,
+            sortorder,
+            names,
+            dtype,
+            copy,
+            name,
+            verify_integrity,
+        )

--- a/temporian/implementation/pandas/data/tests/BUILD
+++ b/temporian/implementation/pandas/data/tests/BUILD
@@ -1,0 +1,15 @@
+package(
+    default_visibility = ["//visibility:public"],
+    licenses = ["notice"],
+)
+
+# Tests
+# =====
+py_test(
+    name = "test_sampling",
+    srcs = ["test_sampling.py"],
+    srcs_version = "PY3",
+    deps = [
+        "//temporian/implementation/pandas/data:sampling",
+    ],
+)

--- a/temporian/implementation/pandas/data/tests/test_sampling.py
+++ b/temporian/implementation/pandas/data/tests/test_sampling.py
@@ -1,0 +1,45 @@
+# Copyright 2021 Google LLC.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from absl.testing import absltest
+import pandas as pd
+
+from temporian.implementation.pandas.data.sampling import PandasSampling
+
+
+class PandasSamplingTest(absltest.TestCase):
+    def test_create_correct(self) -> None:
+        """Test creation is successful if last level is a DatetimeIndex."""
+        PandasSampling.from_arrays(
+            [
+                ["a", "a", "b"],
+                [
+                    pd.Timestamp("2013-01-01"),
+                    pd.Timestamp("2013-01-02"),
+                    pd.Timestamp("2013-01-03"),
+                ],
+            ],
+            names=["str", "datetime"],
+        )
+
+    def test_create_wrong_timestamps_dtype(self) -> None:
+        """Test creation fails if last index level isn't a DatetimeIndex."""
+        with self.assertRaises(ValueError):
+            PandasSampling.from_arrays(
+                [["a", "a", "b"], [1, 2, 3]], names=["str", "int"]
+            )
+
+
+if __name__ == "__main__":
+    absltest.main()


### PR DESCRIPTION
Addresses [this comment](https://github.com/tensorflow/decision-forests/pull/159#discussion_r1089073710) in a previous PR regarding checking that the last level in a PandasSampling (pd.MultiIndex) is a DatetimeIndex.