### PR TITLE
Check np.object column is only of type str

### DIFF
--- a/temporian/implementation/numpy/data/event.py
+++ b/temporian/implementation/numpy/data/event.py
@@ -174,15 +174,17 @@ class NumpyEvent:
 
         # check column dtypes, every dtype should be a key of DTYPE_MAPPING
         for column in df.columns:
-            # if dtype is object, check if it is a string column
+            # if dtype is object, check if it only contains string values
             if df[column].dtype.type is np.object_:
                 if not df[column].apply(lambda x: isinstance(x, str)).all():
                     raise ValueError(
-                        "String columns with mixed types are not supported"
+                        "Object columns are only allowed if they contain only"
+                        " string values"
                     )
-                # convert string column to np.string_
+                # convert object column to np.string_
                 df[column] = df[column].astype(np.string_)
 
+            # convert pandas' StringDtype to np.string_
             elif df[column].dtype.type is str:
                 df[column] = df[column].astype(np.string_)
 

--- a/temporian/implementation/numpy/data/event.py
+++ b/temporian/implementation/numpy/data/event.py
@@ -174,15 +174,14 @@ class NumpyEvent:
 
         # check column dtypes, every dtype should be a key of DTYPE_MAPPING
         for column in df.columns:
-            # if dtype is object, convert to string
+            # if dtype is object, check if it is a string column
             if df[column].dtype.type is np.object_:
-                try:
-                    df[column] = df[column].astype(np.string_)
-                except ValueError as exc:
+                if not df[column].apply(lambda x: isinstance(x, str)).all():
                     raise ValueError(
-                        f"Column {column} has dtype object, but cannot be"
-                        " converted to string."
-                    ) from exc
+                        "String columns with mixed types are not supported"
+                    )
+                # convert string column to np.string_
+                df[column] = df[column].astype(np.string_)
 
             elif df[column].dtype.type not in DTYPE_MAPPING:
                 raise ValueError(

--- a/temporian/implementation/numpy/data/event.py
+++ b/temporian/implementation/numpy/data/event.py
@@ -183,6 +183,9 @@ class NumpyEvent:
                 # convert string column to np.string_
                 df[column] = df[column].astype(np.string_)
 
+            elif df[column].dtype.type is str:
+                df[column] = df[column].astype(np.string_)
+
             elif df[column].dtype.type not in DTYPE_MAPPING:
                 raise ValueError(
                     f"Unsupported dtype {df[column].dtype} for column"

--- a/temporian/implementation/numpy/data/event.py
+++ b/temporian/implementation/numpy/data/event.py
@@ -186,7 +186,10 @@ class NumpyEvent:
             elif df[column].dtype.type is str:
                 df[column] = df[column].astype(np.string_)
 
-            elif df[column].dtype.type not in DTYPE_MAPPING:
+            elif (
+                df[column].dtype.type not in DTYPE_MAPPING
+                and df[column].dtype.type != np.string_
+            ):
                 raise ValueError(
                     f"Unsupported dtype {df[column].dtype} for column"
                     f" {column}. Supported dtypes: {DTYPE_MAPPING.keys()}"

--- a/temporian/implementation/numpy/data/test/df_to_event_test.py
+++ b/temporian/implementation/numpy/data/test/df_to_event_test.py
@@ -62,8 +62,8 @@ class DataFrameToEventTest(absltest.TestCase):
         df = pd.DataFrame(
             [
                 [666964, 1.0, "740"],
-                [666964, 2.0, np.nan],
-                [574016, 3.0, ""],
+                [666964, 2.0, "400"],
+                [574016, 3.0, "200"],
             ],
             columns=["product_id", "timestamp", "costs"],
         )
@@ -80,13 +80,13 @@ class DataFrameToEventTest(absltest.TestCase):
             data={
                 (666964,): [
                     NumpyFeature(
-                        data=np.array(["740", np.nan]).astype(np.string_),
+                        data=np.array(["740", "400"]).astype(np.string_),
                         name="costs",
                     )
                 ],
                 (574016,): [
                     NumpyFeature(
-                        data=np.array([""]).astype(np.string_), name="costs"
+                        data=np.array(["200"]).astype(np.string_), name="costs"
                     )
                 ],
             },
@@ -99,6 +99,22 @@ class DataFrameToEventTest(absltest.TestCase):
 
         # validate
         self.assertTrue(numpy_event == expected_numpy_event)
+
+    def test_mixed_types_in_string_column(self) -> None:
+        df = pd.DataFrame(
+            [
+                [666964, 1.0, "740", "A"],
+                [666964, 2.0, "400", 101],
+                [574016, 3.0, np.nan, "B"],
+            ],
+            columns=["product_id", "timestamp", "costs", "sales"],
+        )
+
+        # Not allowed
+        with self.assertRaises(ValueError):
+            NumpyEvent.from_dataframe(
+                df, index_names=["product_id"], timestamp_column="timestamp"
+            )
 
     def test_missing_values(self) -> None:
         df = pd.DataFrame(

--- a/temporian/implementation/numpy/data/test/df_to_event_test.py
+++ b/temporian/implementation/numpy/data/test/df_to_event_test.py
@@ -119,17 +119,19 @@ class DataFrameToEventTest(absltest.TestCase):
     def test_multiple_string_formats(self) -> None:
         df = pd.DataFrame(
             [
-                [666964, 1.0, "740", "A"],
-                [666964, 2.0, "400", "B"],
-                [574016, 3.0, "200", "C"],
+                [666964, 1.0, "740", "A", "D"],
+                [666964, 2.0, "400", "B", "E"],
+                [574016, 3.0, "200", "C", "F"],
             ],
-            columns=["product_id", "timestamp", "costs", "sales"],
+            columns=["product_id", "timestamp", "costs", "sales", "sales2"],
         )
 
         # set dtype of column costs to string
         df["costs"] = df["costs"].astype(str)
-        # set dtype of column sales to string
+        # set dtype of column sales to pandas string
         df["sales"] = df["sales"].astype("string")
+        # set dtype of column sales2 to np.string_
+        df["sales2"] = df["sales2"].astype(np.string_)
 
         numpy_sampling = NumpySampling(
             data={
@@ -150,6 +152,10 @@ class DataFrameToEventTest(absltest.TestCase):
                         data=np.array(["A", "B"]).astype(np.string_),
                         name="sales",
                     ),
+                    NumpyFeature(
+                        data=np.array(["D", "E"]).astype(np.string_),
+                        name="sales2",
+                    ),
                 ],
                 (574016,): [
                     NumpyFeature(
@@ -157,6 +163,9 @@ class DataFrameToEventTest(absltest.TestCase):
                     ),
                     NumpyFeature(
                         data=np.array(["C"]).astype(np.string_), name="sales"
+                    ),
+                    NumpyFeature(
+                        data=np.array(["F"]).astype(np.string_), name="sales2"
                     ),
                 ],
             },


### PR DESCRIPTION
In this PR I change the DataFrame to NumpyEvent functionality to only allow for string-only columns. All numpy objects columns will be rejected if they have mixed values.