### PR TITLE
SetIndexOperator

### DIFF
--- a/temporian/core/data/event.py
+++ b/temporian/core/data/event.py
@@ -15,8 +15,9 @@
 """An event is a collection (possibly empty) of timesampled feature values."""
 
 from __future__ import annotations
-from typing import List, Optional, Tuple, TYPE_CHECKING
+from typing import Dict, List, Optional, Tuple, TYPE_CHECKING
 
+from temporian.core.data import dtype as dtype_lib
 from temporian.core.data.feature import Feature
 from temporian.core.data.sampling import Sampling
 from temporian.core.data.sampling import IndexDtypes
@@ -90,6 +91,10 @@ class Event(object):
     @property
     def feature_names(self) -> List[str]:
         return [feature.name for feature in self._features]
+
+    @property
+    def dtypes(self) -> Dict[str, dtype_lib.DType]:
+        return {feature.name: feature.dtype for feature in self._features}
 
     @property
     def name(self) -> str:

--- a/temporian/core/operators/BUILD
+++ b/temporian/core/operators/BUILD
@@ -14,10 +14,10 @@ py_library(
         ":arithmetic",
         ":glue",
         ":lag",
-        ":propagate",
-        ":select",
-        ":sample",
         ":prefix",
+        ":propagate",
+        ":sample",
+        ":select",
         "//temporian/core/operators/calendar:day_of_month",
         "//temporian/core/operators/calendar:day_of_week",
         "//temporian/core/operators/calendar:day_of_year",
@@ -108,6 +108,20 @@ py_library(
         "//temporian/core/data:duration",
         "//temporian/core/data:event",
         "//temporian/core/data:feature",
+        "//temporian/proto:core_py_proto",
+    ],
+)
+
+py_library(
+    name = "set_index",
+    srcs = ["set_index.py"],
+    srcs_version = "PY3",
+    deps = [
+        ":base",
+        "//temporian/core:operator_lib",
+        "//temporian/core/data:event",
+        "//temporian/core/data:feature",
+        "//temporian/core/data:sampling",
         "//temporian/proto:core_py_proto",
     ],
 )

--- a/temporian/core/operators/set_index.py
+++ b/temporian/core/operators/set_index.py
@@ -73,7 +73,7 @@ class SetIndexOperator(Operator):
         self, event: Event, labels: List[str]
     ) -> List[Feature]:
         output_features = [
-            Feature(name=feature.name, dtype=feature.dtype)
+            Feature(name=feature.name(), dtype=feature.dtype())
             for feature in event.features()
             if feature.name not in labels
         ]

--- a/temporian/core/operators/set_index.py
+++ b/temporian/core/operators/set_index.py
@@ -115,4 +115,51 @@ operator_lib.register_operator(SetIndexOperator)
 def set_index(
     event: Event, feature_names: List[str], append: bool = False
 ) -> Event:
+    """
+    Sets one or more index columns for the given `Event` object and returns
+    a new `Event` object with the updated index. Optionally, it can also append
+    the new index columns to the existing index.
+
+    Args:
+        event:
+            The input `Event` object for which the index is to be set or
+            updated.
+        feature_names:
+            A list of feature names (strings) that should be used as the new
+            index. These feature names should already exist in the input
+            `Event`.
+        append:
+            A flag indicating whether the new index should be appended to the
+            existing index (True) or replace it (False). Defaults to `False`.
+
+    Returns:
+        A new `Event` object with the updated index, where the specified feature
+        names have been set or appended as index columns, based on the `append`
+        flag.
+
+    Raises:
+        KeyError:
+            If any of the specified feature_names are not found in the input
+            `Event`.
+
+    Examples:
+        Given an input `Event` with index names ['A', 'B', 'C'] and features
+        names ['X', 'Y', 'Z']:
+
+        1. set_index(event, feature_names=['X'], append=False)
+           Output `Event` will have index names ['X'] and features names
+           ['Y', 'Z'].
+
+        2. set_index(event, feature_names=['X', 'Y'], append=False)
+           Output `Event` will have index names ['X', 'Y'] and
+           features names ['Z'].
+
+        3. set_index(event, feature_names=['X', 'Y'], append=True)
+           Output `Event` will have index names ['A', 'B', 'C', 'X', 'Y'] and
+           features names ['Z'].
+
+    Notes:
+        The input `Event` object remains unchanged. The function returns a new
+        `Event` object with the specified index changes.
+    """
     return SetIndexOperator(event, feature_names, append).outputs["event"]

--- a/temporian/core/operators/set_index.py
+++ b/temporian/core/operators/set_index.py
@@ -96,12 +96,10 @@ class SetIndexOperator(Operator):
                 pb.OperatorDef.Attribute(
                     key="feature_names",
                     type=pb.OperatorDef.Attribute.Type.REPEATED_STRING,
-                    is_optional=False,
                 ),
                 pb.OperatorDef.Attribute(
                     key="append",
                     type=pb.OperatorDef.Attribute.Type.BOOL,
-                    is_optional=False,
                 ),
             ],
             inputs=[

--- a/temporian/core/operators/set_index.py
+++ b/temporian/core/operators/set_index.py
@@ -1,0 +1,111 @@
+"""DropIndex operator."""
+from typing import List, Optional, Union
+
+from temporian.core import operator_lib
+from temporian.core.data.event import Event
+from temporian.core.data.feature import Feature
+from temporian.core.data.sampling import Sampling
+from temporian.core.operators.base import Operator
+from temporian.proto import core_pb2 as pb
+
+
+class SetIndexOperator(Operator):
+    """SetIndex operator."""
+
+    def __init__(
+        self,
+        event: Event,
+        labels: Optional[Union[List[str], str]] = None,
+        append: bool = False,
+    ) -> None:
+        super().__init__()
+
+        # process labels
+        labels = self._process_labels(event, labels)
+
+        # input event
+        self.add_input("event", event)
+
+        # attributes
+        self.add_attribute("labels", labels)
+        self.add_attribute("append", append)
+
+        # output features
+        output_features = self._generate_output_features(event, labels)
+
+        # output sampling
+        output_sampling = Sampling(
+            index=[
+                index_name for index_name in event.sampling().index() + labels
+            ]
+            if append
+            else labels
+        )
+        # output event
+        self.add_output(
+            "event",
+            Event(
+                features=output_features,
+                sampling=output_sampling,
+                creator=self,
+            ),
+        )
+        self.check()
+
+    def _process_labels(
+        self,
+        event: Event,
+        labels: Optional[Union[List[str], str]],
+    ) -> List[str]:
+        if isinstance(labels, str):
+            labels = [labels]
+        missing_labels = [
+            label
+            for label in labels
+            if label not in [feature.name() for feature in event.features()]
+        ]
+        if missing_labels:
+            raise KeyError(missing_labels)
+
+        return labels
+
+    def _generate_output_features(
+        self, event: Event, labels: List[str]
+    ) -> List[Feature]:
+        output_features = [
+            Feature(name=feature.name, dtype=feature.dtype)
+            for feature in event.features()
+            if feature.name not in labels
+        ]
+        return output_features
+
+    @classmethod
+    def build_op_definition(cls) -> pb.OperatorDef:
+        return pb.OperatorDef(
+            key="SET_INDEX",
+            attributes=[
+                pb.OperatorDef.Attribute(
+                    key="labels",
+                    type=pb.OperatorDef.Attribute.Type.REPEATED_STRING,
+                    is_optional=False,
+                ),
+                pb.OperatorDef.Attribute(
+                    key="append",
+                    type=pb.OperatorDef.Attribute.Type.BOOL,
+                    is_optional=False,
+                ),
+            ],
+            inputs=[
+                pb.OperatorDef.Input(key="event"),
+            ],
+            outputs=[pb.OperatorDef.Output(key="event")],
+        )
+
+
+operator_lib.register_operator(SetIndexOperator)
+
+
+def set_index(
+    event: Event, labels: Optional[List[str]] = None, append: bool = True
+) -> Event:
+    return SetIndexOperator(event, labels, append).outputs()["event"]

--- a/temporian/implementation/numpy/data/event.py
+++ b/temporian/implementation/numpy/data/event.py
@@ -50,7 +50,7 @@ class NumpyEvent:
         return self.data[self.first_index_value()]
 
     @property
-    def dtypes(self) -> Dict[str, type]:
+    def dtypes(self) -> Dict[str, dtype_lib.DType]:
         return {
             feature.name: feature.dtype
             for feature in self._first_index_features

--- a/temporian/implementation/numpy/operators/BUILD
+++ b/temporian/implementation/numpy/operators/BUILD
@@ -109,6 +109,7 @@ py_library(
     srcs = ["set_index.py"],
     srcs_version = "PY3",
     deps = [
+        ":utils",
         "//temporian/core/operators:set_index",
         "//temporian/implementation/numpy/data:event",
         "//temporian/implementation/numpy/data:sampling",
@@ -158,5 +159,14 @@ py_library(
         "//temporian/implementation/numpy:utils",
         "//temporian/implementation/numpy/data:event",
         "//temporian/implementation/numpy/data:sampling",
+    ],
+)
+
+py_library(
+    name = "utils",
+    srcs = ["utils.py"],
+    srcs_version = "PY3",
+    deps = [
+        "//temporian/implementation/numpy/data:event",
     ],
 )

--- a/temporian/implementation/numpy/operators/BUILD
+++ b/temporian/implementation/numpy/operators/BUILD
@@ -109,6 +109,7 @@ py_library(
     srcs = ["set_index.py"],
     srcs_version = "PY3",
     deps = [
+        ":base",
         ":utils",
         "//temporian/core/operators:set_index",
         "//temporian/implementation/numpy/data:event",

--- a/temporian/implementation/numpy/operators/BUILD
+++ b/temporian/implementation/numpy/operators/BUILD
@@ -105,6 +105,17 @@ py_library(
 )
 
 py_library(
+    name = "set_index",
+    srcs = ["set_index.py"],
+    srcs_version = "PY3",
+    deps = [
+        "//temporian/core/operators:set_index",
+        "//temporian/implementation/numpy/data:event",
+        "//temporian/implementation/numpy/data:sampling",
+    ],
+)
+
+py_library(
     name = "propagate",
     srcs = ["propagate.py"],
     srcs_version = "PY3",

--- a/temporian/implementation/numpy/operators/set_index.py
+++ b/temporian/implementation/numpy/operators/set_index.py
@@ -1,0 +1,92 @@
+from collections import defaultdict
+from typing import Dict, List, Union
+
+import numpy as np
+
+from temporian.core.operators.set_index import SetIndexOperator
+from temporian.implementation.numpy.data.event import NumpyEvent
+from temporian.implementation.numpy.data.event import NumpyFeature
+from temporian.implementation.numpy.data.sampling import NumpySampling
+
+IndexMetadata = Dict[
+    str, Union[int, List[List[NumpyFeature]], List[np.ndarray]]
+]
+
+
+def _append_impl(event: NumpyEvent, append_feat_names: List[str]) -> NumpyEvent:
+    # destination index names
+    dst_idx_names = event.sampling.index + append_feat_names
+
+    # positions of features that are going to be part of the destination index
+    dst_idx_pos = [
+        event.feature_names.index(append_feat_name)
+        for append_feat_name in append_feat_names
+    ]
+    # positions of features that are being kept
+    keep_feats_pos = [
+        pos
+        for pos, feat_name in enumerate(event.feature_names)
+        if feat_name not in append_feat_names
+    ]
+    # initialize destination event & sampling data
+    dst_event_data = {}
+    dst_samp_data = {}
+    for src_idx_lvl, src_idx_lvl_feats in event.data.items():
+        dst_idx_suffs = [
+            tuple(x)
+            for x in zip(*[src_idx_lvl_feats[i].data for i in dst_idx_pos])
+        ]
+        for target_dst_idx_suff in set(dst_idx_suffs):
+            # find all occurrences of destination suff in source event
+            dst_idx_suff_pos = [
+                idx
+                for idx, dst_idx_suff in enumerate(dst_idx_suffs)
+                if dst_idx_suff == target_dst_idx_suff
+            ]
+            # create destination index
+            dst_idx_lvl = src_idx_lvl + tuple(target_dst_idx_suff)
+
+            # initialize event & sampling destination entries
+            dst_event_data[dst_idx_lvl] = []
+            # fill event data
+            for idx in keep_feats_pos:
+                dst_event_data[dst_idx_lvl].append(
+                    NumpyFeature(
+                        event.feature_names[idx],
+                        event.data[src_idx_lvl][idx].data[dst_idx_suff_pos],
+                    )
+                )
+            # fill sampling data
+            dst_samp_data[dst_idx_lvl] = event.sampling.data[src_idx_lvl][
+                dst_idx_suff_pos
+            ]
+            # finally, sort according to timestamps. TODO: this is merging sorted
+            # arrays, we should later improve this code by avoiding the full sort
+            for dst_idx_lvl in dst_event_data.keys():
+                sorted_idxs = np.argsort(
+                    dst_samp_data[dst_idx_lvl], kind="mergesort"
+                )
+                # sampling
+                dst_samp_data[dst_idx_lvl] = dst_samp_data[dst_idx_lvl][
+                    sorted_idxs
+                ]
+                # event
+                for feature in dst_event_data[dst_idx_lvl]:
+                    feature.data = feature.data[sorted_idxs]
+
+    return NumpyEvent(
+        dst_event_data, NumpySampling(dst_idx_names, dst_samp_data)
+    )
+
+
+class SetIndexNumpyImplementation:
+    def __init__(self, operator: SetIndexOperator) -> None:
+        self.operator = operator
+
+    def __call__(self, event: NumpyEvent) -> Dict[str, NumpyEvent]:
+        # get attributes
+        labels = self.operator.attributes()["labels"]
+        append = self.operator.attributes()["append"]
+
+        if append:
+            return {"event": _append_impl(event, labels)}

--- a/temporian/implementation/numpy/operators/set_index.py
+++ b/temporian/implementation/numpy/operators/set_index.py
@@ -20,11 +20,11 @@ def _append_impl(event: NumpyEvent, append_feat_names: List[str]) -> NumpyEvent:
         for append_feat_name in append_feat_names
     ]
     # positions of features that are being kept
-    keep_feats_pos = [
-        pos
+    dst_feat_pos = {
+        feat_name: pos
         for pos, feat_name in enumerate(event.feature_names)
         if feat_name not in append_feat_names
-    ]
+    }
     # initialize destination event & sampling data
     dst_event_data = {}
     dst_samp_data = {}
@@ -47,11 +47,13 @@ def _append_impl(event: NumpyEvent, append_feat_names: List[str]) -> NumpyEvent:
             dst_event_data[dst_idx_lvl] = []
 
             # fill event data
-            for idx in keep_feats_pos:
+            for feat_name, feat_pos in dst_feat_pos.items():
                 dst_event_data[dst_idx_lvl].append(
                     NumpyFeature(
-                        event.feature_names[idx],
-                        event.data[src_idx_lvl][idx].data[dst_idx_suff_pos],
+                        feat_name,
+                        event.data[src_idx_lvl][feat_pos].data[
+                            dst_idx_suff_pos
+                        ],
                     )
                 )
             # fill sampling data
@@ -68,6 +70,69 @@ def _append_impl(event: NumpyEvent, append_feat_names: List[str]) -> NumpyEvent:
     )
 
 
+def _set_impl(event: NumpyEvent, set_feat_names: List[str]) -> NumpyEvent:
+    # positions of features that are going to be part of the destination index
+    dst_idx_pos = [
+        event.feature_names.index(append_feat_name)
+        for append_feat_name in set_feat_names
+    ]
+    # positions of features that are being kept
+    dst_feat_pos = {
+        feat_name: pos
+        for pos, feat_name in enumerate(event.feature_names)
+        if feat_name not in set_feat_names
+    }
+    # intialize empty dict mapping destination index levels to block lengths
+    dst_idx_metadata = defaultdict(
+        lambda: {
+            "timestamps": [],
+            "features": {feat_name: [] for feat_name in dst_feat_pos},
+        }
+    )
+    # loop over source index levels gathering destination indexes
+    for src_idx_lvl, src_idx_lvl_feats in event.data.items():
+        dst_idx_lvls = [
+            tuple(x)
+            for x in zip(*[src_idx_lvl_feats[i].data for i in dst_idx_pos])
+        ]
+        for i, dst_idx_lvl in enumerate(dst_idx_lvls):
+            dst_idx_metadata[dst_idx_lvl]["timestamps"].append(
+                event.sampling.data[src_idx_lvl][i]
+            )
+            for feat_name, feat_pos in dst_feat_pos.items():
+                dst_idx_metadata[dst_idx_lvl]["features"][feat_name].append(
+                    src_idx_lvl_feats[feat_pos].data[i]
+                )
+
+    # create destination sampling & event
+    # sampling
+    dst_samp_data = {
+        dst_idx_lvl: np.array(metadata["timestamps"], dtype=float)
+        for dst_idx_lvl, metadata in dst_idx_metadata.items()
+    }
+    # event
+    dst_event_data = {
+        dst_idx_lvl: [
+            NumpyFeature(
+                name=feat_name,
+                data=np.array(
+                    metadata["features"][feat_name],
+                    dtype=event.dtypes[feat_name],
+                ),
+            )
+            for feat_name in dst_feat_pos
+        ]
+        for dst_idx_lvl, metadata in dst_idx_metadata.items()
+    }
+    # finally, sort according to timestamps. TODO: this is merging sorted
+    # arrays, we should later improve this code by avoiding the full sort
+    _sort_by_timestamp(dst_event_data, dst_samp_data)
+
+    return NumpyEvent(
+        dst_event_data, NumpySampling(set_feat_names, dst_samp_data)
+    )
+
+
 class SetIndexNumpyImplementation:
     def __init__(self, operator: SetIndexOperator) -> None:
         self.operator = operator
@@ -79,3 +144,5 @@ class SetIndexNumpyImplementation:
 
         if append:
             return {"event": _append_impl(event, labels)}
+
+        return {"event": _set_impl(event, labels)}

--- a/temporian/implementation/numpy/operators/set_index.py
+++ b/temporian/implementation/numpy/operators/set_index.py
@@ -9,6 +9,42 @@ from temporian.implementation.numpy.data.event import NumpyEvent
 from temporian.implementation.numpy.data.event import NumpyFeature
 from temporian.implementation.numpy.data.sampling import NumpySampling
 from temporian.implementation.numpy.operators.utils import _sort_by_timestamp
+from temporian.implementation.numpy.operators.base import OperatorImplementation
+
+
+class SetIndexNumpyImplementation(OperatorImplementation):
+    """
+    A class that represents the implementation of the SetIndexOperator for
+    NumpyEvent objects.
+
+    Attributes:
+        operator (SetIndexOperator): The SetIndexOperator object.
+    """
+
+    def __init__(self, operator: SetIndexOperator) -> None:
+        super().__init__(operator)
+
+    def __call__(self, event: NumpyEvent) -> Dict[str, NumpyEvent]:
+        """
+        Execute the SetIndexOperator to the given NumpyEvent and return the
+        updated NumpyEvent.
+
+        Args:
+            event:
+                The input NumpyEvent object.
+
+        Returns:
+            A dictionary containing the resulting NumpyEvent object with the key
+            "event".
+        """
+        # get attributes
+        feature_names = self.operator.attributes["feature_names"]
+        append = self.operator.attributes["append"]
+
+        if append:
+            return {"event": _append_impl(event, feature_names)}
+
+        return {"event": _set_impl(event, feature_names)}
 
 
 def _append_impl(event: NumpyEvent, append_feat_names: List[str]) -> NumpyEvent:
@@ -150,38 +186,3 @@ def _set_impl(event: NumpyEvent, set_feat_names: List[str]) -> NumpyEvent:
     return NumpyEvent(
         dst_event_data, NumpySampling(set_feat_names, dst_samp_data)
     )
-
-
-class SetIndexNumpyImplementation:
-    """
-    A class that represents the implementation of the SetIndexOperator for
-    NumpyEvent objects.
-
-    Attributes:
-        operator (SetIndexOperator): The SetIndexOperator object.
-    """
-
-    def __init__(self, operator: SetIndexOperator) -> None:
-        self.operator = operator
-
-    def __call__(self, event: NumpyEvent) -> Dict[str, NumpyEvent]:
-        """
-        Execute the SetIndexOperator to the given NumpyEvent and return the
-        updated NumpyEvent.
-
-        Args:
-            event:
-                The input NumpyEvent object.
-
-        Returns:
-            A dictionary containing the resulting NumpyEvent object with the key
-            "event".
-        """
-        # get attributes
-        feature_names = self.operator.attributes["feature_names"]
-        append = self.operator.attributes["append"]
-
-        if append:
-            return {"event": _append_impl(event, feature_names)}
-
-        return {"event": _set_impl(event, feature_names)}

--- a/temporian/implementation/numpy/operators/set_index.py
+++ b/temporian/implementation/numpy/operators/set_index.py
@@ -4,6 +4,7 @@ from typing import Dict, List
 import numpy as np
 
 from temporian.core.operators.set_index import SetIndexOperator
+from temporian.implementation.numpy.data.feature import DTYPE_REVERSE_MAPPING
 from temporian.implementation.numpy.data.event import NumpyEvent
 from temporian.implementation.numpy.data.event import NumpyFeature
 from temporian.implementation.numpy.data.sampling import NumpySampling
@@ -28,13 +29,13 @@ def _append_impl(event: NumpyEvent, append_feat_names: List[str]) -> NumpyEvent:
 
     # positions of features that are going to be part of the destination index
     dst_idx_pos = [
-        event.feature_names.index(append_feat_name)
+        event.feature_names().index(append_feat_name)
         for append_feat_name in append_feat_names
     ]
     # positions of features that are being kept
     dst_feat_pos = {
         feat_name: pos
-        for pos, feat_name in enumerate(event.feature_names)
+        for pos, feat_name in enumerate(event.feature_names())
         if feat_name not in append_feat_names
     }
     # initialize destination event & sampling data
@@ -91,13 +92,13 @@ def _set_impl(event: NumpyEvent, set_feat_names: List[str]) -> NumpyEvent:
     """
     # positions of features that are going to be part of the destination index
     dst_idx_pos = [
-        event.feature_names.index(append_feat_name)
+        event.feature_names().index(append_feat_name)
         for append_feat_name in set_feat_names
     ]
     # positions of features that are being kept
     dst_feat_pos = {
         feat_name: pos
-        for pos, feat_name in enumerate(event.feature_names)
+        for pos, feat_name in enumerate(event.feature_names())
         if feat_name not in set_feat_names
     }
     # intialize empty dict mapping destination index levels to block lengths
@@ -135,7 +136,7 @@ def _set_impl(event: NumpyEvent, set_feat_names: List[str]) -> NumpyEvent:
                 name=feat_name,
                 data=np.array(
                     metadata["features"][feat_name],
-                    dtype=event.dtypes[feat_name],
+                    dtype=DTYPE_REVERSE_MAPPING[event.dtypes[feat_name]],
                 ),
             )
             for feat_name in dst_feat_pos
@@ -177,8 +178,8 @@ class SetIndexNumpyImplementation:
             "event".
         """
         # get attributes
-        labels = self.operator.attributes()["labels"]
-        append = self.operator.attributes()["append"]
+        labels = self.operator.attributes["labels"]
+        append = self.operator.attributes["append"]
 
         if append:
             return {"event": _append_impl(event, labels)}

--- a/temporian/implementation/numpy/operators/set_index.py
+++ b/temporian/implementation/numpy/operators/set_index.py
@@ -11,6 +11,18 @@ from temporian.implementation.numpy.operators.utils import _sort_by_timestamp
 
 
 def _append_impl(event: NumpyEvent, append_feat_names: List[str]) -> NumpyEvent:
+    """
+    Append the specified feature names to the index of the given NumpyEvent.
+
+    Args:
+        event:
+            The input NumpyEvent object.
+        append_feat_names:
+            A list of feature names to append to the index.
+
+    Returns:
+        The resulting NumpyEvent object with the updated index.
+    """
     # destination index names
     dst_idx_names = event.sampling.index + append_feat_names
 
@@ -71,6 +83,18 @@ def _append_impl(event: NumpyEvent, append_feat_names: List[str]) -> NumpyEvent:
 
 
 def _set_impl(event: NumpyEvent, set_feat_names: List[str]) -> NumpyEvent:
+    """
+    Set the specified feature names as the new index of the given NumpyEvent.
+
+    Args:
+        event:
+            The input NumpyEvent object.
+        set_feat_names:
+            A list of feature names to set as the new index.
+
+    Returns:
+        The resulting NumpyEvent object with the updated index.
+    """
     # positions of features that are going to be part of the destination index
     dst_idx_pos = [
         event.feature_names.index(append_feat_name)
@@ -134,10 +158,30 @@ def _set_impl(event: NumpyEvent, set_feat_names: List[str]) -> NumpyEvent:
 
 
 class SetIndexNumpyImplementation:
+    """
+    A class that represents the implementation of the SetIndexOperator for
+    NumpyEvent objects.
+
+    Attributes:
+        operator (SetIndexOperator): The SetIndexOperator object.
+    """
+
     def __init__(self, operator: SetIndexOperator) -> None:
         self.operator = operator
 
     def __call__(self, event: NumpyEvent) -> Dict[str, NumpyEvent]:
+        """
+        Execute the SetIndexOperator to the given NumpyEvent and return the
+        updated NumpyEvent.
+
+        Args:
+            event:
+                The input NumpyEvent object.
+
+        Returns:
+            A dictionary containing the resulting NumpyEvent object with the key
+            "event".
+        """
         # get attributes
         labels = self.operator.attributes()["labels"]
         append = self.operator.attributes()["append"]

--- a/temporian/implementation/numpy/operators/set_index.py
+++ b/temporian/implementation/numpy/operators/set_index.py
@@ -178,10 +178,10 @@ class SetIndexNumpyImplementation:
             "event".
         """
         # get attributes
-        labels = self.operator.attributes["labels"]
+        feature_names = self.operator.attributes["feature_names"]
         append = self.operator.attributes["append"]
 
         if append:
-            return {"event": _append_impl(event, labels)}
+            return {"event": _append_impl(event, feature_names)}
 
-        return {"event": _set_impl(event, labels)}
+        return {"event": _set_impl(event, feature_names)}

--- a/temporian/implementation/numpy/operators/set_index.py
+++ b/temporian/implementation/numpy/operators/set_index.py
@@ -55,19 +55,13 @@ def _append_impl(event: NumpyEvent, append_feat_names: List[str]) -> NumpyEvent:
             # create destination index
             dst_idx_lvl = src_idx_lvl + tuple(target_dst_idx_suff)
 
-            # initialize event & sampling destination entries
-            dst_event_data[dst_idx_lvl] = []
-
-            # fill event data
-            for feat_name, feat_pos in dst_feat_pos.items():
-                dst_event_data[dst_idx_lvl].append(
-                    NumpyFeature(
-                        feat_name,
-                        event.data[src_idx_lvl][feat_pos].data[
-                            dst_idx_suff_pos
-                        ],
-                    )
+            dst_event_data[dst_idx_lvl] = [
+                NumpyFeature(
+                    feat_name,
+                    event.data[src_idx_lvl][feat_pos].data[dst_idx_suff_pos],
                 )
+                for feat_name, feat_pos in dst_feat_pos.items()
+            ]
             # fill sampling data
             dst_samp_data[dst_idx_lvl] = event.sampling.data[src_idx_lvl][
                 dst_idx_suff_pos

--- a/temporian/implementation/numpy/operators/test/BUILD
+++ b/temporian/implementation/numpy/operators/test/BUILD
@@ -199,6 +199,21 @@ py_test(
 )
 
 py_test(
+    name = "set_index_test",
+    srcs = ["set_index_test.py"],
+    srcs_version = "PY3",
+    deps = [
+        # absl/testing:absltest dep,
+        "//temporian/core/data:event",
+        "//temporian/core/data:sampling",
+        "//temporian/core/operators:set_index",
+        "//temporian/implementation/numpy/data:event",
+        "//temporian/implementation/numpy/data:sampling",
+        "//temporian/implementation/numpy/operators:set_index",
+    ],
+)
+
+py_test(
     name = "simple_moving_average_test",
     srcs = ["simple_moving_average_test.py"],
     srcs_version = "PY3",

--- a/temporian/implementation/numpy/operators/test/set_index_test.py
+++ b/temporian/implementation/numpy/operators/test/set_index_test.py
@@ -62,7 +62,7 @@ class SetIndexNumpyImplementationTest(absltest.TestCase):
             index_names=["state_id", "store_id"],
         )
         operator = SetIndexOperator(
-            self.input_evt, labels="store_id", append=True
+            self.input_evt, feature_names="store_id", append=True
         )
         # instance operator implementation
         operator_impl = SetIndexNumpyImplementation(operator)
@@ -98,7 +98,9 @@ class SetIndexNumpyImplementationTest(absltest.TestCase):
             index_names=["state_id", "store_id", "item_id"],
         )
         operator = SetIndexOperator(
-            self.input_evt, labels=["store_id", "item_id"], append=True
+            self.input_evt,
+            feature_names=["store_id", "item_id"],
+            append=True,
         )
         # instance operator implementation
         operator_impl = SetIndexNumpyImplementation(operator)
@@ -133,7 +135,7 @@ class SetIndexNumpyImplementationTest(absltest.TestCase):
             index_names=["store_id"],
         )
         operator = SetIndexOperator(
-            self.input_evt, labels=["store_id"], append=False
+            self.input_evt, feature_names=["store_id"], append=False
         )
         # instance operator implementation
         operator_impl = SetIndexNumpyImplementation(operator)
@@ -168,7 +170,9 @@ class SetIndexNumpyImplementationTest(absltest.TestCase):
             index_names=["store_id", "item_id"],
         )
         operator = SetIndexOperator(
-            self.input_evt, labels=["store_id", "item_id"], append=False
+            self.input_evt,
+            feature_names=["store_id", "item_id"],
+            append=False,
         )
         # instance operator implementation
         operator_impl = SetIndexNumpyImplementation(operator)

--- a/temporian/implementation/numpy/operators/test/set_index_test.py
+++ b/temporian/implementation/numpy/operators/test/set_index_test.py
@@ -119,6 +119,76 @@ class SetIndexNumpyImplementationTest(absltest.TestCase):
         # validate output
         self.assertEqual(op_numpy_output_evt, expected_numpy_output_evt)
 
+    def test_set_single(self) -> None:
+        # output NumPy event
+        expected_numpy_output_evt = NumpyEvent.from_dataframe(
+            pd.DataFrame(
+                [
+                    [0, 2, 0.1, 13.0],
+                    [0, 2, 0.2, 14.0],
+                    [0, 1, 0.4, 10.0],
+                    [0, 1, 0.5, 11.0],
+                    [0, 1, 0.6, 12.0],
+                    [1, 2, 0.3, 15.0],
+                    [1, 3, 0.3, 17.0],
+                    [1, 2, 0.4, 16.0],
+                ],
+                columns=[
+                    "store_id",
+                    "item_id",
+                    "timestamp",
+                    "sales",
+                ],
+            ),
+            index_names=["store_id"],
+        )
+        operator = SetIndexOperator(
+            self.input_evt, labels=["store_id"], append=False
+        )
+        # instance operator implementation
+        operator_impl = SetIndexNumpyImplementation(operator)
+
+        # call operator
+        op_numpy_output_evt = operator_impl(event=self.numpy_input_evt)["event"]
+
+        # validate output
+        self.assertEqual(op_numpy_output_evt, expected_numpy_output_evt)
+
+    def test_set_multiple(self) -> None:
+        # output NumPy event
+        expected_numpy_output_evt = NumpyEvent.from_dataframe(
+            pd.DataFrame(
+                [
+                    [0, 2, 0.1, 13.0],
+                    [0, 2, 0.2, 14.0],
+                    [0, 1, 0.4, 10.0],
+                    [0, 1, 0.5, 11.0],
+                    [0, 1, 0.6, 12.0],
+                    [1, 2, 0.3, 15.0],
+                    [1, 2, 0.4, 16.0],
+                    [1, 3, 0.3, 17.0],
+                ],
+                columns=[
+                    "store_id",
+                    "item_id",
+                    "timestamp",
+                    "sales",
+                ],
+            ),
+            index_names=["store_id", "item_id"],
+        )
+        operator = SetIndexOperator(
+            self.input_evt, labels=["store_id", "item_id"], append=False
+        )
+        # instance operator implementation
+        operator_impl = SetIndexNumpyImplementation(operator)
+
+        # call operator
+        op_numpy_output_evt = operator_impl(event=self.numpy_input_evt)["event"]
+
+        # validate output
+        self.assertEqual(op_numpy_output_evt, expected_numpy_output_evt)
+
 
 if __name__ == "__main__":
     absltest.main()

--- a/temporian/implementation/numpy/operators/test/set_index_test.py
+++ b/temporian/implementation/numpy/operators/test/set_index_test.py
@@ -1,0 +1,124 @@
+from absl.testing import absltest
+
+import pandas as pd
+
+from temporian.core.data.event import Event
+from temporian.core.data.event import Feature
+from temporian.core.data.sampling import Sampling
+from temporian.core.operators.set_index import SetIndexOperator
+from temporian.implementation.numpy.data.event import NumpyEvent
+from temporian.implementation.numpy.operators.set_index import (
+    SetIndexNumpyImplementation,
+)
+
+
+class SetIndexNumpyImplementationTest(absltest.TestCase):
+    def setUp(self) -> None:
+        # input event
+        self.input_evt = Event(
+            features=[
+                Feature("store_id", dtype=int),
+                Feature("item_id", dtype=int),
+                Feature("sales", dtype=float),
+            ],
+            sampling=Sampling(index=["state_id"]),
+        )
+        # input NumPy event
+        self.numpy_input_evt = NumpyEvent.from_dataframe(
+            pd.DataFrame(
+                [
+                    ["A", 0, 1, 0.4, 10.0],
+                    ["A", 0, 1, 0.5, 11.0],
+                    ["A", 0, 1, 0.6, 12.0],
+                    ["B", 0, 2, 0.1, 13.0],
+                    ["B", 0, 2, 0.2, 14.0],
+                    ["B", 1, 2, 0.3, 15.0],
+                    ["B", 1, 2, 0.4, 16.0],
+                    ["B", 1, 3, 0.3, 17.0],
+                ],
+                columns=[
+                    "state_id",
+                    "store_id",
+                    "item_id",
+                    "timestamp",
+                    "sales",
+                ],
+            ),
+            index_names=["state_id"],
+        )
+
+    def test_append_single(self) -> None:
+        # output NumPy event
+        expected_numpy_output_evt = NumpyEvent.from_dataframe(
+            pd.DataFrame(
+                [
+                    ["A", 0, 1, 0.4, 10.0],
+                    ["A", 0, 1, 0.5, 11.0],
+                    ["A", 0, 1, 0.6, 12.0],
+                    ["B", 0, 2, 0.1, 13.0],
+                    ["B", 0, 2, 0.2, 14.0],
+                    ["B", 1, 2, 0.3, 15.0],
+                    ["B", 1, 3, 0.3, 17.0],
+                    ["B", 1, 2, 0.4, 16.0],
+                ],
+                columns=[
+                    "state_id",
+                    "store_id",
+                    "item_id",
+                    "timestamp",
+                    "sales",
+                ],
+            ),
+            index_names=["state_id", "store_id"],
+        )
+        operator = SetIndexOperator(
+            self.input_evt, labels="store_id", append=True
+        )
+        # instance operator implementation
+        operator_impl = SetIndexNumpyImplementation(operator)
+
+        # call operator
+        op_numpy_output_evt = operator_impl(event=self.numpy_input_evt)["event"]
+
+        # validate output
+        self.assertEqual(op_numpy_output_evt, expected_numpy_output_evt)
+
+    def test_append_multiple(self) -> None:
+        # output NumPy event
+        expected_numpy_output_evt = NumpyEvent.from_dataframe(
+            pd.DataFrame(
+                [
+                    ["A", 0, 1, 0.4, 10.0],
+                    ["A", 0, 1, 0.5, 11.0],
+                    ["A", 0, 1, 0.6, 12.0],
+                    ["B", 0, 2, 0.1, 13.0],
+                    ["B", 0, 2, 0.2, 14.0],
+                    ["B", 1, 2, 0.3, 15.0],
+                    ["B", 1, 3, 0.3, 17.0],
+                    ["B", 1, 2, 0.4, 16.0],
+                ],
+                columns=[
+                    "state_id",
+                    "store_id",
+                    "item_id",
+                    "timestamp",
+                    "sales",
+                ],
+            ),
+            index_names=["state_id", "store_id", "item_id"],
+        )
+        operator = SetIndexOperator(
+            self.input_evt, labels=["store_id", "item_id"], append=True
+        )
+        # instance operator implementation
+        operator_impl = SetIndexNumpyImplementation(operator)
+
+        # call operator
+        op_numpy_output_evt = operator_impl(event=self.numpy_input_evt)["event"]
+
+        # validate output
+        self.assertEqual(op_numpy_output_evt, expected_numpy_output_evt)
+
+
+if __name__ == "__main__":
+    absltest.main()

--- a/temporian/implementation/numpy/operators/test/set_index_test.py
+++ b/temporian/implementation/numpy/operators/test/set_index_test.py
@@ -68,7 +68,9 @@ class SetIndexNumpyImplementationTest(absltest.TestCase):
         operator_impl = SetIndexNumpyImplementation(operator)
 
         # call operator
-        op_numpy_output_evt = operator_impl(event=self.numpy_input_evt)["event"]
+        op_numpy_output_evt = operator_impl.call(event=self.numpy_input_evt)[
+            "event"
+        ]
 
         # validate output
         self.assertEqual(op_numpy_output_evt, expected_numpy_output_evt)
@@ -106,7 +108,9 @@ class SetIndexNumpyImplementationTest(absltest.TestCase):
         operator_impl = SetIndexNumpyImplementation(operator)
 
         # call operator
-        op_numpy_output_evt = operator_impl(event=self.numpy_input_evt)["event"]
+        op_numpy_output_evt = operator_impl.call(event=self.numpy_input_evt)[
+            "event"
+        ]
 
         # validate output
         self.assertEqual(op_numpy_output_evt, expected_numpy_output_evt)
@@ -141,7 +145,9 @@ class SetIndexNumpyImplementationTest(absltest.TestCase):
         operator_impl = SetIndexNumpyImplementation(operator)
 
         # call operator
-        op_numpy_output_evt = operator_impl(event=self.numpy_input_evt)["event"]
+        op_numpy_output_evt = operator_impl.call(event=self.numpy_input_evt)[
+            "event"
+        ]
 
         # validate output
         self.assertEqual(op_numpy_output_evt, expected_numpy_output_evt)
@@ -178,7 +184,9 @@ class SetIndexNumpyImplementationTest(absltest.TestCase):
         operator_impl = SetIndexNumpyImplementation(operator)
 
         # call operator
-        op_numpy_output_evt = operator_impl(event=self.numpy_input_evt)["event"]
+        op_numpy_output_evt = operator_impl.call(event=self.numpy_input_evt)[
+            "event"
+        ]
 
         # validate output
         self.assertEqual(op_numpy_output_evt, expected_numpy_output_evt)

--- a/temporian/implementation/numpy/operators/test/set_index_test.py
+++ b/temporian/implementation/numpy/operators/test/set_index_test.py
@@ -2,9 +2,6 @@ from absl.testing import absltest
 
 import pandas as pd
 
-from temporian.core.data.event import Event
-from temporian.core.data.event import Feature
-from temporian.core.data.sampling import Sampling
 from temporian.core.operators.set_index import SetIndexOperator
 from temporian.implementation.numpy.data.event import NumpyEvent
 from temporian.implementation.numpy.operators.set_index import (
@@ -14,15 +11,6 @@ from temporian.implementation.numpy.operators.set_index import (
 
 class SetIndexNumpyImplementationTest(absltest.TestCase):
     def setUp(self) -> None:
-        # input event
-        self.input_evt = Event(
-            features=[
-                Feature("store_id", dtype=int),
-                Feature("item_id", dtype=int),
-                Feature("sales", dtype=float),
-            ],
-            sampling=Sampling(index=["state_id"]),
-        )
         # input NumPy event
         self.numpy_input_evt = NumpyEvent.from_dataframe(
             pd.DataFrame(
@@ -46,6 +34,8 @@ class SetIndexNumpyImplementationTest(absltest.TestCase):
             ),
             index_names=["state_id"],
         )
+        # input event
+        self.input_evt = self.numpy_input_evt.schema()
 
     def test_append_single(self) -> None:
         # output NumPy event

--- a/temporian/implementation/numpy/operators/utils.py
+++ b/temporian/implementation/numpy/operators/utils.py
@@ -8,12 +8,12 @@ from temporian.implementation.numpy.data.event import NumpyFeature
 def _sort_by_timestamp(
     event_data: Dict[str, List[NumpyFeature]], samp_data: Dict[str, np.array]
 ) -> None:
-    """Sorts the data in dst_event_data and dst_samp_data according to their
-    timestamps.
+    """Sorts the data in event_data and samp_data according to their
+    timestamps. This operations is done inplace.
 
-    This function takes in two dictionaries, dst_event_data and dst_samp_data,
+    This function takes in two dictionaries, event and samp_data,
     that contain event data and sampling data, respectively. It sorts the data
-    in both dictionaries based on the timestamps in dst_samp_data using a
+    in both dictionaries based on the timestamps in samp_data using a
     "mergesort" algorithm.
 
     Args:

--- a/temporian/implementation/numpy/operators/utils.py
+++ b/temporian/implementation/numpy/operators/utils.py
@@ -8,6 +8,22 @@ from temporian.implementation.numpy.data.event import NumpyFeature
 def _sort_by_timestamp(
     event_data: Dict[str, List[NumpyFeature]], samp_data: Dict[str, np.array]
 ) -> None:
+    """Sorts the data in dst_event_data and dst_samp_data according to their
+    timestamps.
+
+    This function takes in two dictionaries, dst_event_data and dst_samp_data,
+    that contain event data and sampling data, respectively. It sorts the data
+    in both dictionaries based on the timestamps in dst_samp_data using a
+    "mergesort" algorithm.
+
+    Args:
+        event_data:
+            A dictionary containing the event data, with keys representing index
+            levels and values being lists of NumpyFeature objects.
+        samp_data:
+            A dictionary containing the sampling data, with keys representing
+            index levels and values being numpy arrays of timestamps.
+    """
     for idx_lvl in event_data:
         sorted_idxs = np.argsort(samp_data[idx_lvl], kind="mergesort")
 

--- a/temporian/implementation/numpy/operators/utils.py
+++ b/temporian/implementation/numpy/operators/utils.py
@@ -1,0 +1,19 @@
+from typing import Dict, List
+
+import numpy as np
+
+from temporian.implementation.numpy.data.event import NumpyFeature
+
+
+def _sort_by_timestamp(
+    event_data: Dict[str, List[NumpyFeature]], samp_data: Dict[str, np.array]
+) -> None:
+    for idx_lvl in event_data:
+        sorted_idxs = np.argsort(samp_data[idx_lvl], kind="mergesort")
+
+        # sampling
+        samp_data[idx_lvl] = samp_data[idx_lvl][sorted_idxs]
+
+        # event
+        for feature in event_data[idx_lvl]:
+            feature.data = feature.data[sorted_idxs]


### PR DESCRIPTION
This PR implements the `set_index` logic. This operator can be used to append a level to the existing index, or wipe the existing index in favor of a new one. Depends on #51.