### PR TITLE
add bazel tests to github action

### DIFF
--- a/.github/workflows/formatting.yaml
+++ b/.github/workflows/formatting.yaml
@@ -3,7 +3,7 @@ name: formatting
 on: push
 
 jobs:
-  test:
+  formatting:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/.github/workflows/formatting.yaml
+++ b/.github/workflows/formatting.yaml
@@ -1,4 +1,4 @@
-name: Check formatting
+name: formatting
 
 on: push
 

--- a/.github/workflows/formatting.yaml
+++ b/.github/workflows/formatting.yaml
@@ -1,0 +1,25 @@
+name: Check formatting
+
+on: push
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Install poetry
+        run: pipx install poetry
+
+      - name: Setup Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.9'
+          cache: 'poetry'
+
+      - name: Install dependencies
+        run: poetry install --no-interaction
+
+      - name: Check format with black
+        run: poetry run black --check .

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -16,16 +16,14 @@ jobs:
           path: ~/.cache/bazel
           key: ${{ runner.os }}-bazel-cache
 
+      - name: Install poetry
+        run: pipx install poetry
+
       - name: Setup Python
         uses: actions/setup-python@v4
         with:
           python-version: '3.9'
           cache: 'poetry'
-
-      - name: Install Poetry
-        uses: snok/install-poetry@v1
-        with:
-          virtualenvs-create: false
 
       - name: Install dependencies
         run: poetry install --no-interaction

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,4 +1,4 @@
-name: Run bazel tests
+name: tests
 
 on: push
 

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,0 +1,20 @@
+name: Run bazel tests
+
+on: push
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Bazel cache
+        id: bazel-cache
+        uses: actions/cache@v3
+        with:
+          path: ~/.cache/bazel
+          key: ${{ runner.os }}-{{ env.version }}-bazel-cache
+
+      - name: Run tests
+        run: bazel test //...:all

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -14,7 +14,7 @@ jobs:
         uses: actions/cache@v3
         with:
           path: ~/.cache/bazel
-          key: ${{ runner.os }}-{{ env.version }}-bazel-cache
+          key: ${{ runner.os }}-bazel-cache
 
       - name: Run tests
-        run: bazel test //...:all
+        run: bazel test //...:all --test_output=errors

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -29,4 +29,4 @@ jobs:
         run: poetry install --no-interaction
 
       - name: Run tests
-        run: bazel test //...:all --test_output=errors
+        run: poetry run bazel test //...:all --test_output=errors

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -16,5 +16,19 @@ jobs:
           path: ~/.cache/bazel
           key: ${{ runner.os }}-bazel-cache
 
+      - name: Setup Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.9'
+          cache: 'poetry'
+
+      - name: Install Poetry
+        uses: snok/install-poetry@v1
+        with:
+          virtualenvs-create: false
+
+      - name: Install dependencies
+        run: poetry install --no-interaction
+
       - name: Run tests
         run: bazel test //...:all --test_output=errors

--- a/README.md
+++ b/README.md
@@ -4,6 +4,9 @@
 signals before their use as input features with of-the-shelf tabular machine
 learning libraries (e.g., TensorFlow Decision Forests).
 
+![tests](https://github.com/google/temporian/actions/workflows/test.yml/badge.svg)
+![formatting](https://github.com/google/temporian/actions/workflows/formatting.yml/badge.svg)
+
 ## Requirements
 
 Dependencies are managed through [Poetry](https://python-poetry.org/). To

--- a/README.md
+++ b/README.md
@@ -4,8 +4,8 @@
 signals before their use as input features with of-the-shelf tabular machine
 learning libraries (e.g., TensorFlow Decision Forests).
 
-![tests](https://github.com/google/temporian/actions/workflows/test.yml/badge.svg)
-![formatting](https://github.com/google/temporian/actions/workflows/formatting.yml/badge.svg)
+![tests](https://github.com/google/temporian/actions/workflows/test.yaml/badge.svg)
+![formatting](https://github.com/google/temporian/actions/workflows/formatting.yaml/badge.svg)
 
 ## Requirements
 

--- a/temporian/core/data/event.py
+++ b/temporian/core/data/event.py
@@ -64,7 +64,6 @@ class Event(object):
 
 
 def input_event(features: List[Feature], index: List[str] = []) -> Event:
-
     sampling = Sampling(index=index, creator=None)
 
     for feature in features:

--- a/temporian/core/processor.py
+++ b/temporian/core/processor.py
@@ -16,8 +16,6 @@
 
 from typing import List, Set, Dict, Union, Optional
 
-from collections import defaultdict
-
 from temporian.core.data.event import Event
 from temporian.core.data.feature import Feature
 from temporian.core.data.sampling import Sampling
@@ -214,7 +212,6 @@ def infer_processor(
 
         # Add the parent events to the pending list.
         for input_event in event.creator().inputs().values():
-
             if input_event in done_events:
                 # Already processed.
                 continue

--- a/temporian/implementation/numpy/data/sampling.py
+++ b/temporian/implementation/numpy/data/sampling.py
@@ -9,7 +9,6 @@ class NumpySampling:
         self.data = data
 
     def __eq__(self, other):
-
         if not isinstance(other, NumpySampling):
             return False
 
@@ -19,7 +18,7 @@ class NumpySampling:
         if self.data.keys() != other.data.keys():
             return False
 
-         # Check if both sampling have same timestamps per index
+        # Check if both sampling have same timestamps per index
         for index in self.data:
             if not np.array_equal(self.data[index], other.data[index]):
                 return False

--- a/temporian/test/api_test.py
+++ b/temporian/test/api_test.py
@@ -132,11 +132,7 @@ class TFPTest(absltest.TestCase):
 
         with tempfile.TemporaryDirectory() as tempdir:
             path = os.path.join(tempdir, "my_processor.tem")
-            t.save(
-                inputs=None,
-                outputs=b,
-                path=path
-            )
+            t.save(inputs=None, outputs=b, path=path)
 
             i, o = t.load(path=path, squeeze=True)
 


### PR DESCRIPTION
Added GitHub actions to check that tests pass and code is formatted correctly.
Added badges of both actions to readme.

⚠️ Using python 3.9 in both actions. We may want to downgrade it if we aim to support older versions.

# Tests action

Runs bazel tests.
Used --test_output=errors for easy debugging of errors that occur in action.
Bazelisk comes preinstalled in linux runners so no need to install it.
Used `actions/cache` to store bazel cache for reduced action runtime.
Poetry is installed and environment is also cached thanks to the `cache: 'poetry'` arg of `setup-python` action.

# Formatting action

Very similar to tests one, but drops the bazel caching step, and runs `black --check` instead of `bazel test`.