### PR TITLE
Unix timestamp samplings

### DIFF
--- a/temporian/core/data/duration.py
+++ b/temporian/core/data/duration.py
@@ -53,9 +53,13 @@ def weeks(value: float) -> Duration:
 
 
 def convert_date_to_duration(
-    date: Union[np.datetime64, datetime.datetime]
+    date: Union[np.datetime64, datetime.datetime, int, float]
 ) -> Duration:
-    """Convert date to Unix timestamp.
+    """Convert date value to float.
+
+    If a float or int, it is returned as float.
+    If a date, it is converted to a Unix timestamp (number of seconds from Unix
+    epoch).
 
     Args:
         date: the date to convert.
@@ -68,11 +72,13 @@ def convert_date_to_duration(
             - np.datetime64
             - datetime.datetime
     """
-    # if it is already a duration, return it
+    # if it is already a number, return it as float
     if isinstance(date, float):
         return date
     if isinstance(date, int):
         return float(date)
+
+    # if it is a date, convert it to unix timestamp
     if isinstance(date, np.datetime64):
         return convert_numpy_datetime64_to_duration(date)
     if isinstance(date, datetime.datetime):

--- a/temporian/core/data/duration.py
+++ b/temporian/core/data/duration.py
@@ -55,19 +55,18 @@ def weeks(value: float) -> Duration:
 def convert_date_to_duration(
     date: Union[np.datetime64, datetime.datetime]
 ) -> Duration:
-    """Convert date to duration epoch UTC
+    """Convert date to Unix timestamp.
 
     Args:
-        date (Union[np.datetime64, datetime.datetime]):
-            Date to convert
+        date: the date to convert.
 
     Returns:
-        int: Duration epoch UTC
+        int: unix timestamp (seconds elapsed from unix epoch).
 
     Raises:
-        TypeError: Unsupported type. Supported types are:
-        - np.datetime64
-        - datetime.datetime
+        TypeError: unsupported type. Supported types are:
+            - np.datetime64
+            - datetime.datetime
     """
     # if it is already a duration, return it
     if isinstance(date, float):

--- a/temporian/core/data/sampling.py
+++ b/temporian/core/data/sampling.py
@@ -22,9 +22,11 @@ class Sampling(object):
         self,
         index: List[str],
         creator: Optional[Any] = None,
+        is_unix_timestamp: bool = False,
     ):
         self._index: List[str] = index
         self._creator = creator
+        self._is_unix_timestamp = is_unix_timestamp
 
     def __repr__(self):
         return f"Sampling<index:{self._index},id:{id(self)}>"
@@ -37,3 +39,6 @@ class Sampling(object):
 
     def set_creator(self, creator):
         self._creator = creator
+
+    def is_unix_timestamp(self) -> bool:
+        return self._is_unix_timestamp

--- a/temporian/core/operators/calendar/base.py
+++ b/temporian/core/operators/calendar/base.py
@@ -31,6 +31,13 @@ class BaseCalendarOperator(Operator, ABC):
     def __init__(self, sampling: Event):
         super().__init__()
 
+        if not sampling.sampling().is_unix_timestamp():
+            raise ValueError(
+                "Calendar operators can only be applied on events with unix"
+                " timestamps as sampling. This can be specified with"
+                " is_unix_timestamp=True when manually creating a sampling."
+            )
+
         # input
         self.add_input("sampling", sampling)
 

--- a/temporian/implementation/numpy/data/event.py
+++ b/temporian/implementation/numpy/data/event.py
@@ -162,7 +162,12 @@ class NumpyEvent:
                 f"Timestamp column {timestamp_column} cannot be on index_names"
             )
 
-        # convert timestamp column to UTC Epoch float
+        # check if created sampling's values will be unix timestamps
+        is_unix_timestamp = pd.api.types.is_datetime64_any_dtype(
+            df[timestamp_column]
+        )
+
+        # convert timestamp column to float
         df[timestamp_column] = df[timestamp_column].apply(
             convert_date_to_duration
         )
@@ -215,7 +220,9 @@ class NumpyEvent:
             ]
 
         numpy_sampling = NumpySampling(
-            index=index_names, data=sampling, is_unix_timestamp=True
+            index=index_names,
+            data=sampling,
+            is_unix_timestamp=is_unix_timestamp,
         )
 
         return NumpyEvent(data=data, sampling=numpy_sampling)

--- a/temporian/implementation/numpy/data/event.py
+++ b/temporian/implementation/numpy/data/event.py
@@ -8,6 +8,7 @@ from temporian.core.data.event import Event
 from temporian.core.data.event import Feature
 from temporian.core.data.sampling import Sampling
 from temporian.core.data.duration import convert_date_to_duration
+from temporian.core.data.sampling import Sampling
 from temporian.implementation.numpy.data.sampling import NumpySampling
 
 DTYPE_MAPPING = {
@@ -98,7 +99,10 @@ class NumpyEvent:
             features=[
                 feature.schema() for feature in list(self.data.values())[0]
             ],
-            sampling=Sampling(self.sampling.index),
+            sampling=Sampling(
+                index=self.sampling.index,
+                is_unix_timestamp=self.sampling.is_unix_timestamp,
+            ),
         )
 
     @staticmethod
@@ -210,7 +214,9 @@ class NumpyEvent:
                 for feature in feature_columns
             ]
 
-        numpy_sampling = NumpySampling(index=index_names, data=sampling)
+        numpy_sampling = NumpySampling(
+            index=index_names, data=sampling, is_unix_timestamp=True
+        )
 
         return NumpyEvent(data=data, sampling=numpy_sampling)
 

--- a/temporian/implementation/numpy/data/sampling.py
+++ b/temporian/implementation/numpy/data/sampling.py
@@ -4,9 +4,15 @@ import numpy as np
 
 
 class NumpySampling:
-    def __init__(self, index: List[str], data: Dict[Tuple, np.ndarray]) -> None:
+    def __init__(
+        self,
+        index: List[str],
+        data: Dict[Tuple, np.ndarray],
+        is_unix_timestamp: bool = False,
+    ) -> None:
         self.index = index
         self.data = data
+        self.is_unix_timestamp = is_unix_timestamp
 
     @property
     def has_repeated_timestamps(self) -> bool:

--- a/temporian/implementation/numpy/data/tests/test_df_to_event.py
+++ b/temporian/implementation/numpy/data/tests/test_df_to_event.py
@@ -110,6 +110,7 @@ class DataFrameToEventTest(absltest.TestCase):
 
         # validate
         self.assertTrue(numpy_event == expected_numpy_event)
+        self.assertFalse(numpy_event.sampling.is_unix_timestamp)
 
     def test_npdatetime64_index(self) -> None:
         df = pd.DataFrame(
@@ -146,6 +147,7 @@ class DataFrameToEventTest(absltest.TestCase):
 
         # validate
         self.assertTrue(numpy_event == expected_numpy_event)
+        self.assertTrue(numpy_event.sampling.is_unix_timestamp)
 
     def test_pdTimestamp_index(self) -> None:
         df = pd.DataFrame(
@@ -182,6 +184,7 @@ class DataFrameToEventTest(absltest.TestCase):
 
         # validate
         self.assertTrue(numpy_event == expected_numpy_event)
+        self.assertTrue(numpy_event.sampling.is_unix_timestamp)
 
     def test_datetime_index(self) -> None:
         df = pd.DataFrame(
@@ -230,6 +233,7 @@ class DataFrameToEventTest(absltest.TestCase):
 
         # validate
         self.assertTrue(numpy_event == expected_numpy_event)
+        self.assertTrue(numpy_event.sampling.is_unix_timestamp)
 
     def test_no_index(self) -> None:
         df = pd.DataFrame(

--- a/temporian/implementation/numpy/data/tests/test_df_to_event.py
+++ b/temporian/implementation/numpy/data/tests/test_df_to_event.py
@@ -12,11 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import datetime
-import time
-import pandas as pd
-import numpy as np
 from absl.testing import absltest
+import datetime
+import numpy as np
+import pandas as pd
+
 from temporian.implementation.numpy.data.event import NumpyEvent
 from temporian.implementation.numpy.data.event import NumpyFeature
 from temporian.implementation.numpy.data.sampling import NumpySampling

--- a/temporian/implementation/numpy/operators/tests/calendar_day_of_month_test.py
+++ b/temporian/implementation/numpy/operators/tests/calendar_day_of_month_test.py
@@ -16,6 +16,8 @@ from absl.testing import absltest
 import numpy as np
 import pandas as pd
 
+from temporian.core.data.event import Event
+from temporian.core.data.sampling import Sampling
 from temporian.core.operators.calendar.day_of_month import (
     CalendarDayOfMonthOperator,
 )
@@ -112,6 +114,20 @@ class CalendarDayOfMonthNumpyImplementationTest(absltest.TestCase):
         self.assertTrue(
             output["event"]._first_index_features[0].dtype == np.int32
         )
+
+    # TODO: move this test to core operators' test suite when created
+    # since its testing BaseCalendarOperator's logic, not
+    # CalendarDayOfMonthNumpyImplementation's
+    def test_invalid_sampling(self) -> None:
+        """
+        Test calendar operator with a non-utc timestamp
+        sampling.
+        """
+        input_event = Event(
+            features=[], sampling=Sampling(index=[], is_unix_timestamp=False)
+        )
+        with self.assertRaises(ValueError):
+            CalendarDayOfMonthOperator(input_event)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Add `is_unix_timestamp` attr to samplings

Didn't include UTC in the name of the attribute since unix time is implicitly UTC - there's no non-UTC unix timestamps. Lmk if you still think it would be a good idea to have it in the attribute name, IMO it makes it harder to read.