### PR TITLE
Handle Categoricals in `NumpyEvent.from_dataframe()`

### DIFF
--- a/temporian/implementation/numpy/data/event.py
+++ b/temporian/implementation/numpy/data/event.py
@@ -160,6 +160,11 @@ class NumpyEvent:
 
         # check column dtypes, every dtype should be a key of DTYPE_MAPPING
         for column in df.columns:
+            # check if its a categorical column
+            if df[column].dtype.name == "category":
+                # TODO: we force int32 because we don't support int8 nor int16 yet
+                df[column] = df[column].cat.codes.astype(np.int32)
+
             if df[column].dtype.type not in DTYPE_MAPPING:
                 raise ValueError(
                     f"Unsupported dtype {df[column].dtype} for column"


### PR DESCRIPTION
- [x] Support Categoricals as inputs for dataframe. 

Currently, we convert all categoricals to a np.int32 representing the category code. We should support int8 and int16 for a lighter conversion.