### PR TITLE
Improve `to_dataframe` efficiency 

### DIFF
--- a/temporian/implementation/numpy/data/event.py
+++ b/temporian/implementation/numpy/data/event.py
@@ -241,16 +241,11 @@ class NumpyEvent:
 
         for index, features in self.data.items():
             timestamps = self.sampling.data[index]
-
-            for i, timestamp in enumerate(timestamps):
-                # add row to dictionary
-                row = (
-                    list(index)
-                    + [feature.data[i] for feature in features]
-                    + [timestamp]
-                )
-                for i, column_name in enumerate(columns):
-                    data[column_name].append(row[i])
+            data["timestamp"].extend(timestamps)
+            for feature in features:
+                data[feature.name].extend(feature.data)
+            for index_key in self.sampling.index:
+                data[index_key].extend(index * len(timestamps))
 
         # Converting dictionary to pandas DataFrame
         df = pd.DataFrame(data)


### PR DESCRIPTION
The functionality to convert from a NumpyEvent to a DataFrame was working too slow.
On the MINI config of the colab, the time for conversion was around 1 minute. Improved it to 224ms. It probably can be further improved considering converting from DataFrame to NumpyEvent takes 22ms.