### PR TITLE
Support String in `NumpyEvent.from_dataframe()`

### DIFF
--- a/temporian/implementation/numpy/data/event.py
+++ b/temporian/implementation/numpy/data/event.py
@@ -175,7 +175,13 @@ class NumpyEvent:
         for column in df.columns:
             # if dtype is object, convert to string
             if df[column].dtype.type is np.object_:
-                df[column] = df[column].astype(np.string_)
+                try:
+                    df[column] = df[column].astype(np.string_)
+                except ValueError as exc:
+                    raise ValueError(
+                        f"Column {column} has dtype object, but cannot be"
+                        " converted to string."
+                    ) from exc
 
             elif df[column].dtype.type not in DTYPE_MAPPING:
                 raise ValueError(

--- a/temporian/implementation/numpy/data/event.py
+++ b/temporian/implementation/numpy/data/event.py
@@ -46,10 +46,10 @@ class NumpyFeature:
         if self.name != __o.name:
             return False
 
-        if not np.array_equal(self.data, __o.data, equal_nan=True):
-            return False
+        if self.dtype is np.string_:
+            return np.array_equal(self.data, __o.data)
 
-        return True
+        return np.array_equal(self.data, __o.data, equal_nan=True)
 
     def core_dtype(self) -> Any:
         if self.dtype.type is np.string_:
@@ -173,7 +173,11 @@ class NumpyEvent:
 
         # check column dtypes, every dtype should be a key of DTYPE_MAPPING
         for column in df.columns:
-            if df[column].dtype.type not in DTYPE_MAPPING:
+            # if dtype is object, convert to string
+            if df[column].dtype.type is np.object_:
+                df[column] = df[column].astype(np.string_)
+
+            elif df[column].dtype.type not in DTYPE_MAPPING:
                 raise ValueError(
                     f"Unsupported dtype {df[column].dtype} for column"
                     f" {column}. Supported dtypes: {DTYPE_MAPPING.keys()}"

--- a/temporian/implementation/numpy/data/tests/test_df_to_event.py
+++ b/temporian/implementation/numpy/data/tests/test_df_to_event.py
@@ -61,20 +61,44 @@ class DataFrameToEventTest(absltest.TestCase):
     def test_string_column(self) -> None:
         df = pd.DataFrame(
             [
-                [666964, 1.0, "740.0"],
-                [666964, 2.0, "508.0"],
-                [574016, 3.0, "573.0"],
+                [666964, 1.0, "740"],
+                [666964, 2.0, np.nan],
+                [574016, 3.0, ""],
             ],
             columns=["product_id", "timestamp", "costs"],
         )
 
-        self.assertRaisesRegex(
-            ValueError,
-            "Unsupported dtype",
-            NumpyEvent.from_dataframe,
-            df,
-            ["product_id"],
+        numpy_sampling = NumpySampling(
+            data={
+                (666964,): np.array([1.0, 2.0]),
+                (574016,): np.array([3.0]),
+            },
+            index=["product_id"],
         )
+
+        expected_numpy_event = NumpyEvent(
+            data={
+                (666964,): [
+                    NumpyFeature(
+                        data=np.array(["740", np.nan]).astype(np.string_),
+                        name="costs",
+                    )
+                ],
+                (574016,): [
+                    NumpyFeature(
+                        data=np.array([""]).astype(np.string_), name="costs"
+                    )
+                ],
+            },
+            sampling=numpy_sampling,
+        )
+
+        numpy_event = NumpyEvent.from_dataframe(
+            df, index_names=["product_id"], timestamp_column="timestamp"
+        )
+
+        # validate
+        self.assertTrue(numpy_event == expected_numpy_event)
 
     def test_missing_values(self) -> None:
         df = pd.DataFrame(


### PR DESCRIPTION
Convert np.objects in DataFrame to np.strings

- [x] Raise exception when non string object is passed