### PR TITLE
Select Operator

### DIFF
--- a/temporian/core/data/BUILD
+++ b/temporian/core/data/BUILD
@@ -1,4 +1,3 @@
-
 package(
     default_visibility = ["//visibility:public"],
     licenses = ["notice"],

--- a/temporian/core/data/event.py
+++ b/temporian/core/data/event.py
@@ -16,7 +16,6 @@
 
 from typing import Any, List, Optional
 
-import temporian
 from temporian.core.data.feature import Feature
 from temporian.core.data.sampling import Sampling
 
@@ -35,11 +34,13 @@ class Event(object):
         self._creator = creator
 
     def __getitem__(self, feature_names: List[str]) -> "Event":
+        # import select operator
+        from temporian.core.operators.select import SelectOperator
+
         # instance select operator. Import from base temporian package
         # to avoid circular import
-        select_operator = temporian.core.operators.select.SelectOperator(
-            self, feature_names
-        )
+        select_operator = SelectOperator(self, feature_names)
+
         # return Event
         return select_operator.outputs()["event"]
 

--- a/temporian/core/data/event.py
+++ b/temporian/core/data/event.py
@@ -41,7 +41,7 @@ class Event(object):
             self, feature_names
         )
         # return Event
-        return select_operator.outputs()["output_event"]
+        return select_operator.outputs()["event"]
 
     def __repr__(self) -> str:
         features_print = "\n\t\t".join(

--- a/temporian/core/data/event.py
+++ b/temporian/core/data/event.py
@@ -16,6 +16,7 @@
 
 from typing import Any, List, Optional
 
+import temporian
 from temporian.core.data.feature import Feature
 from temporian.core.data.sampling import Sampling
 
@@ -32,6 +33,15 @@ class Event(object):
         self._features = features
         self._sampling = sampling
         self._creator = creator
+
+    def __getitem__(self, feature_names: List[str]) -> "Event":
+        # instance select operator. Import from base temporian package
+        # to avoid circular import
+        select_operator = temporian.core.operators.select.SelectOperator(
+            self, feature_names
+        )
+        # return Event
+        return select_operator.outputs()["output_event"]
 
     def __repr__(self) -> str:
         features_print = "\n\t\t".join(

--- a/temporian/core/data/event.py
+++ b/temporian/core/data/event.py
@@ -33,8 +33,18 @@ class Event(object):
         self._sampling = sampling
         self._creator = creator
 
-    def __repr__(self):
-        return f"Event<features:{self._features},sampling:{self._sampling},id:{id(self)}>"
+    def __repr__(self) -> str:
+        features_print = "\n\t\t".join(
+            [str(feature) for feature in self._features]
+        )
+        return (
+            "Event: { \n"
+            "\tfeatures: {\n"
+            f"\t\t{features_print}\n"
+            "\t},\n"
+            f"\tsampling: {self._sampling},\n"
+            f"\tid:{id(self)}\n}}"
+        )
 
     def sampling(self):
         return self._sampling

--- a/temporian/core/operators/BUILD
+++ b/temporian/core/operators/BUILD
@@ -66,3 +66,16 @@ py_library(
         "//temporian/proto:core_py_proto",
     ],
 )
+
+py_library(
+    name = "select",
+    srcs = ["select.py"],
+    srcs_version = "PY3",
+    deps = [
+        ":base",
+        "//temporian/core:operator_lib",
+        "//temporian/core/data:event",
+        "//temporian/core/data:feature",
+        "//temporian/proto:core_py_proto",
+    ],
+)

--- a/temporian/core/operators/assign.py
+++ b/temporian/core/operators/assign.py
@@ -42,7 +42,7 @@ class AssignOperator(Operator):
         ]
         output_sampling = assignee_event.sampling()
         self.add_output(
-            "output",
+            "event",
             Event(
                 features=output_features, sampling=output_sampling, creator=self
             ),
@@ -57,7 +57,7 @@ class AssignOperator(Operator):
                 pb.OperatorDef.Input(key="assignee_event"),
                 pb.OperatorDef.Input(key="assigned_event"),
             ],
-            outputs=[pb.OperatorDef.Output(key="output")],
+            outputs=[pb.OperatorDef.Output(key="event")],
         )
 
 
@@ -68,4 +68,4 @@ def assign(
     assignee_event: Event,
     assigned_event: Event,
 ) -> Event:
-    return AssignOperator(assignee_event, assigned_event).outputs()["output"]
+    return AssignOperator(assignee_event, assigned_event).outputs()["event"]

--- a/temporian/core/operators/base.py
+++ b/temporian/core/operators/base.py
@@ -127,7 +127,6 @@ class Operator(ABC):
             if key in self._attributes:
                 raise ValueError(f'Already existing attribute "{key}".')
             self._attributes[key] = value
-        print(str(self))
 
     @classmethod
     def build_op_definition(cls) -> pb.OperatorDef:

--- a/temporian/core/operators/place_holder.py
+++ b/temporian/core/operators/place_holder.py
@@ -41,7 +41,7 @@ class PlaceHolder(base.Operator):
             feature.set_sampling(sampling)
 
         self.add_output(
-            "output",
+            "event",
             event_lib.Event(
                 features=features,
                 sampling=sampling,
@@ -56,7 +56,7 @@ class PlaceHolder(base.Operator):
         return pb.OperatorDef(
             key="PLACE_HOLDER",
             place_holder=True,
-            outputs=[pb.OperatorDef.Output(key="output")],
+            outputs=[pb.OperatorDef.Output(key="event")],
         )
 
 
@@ -66,4 +66,4 @@ operator_lib.register_operator(PlaceHolder)
 def place_holder(
     features: List[feature_lib.Feature], index: List[str]
 ) -> event_lib.Event:
-    return PlaceHolder(features=features, index=index).outputs()["output"]
+    return PlaceHolder(features=features, index=index).outputs()["event"]

--- a/temporian/core/operators/select.py
+++ b/temporian/core/operators/select.py
@@ -17,7 +17,6 @@ from typing import List, Union
 
 from temporian.core import operator_lib
 from temporian.core.data.event import Event
-from temporian.core.data.feature import Feature
 from temporian.core.operators.base import Operator
 from temporian.proto import core_pb2 as pb
 
@@ -30,29 +29,29 @@ class SelectOperator(Operator):
     ):
         super().__init__()
 
+        # store selected feature names
+        if isinstance(feature_names, str):
+            feature_names = [feature_names]
+        self.add_attribute("feature_names", feature_names)
+
         # inputs
         self.add_input("input_event", input_event)
 
         # outputs
         output_features = [
-            Feature(
-                name=feature.name(),
-                dtype=feature.dtype(),
-                sampling=feature.sampling(),
-                creator=self,
-            )
+            feature
             for feature in input_event.features()
             if feature.name() in feature_names
         ]
         output_sampling = input_event.sampling()
         self.add_output(
             "output_event",
-            Event(features=output_features, sampling=output_sampling),
+            Event(
+                features=output_features,
+                sampling=output_sampling,
+                creator=self,
+            ),
         )
-        # feature names
-        if isinstance(feature_names, str):
-            feature_names = [feature_names]
-        self.add_attribute("feature_names", feature_names)
 
         self.check()
 

--- a/temporian/core/operators/select.py
+++ b/temporian/core/operators/select.py
@@ -1,0 +1,84 @@
+# Copyright 2021 Google LLC.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Select operator."""
+from typing import List, Union
+
+from temporian.core import operator_lib
+from temporian.core.data.event import Event
+from temporian.core.data.feature import Feature
+from temporian.core.operators.base import Operator
+from temporian.proto import core_pb2 as pb
+
+
+class SelectOperator(Operator):
+    """Select operator."""
+
+    def __init__(
+        self, input_event: Event, feature_names: Union[str, List[str]]
+    ):
+        super().__init__()
+
+        # inputs
+        self.add_input("input_event", input_event)
+
+        # outputs
+        output_features = [
+            Feature(
+                name=feature.name(),
+                dtype=feature.dtype(),
+                sampling=feature.sampling(),
+                creator=self,
+            )
+            for feature in input_event.features()
+            if feature.name() in feature_names
+        ]
+        output_sampling = input_event.sampling()
+        self.add_output(
+            "output_event",
+            Event(features=output_features, sampling=output_sampling),
+        )
+        # feature names
+        if isinstance(feature_names, str):
+            feature_names = [feature_names]
+        self.add_attribute("feature_names", feature_names)
+
+        self.check()
+
+    @classmethod
+    def build_op_definition(cls) -> pb.OperatorDef:
+        return pb.OperatorDef(
+            key="SELECT",
+            attributes=[
+                pb.OperatorDef.Attribute(
+                    key="feature_names",
+                    type=pb.OperatorDef.Attribute.Type.REPEATED_STRING,
+                    is_optional=False,
+                ),
+            ],
+            inputs=[
+                pb.OperatorDef.Input(key="input_event"),
+            ],
+            outputs=[pb.OperatorDef.Output(key="output_event")],
+        )
+
+
+operator_lib.register_operator(SelectOperator)
+
+
+def select(
+    input_event: Event,
+    feature_names: List[str],
+) -> Event:
+    return SelectOperator(input_event, feature_names).outputs()["output_event"]

--- a/temporian/core/operators/select.py
+++ b/temporian/core/operators/select.py
@@ -24,9 +24,7 @@ from temporian.proto import core_pb2 as pb
 class SelectOperator(Operator):
     """Select operator."""
 
-    def __init__(
-        self, input_event: Event, feature_names: Union[str, List[str]]
-    ):
+    def __init__(self, event: Event, feature_names: Union[str, List[str]]):
         super().__init__()
 
         # store selected feature names
@@ -35,19 +33,19 @@ class SelectOperator(Operator):
         self.add_attribute("feature_names", feature_names)
 
         # inputs
-        self.add_input("input_event", input_event)
+        self.add_input("event", event)
 
         # outputs
         output_features = []
         for feature_name in feature_names:
-            for feature in input_event.features():
+            for feature in event.features():
                 # TODO: maybe implement features attributes of Event as dict
                 # so we can index by name?
                 if feature.name() == feature_name:
                     output_features.append(feature)
-        output_sampling = input_event.sampling()
+        output_sampling = event.sampling()
         self.add_output(
-            "output_event",
+            "event",
             Event(
                 features=output_features,
                 sampling=output_sampling,
@@ -69,9 +67,9 @@ class SelectOperator(Operator):
                 ),
             ],
             inputs=[
-                pb.OperatorDef.Input(key="input_event"),
+                pb.OperatorDef.Input(key="event"),
             ],
-            outputs=[pb.OperatorDef.Output(key="output_event")],
+            outputs=[pb.OperatorDef.Output(key="event")],
         )
 
 
@@ -79,7 +77,7 @@ operator_lib.register_operator(SelectOperator)
 
 
 def select(
-    input_event: Event,
+    event: Event,
     feature_names: List[str],
 ) -> Event:
-    return SelectOperator(input_event, feature_names).outputs()["output_event"]
+    return SelectOperator(event, feature_names).outputs()["event"]

--- a/temporian/core/operators/select.py
+++ b/temporian/core/operators/select.py
@@ -38,11 +38,13 @@ class SelectOperator(Operator):
         self.add_input("input_event", input_event)
 
         # outputs
-        output_features = [
-            feature
-            for feature in input_event.features()
-            if feature.name() in feature_names
-        ]
+        output_features = []
+        for feature_name in feature_names:
+            for feature in input_event.features():
+                # TODO: maybe implement features attributes of Event as dict
+                # so we can index by name?
+                if feature.name() == feature_name:
+                    output_features.append(feature)
         output_sampling = input_event.sampling()
         self.add_output(
             "output_event",

--- a/temporian/core/operators/simple_moving_average.py
+++ b/temporian/core/operators/simple_moving_average.py
@@ -28,7 +28,7 @@ class SimpleMovingAverage(Operator):
 
     def __init__(
         self,
-        data: Event,
+        event: Event,
         window_length: str,
         sampling: Optional[Event] = None,
     ):
@@ -39,9 +39,9 @@ class SimpleMovingAverage(Operator):
         if sampling is not None:
             self.add_input("sampling", sampling)
         else:
-            sampling = data.sampling()
+            sampling = event.sampling()
 
-        self.add_input("data", data)
+        self.add_input("event", event)
 
         output_features = [  # pylint: disable=g-complex-comprehension
             Feature(
@@ -50,11 +50,11 @@ class SimpleMovingAverage(Operator):
                 sampling=sampling,
                 creator=self,
             )
-            for f in data.features()
+            for f in event.features()
         ]
 
         self.add_output(
-            "output",
+            "event",
             Event(
                 features=output_features,
                 sampling=sampling,
@@ -76,10 +76,10 @@ class SimpleMovingAverage(Operator):
                 ),
             ],
             inputs=[
-                pb.OperatorDef.Input(key="data"),
+                pb.OperatorDef.Input(key="event"),
                 pb.OperatorDef.Input(key="sampling", is_optional=True),
             ],
-            outputs=[pb.OperatorDef.Output(key="output")],
+            outputs=[pb.OperatorDef.Output(key="event")],
         )
 
 
@@ -87,12 +87,12 @@ operator_lib.register_operator(SimpleMovingAverage)
 
 
 def sma(
-    data: Event,
+    event: Event,
     window_length: str,
     sampling: Optional[Event] = None,
 ) -> Event:
     return SimpleMovingAverage(
-        data=data,
+        event=event,
         window_length=window_length,
         sampling=sampling,
-    ).outputs()["output"]
+    ).outputs()["event"]

--- a/temporian/implementation/pandas/operators/BUILD
+++ b/temporian/implementation/pandas/operators/BUILD
@@ -38,6 +38,17 @@ py_library(
     srcs_version = "PY3",
     deps = [
         ":assign",
+        ":select",
         "//temporian/implementation/pandas/operators/window:simple_moving_average",
+    ],
+)
+
+py_library(
+    name = "select",
+    srcs = ["select.py"],
+    srcs_version = "PY3",
+    deps = [
+        ":base",
+        "//temporian/implementation/pandas/data:event",
     ],
 )

--- a/temporian/implementation/pandas/operators/assign.py
+++ b/temporian/implementation/pandas/operators/assign.py
@@ -64,7 +64,8 @@ class PandasAssignOperator(PandasOperator):
             raise ValueError(
                 "Cannot have repeated timestamps in assigned EventSequence."
             )
-
+        output_event = assignee_event.join(
+            assigned_event, how="left", rsuffix="y"
+        )
         # make assignment
-        output = assignee_event.join(assigned_event, how="left", rsuffix="y")
-        return {"output": output}
+        return {"event": output_event}

--- a/temporian/implementation/pandas/operators/assign.py
+++ b/temporian/implementation/pandas/operators/assign.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 """Implementation for the Assign operator."""
+from typing import Dict
 
 from temporian.implementation.pandas.data.event import PandasEvent
 from temporian.implementation.pandas.operators.base import PandasOperator
@@ -22,7 +23,7 @@ from temporian.implementation.pandas import utils
 class PandasAssignOperator(PandasOperator):
     def __call__(
         self, assignee_event: PandasEvent, assigned_event: PandasEvent
-    ) -> PandasEvent:
+    ) -> Dict[str, PandasEvent]:
         """Assign features to an event.
 
         Input event and features must have same index. Features cannot have more

--- a/temporian/implementation/pandas/operators/core_mapping.py
+++ b/temporian/implementation/pandas/operators/core_mapping.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 from temporian.implementation.pandas.operators import assign
+from temporian.implementation.pandas.operators import select
 from temporian.implementation.pandas.operators.window import (
     simple_moving_average,
 )
@@ -20,4 +21,5 @@ from temporian.implementation.pandas.operators.window import (
 OPERATOR_IMPLEMENTATIONS = {
     "ASSIGN": assign.PandasAssignOperator,
     "SIMPLE_MOVING_AVERAGE": simple_moving_average.PandasSimpleMovingAverageOperator,
+    "SELECT": select.PandasSelectOperator,
 }

--- a/temporian/implementation/pandas/operators/select.py
+++ b/temporian/implementation/pandas/operators/select.py
@@ -25,14 +25,14 @@ class PandasSelectOperator(PandasOperator):
     def __init__(self, feature_names: List[str]) -> None:
         self.feature_names = feature_names
 
-    def __call__(self, input_event: PandasEvent) -> Dict[str, PandasEvent]:
+    def __call__(self, event: PandasEvent) -> Dict[str, PandasEvent]:
         # get index
-        event_index = input_event.index
+        event_index = event.index
 
         # create output event
         output_event = PandasEvent(
-            data={col: input_event[col] for col in self.feature_names},
+            data={col: event[col] for col in self.feature_names},
             copy=False,
             index=event_index,
         )
-        return {"output_event": output_event}
+        return {"event": output_event}

--- a/temporian/implementation/pandas/operators/select.py
+++ b/temporian/implementation/pandas/operators/select.py
@@ -29,24 +29,10 @@ class PandasSelectOperator(PandasOperator):
         # get index
         event_index = input_event.index
 
-        # get column positions
-        column_positions = {
-            col: pos for pos, col in enumerate(input_event.columns)
-        }
-        # get numpy array from DataFrame. This creates a view (doesn't
-        # duplicate memory)
-        input_event_arr = input_event.to_numpy()
-
-        # select columns from array. Once again this creates a view of the
-        # array
-        input_event_arr_select = input_event_arr[
-            :, [column_positions[column] for column in self.feature_names]
-        ]
-        # create PandasEvent from selected array. This creates a view of the
-        # input array
+        # create output event
         output_event = PandasEvent(
-            input_event_arr_select,
-            columns=self.feature_names,
+            data={col: input_event[col] for col in self.feature_names},
+            copy=False,
             index=event_index,
         )
         return {"output_event": output_event}

--- a/temporian/implementation/pandas/operators/select.py
+++ b/temporian/implementation/pandas/operators/select.py
@@ -1,0 +1,52 @@
+# Copyright 2021 Google LLC.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Implementation for the Select operator."""
+from typing import Dict, List
+
+from temporian.implementation.pandas.data.event import PandasEvent
+from temporian.implementation.pandas.operators.base import PandasOperator
+
+
+class PandasSelectOperator(PandasOperator):
+    """Select a subset of features from an event."""
+
+    def __init__(self, feature_names: List[str]) -> None:
+        self.feature_names = feature_names
+
+    def __call__(self, input_event: PandasEvent) -> Dict[str, PandasEvent]:
+        # get index
+        event_index = input_event.index
+
+        # get column positions
+        column_positions = {
+            col: pos for pos, col in enumerate(input_event.columns)
+        }
+        # get numpy array from DataFrame. This creates a view (doesn't
+        # duplicate memory)
+        input_event_arr = input_event.to_numpy()
+
+        # select columns from array. Once again this creates a view of the
+        # array
+        input_event_arr_select = input_event_arr[
+            :, [column_positions[column] for column in self.feature_names]
+        ]
+        # create PandasEvent from selected array. This creates a view of the
+        # input array
+        output_event = PandasEvent(
+            input_event_arr_select,
+            columns=self.feature_names,
+            index=event_index,
+        )
+        return {"output_event": output_event}

--- a/temporian/implementation/pandas/operators/tests/assign/assign_test.py
+++ b/temporian/implementation/pandas/operators/tests/assign/assign_test.py
@@ -57,7 +57,7 @@ class AssignOperatorTest(absltest.TestCase):
         )
         self.assertEqual(
             True,
-            with_idx_same_timestamps.OUTPUT.equals(operator_output["output"]),
+            with_idx_same_timestamps.OUTPUT.equals(operator_output["event"]),
         )
 
     def test_with_idx_more_timestamps(self) -> None:
@@ -66,7 +66,7 @@ class AssignOperatorTest(absltest.TestCase):
         )
         self.assertEqual(
             True,
-            with_idx_more_timestamps.OUTPUT.equals(operator_output["output"]),
+            with_idx_more_timestamps.OUTPUT.equals(operator_output["event"]),
         )
 
 

--- a/temporian/implementation/pandas/operators/window/tests/simple_moving_average/test.py
+++ b/temporian/implementation/pandas/operators/window/tests/simple_moving_average/test.py
@@ -42,8 +42,8 @@ class SimpleMovingAverageOperatorTest(absltest.TestCase):
             window_length="7d"
         )
         output = operator(no_index.INPUT, no_index.SAMPLING)
-        pd.testing.assert_frame_equal(no_index.OUTPUT, output["output"])
-        self.assertTrue(no_index.OUTPUT.equals(output["output"]))
+        pd.testing.assert_frame_equal(no_index.OUTPUT, output["event"])
+        self.assertTrue(no_index.OUTPUT.equals(output["event"]))
 
     def test_same_sampling(self) -> None:
         """Test same sampling for all index values."""
@@ -51,8 +51,8 @@ class SimpleMovingAverageOperatorTest(absltest.TestCase):
             window_length="7d"
         )
         output = operator(same_sampling.INPUT, same_sampling.SAMPLING)
-        pd.testing.assert_frame_equal(same_sampling.OUTPUT, output["output"])
-        self.assertTrue(same_sampling.OUTPUT.equals(output["output"]))
+        pd.testing.assert_frame_equal(same_sampling.OUTPUT, output["event"])
+        self.assertTrue(same_sampling.OUTPUT.equals(output["event"]))
 
     def test_diff_sampling(self) -> None:
         """Test different sampling for each index value."""
@@ -60,8 +60,8 @@ class SimpleMovingAverageOperatorTest(absltest.TestCase):
             window_length="7d"
         )
         output = operator(diff_sampling.INPUT, diff_sampling.SAMPLING)
-        pd.testing.assert_frame_equal(diff_sampling.OUTPUT, output["output"])
-        self.assertTrue(diff_sampling.OUTPUT.equals(output["output"]))
+        pd.testing.assert_frame_equal(diff_sampling.OUTPUT, output["event"])
+        self.assertTrue(diff_sampling.OUTPUT.equals(output["event"]))
 
     def disabled_test_many_events_per_day(self) -> None:
         """Test several events occuring per day."""
@@ -72,9 +72,9 @@ class SimpleMovingAverageOperatorTest(absltest.TestCase):
             many_events_per_day.INPUT, many_events_per_day.SAMPLING
         )
         pd.testing.assert_frame_equal(
-            many_events_per_day.OUTPUT, output["output"]
+            many_events_per_day.OUTPUT, output["event"]
         )
-        self.assertTrue(many_events_per_day.OUTPUT.equals(output["output"]))
+        self.assertTrue(many_events_per_day.OUTPUT.equals(output["event"]))
 
     def disabled_test_many_features(self) -> None:
         """Test several events occuring per day."""
@@ -82,8 +82,8 @@ class SimpleMovingAverageOperatorTest(absltest.TestCase):
             window_length="7d"
         )
         output = operator(many_features.INPUT, many_features.SAMPLING)
-        pd.testing.assert_frame_equal(many_features.OUTPUT, output["output"])
-        self.assertTrue(many_features.OUTPUT.equals(output["output"]))
+        pd.testing.assert_frame_equal(many_features.OUTPUT, output["event"])
+        self.assertTrue(many_features.OUTPUT.equals(output["event"]))
 
 
 if __name__ == "__main__":

--- a/temporian/proto/core.proto
+++ b/temporian/proto/core.proto
@@ -170,6 +170,7 @@ message OperatorDef {
       UNDEFINED = 0;
       INTEGER_64 = 1;
       STRING = 2;
+      REPEATED_STRING=3;
     }
   }
 }

--- a/temporian/test/BUILD
+++ b/temporian/test/BUILD
@@ -30,6 +30,7 @@ py_test(
         "//temporian/core/data:event",
         "//temporian/core/data:sampling",
         "//temporian/core/operators:assign",
+        "//temporian/core/operators:select",
         "//temporian/core/operators:simple_moving_average",
         "//temporian/implementation/pandas/data:event",
     ],

--- a/temporian/test/api_test.py
+++ b/temporian/test/api_test.py
@@ -32,7 +32,7 @@ class TFPTest(absltest.TestCase):
             index=[],
         )
 
-        b = t.sma(data=a, window_length=7)
+        b = t.sma(event=a, window_length=7)
 
         input_signal_data = PandasEvent(
             {
@@ -58,7 +58,7 @@ class TFPTest(absltest.TestCase):
             ],
             index=[],
         )
-        b = t.sma(data=a, window_length=7)
+        b = t.sma(event=a, window_length=7)
 
         with tempfile.TemporaryDirectory() as tempdir:
             path = os.path.join(tempdir, "my_processor.tem")

--- a/temporian/test/prototype_test.py
+++ b/temporian/test/prototype_test.py
@@ -21,6 +21,7 @@ from temporian.core.data.event import Event
 from temporian.core.data.event import Feature
 from temporian.core.data.sampling import Sampling
 from temporian.core.operators.assign import assign
+from temporian.core.operators.select import select
 from temporian.core.operators.simple_moving_average import sma
 from temporian.implementation.pandas.data import event as pandas_event
 
@@ -97,8 +98,8 @@ class PrototypeTest(absltest.TestCase):
         assign_assign_event = assign(assign_output_1, assign_output_2)
 
         # call sma operator
-        sma_assigned_selected_event = sma(
-            assign_output_event["costs"],  # in-place select using []
+        sma_assigned_event = sma(
+            assign_assign_event["costs"],  # in-place select using []
             window_length="7d",
             sampling=assigned_event,
         )

--- a/temporian/test/prototype_test.py
+++ b/temporian/test/prototype_test.py
@@ -97,8 +97,10 @@ class PrototypeTest(absltest.TestCase):
         assign_assign_event = assign(assign_output_1, assign_output_2)
 
         # call sma operator
-        sma_assigned_event = sma(
-            assigned_event, window_length="7d", sampling=assigned_event
+        sma_assigned_selected_event = sma(
+            assign_output_event["costs"],  # in-place select using []
+            window_length="7d",
+            sampling=assigned_event,
         )
 
         # call assign operator with result of sma


### PR DESCRIPTION
This PR implements the Select Operator. 

The operator can be called:

- using ```temporian.core.operators.select.select``` (as with any other operator)
- using the `__getitem__` method in the core `Event` class, i.e. ```selected_event = event[["f_1", "f_2"]]```

The implementation is hacky, but it's the only way I found to be able to create a view of multiple columns of a `pandas` `DataFrame`. Using `df[["f_1", "f_2"]]` always returns a copy, which we don't want. The current implementation does not duplicate any data.

I've also updated the `prototype_test.py` script to include an instance of the select operator. 

Other unrelated, small changes:
- fixed `PandasAssignOperator` return type
- removed unnecessary print in core `Operator` class
- updated core `Event` __repr__ method to be more readable

All tests pass.