### PR TITLE
Migrate from `np.string_` to `np.str_`

### DIFF
--- a/temporian/implementation/numpy/data/event.py
+++ b/temporian/implementation/numpy/data/event.py
@@ -262,8 +262,12 @@ class NumpyEvent:
             data["timestamp"].extend(timestamps)
             for feature in features:
                 data[feature.name].extend(feature.data)
-            for index_key in self.sampling.index:
-                data[index_key].extend(index * len(timestamps))
+
+            if not isinstance(index, tuple):
+                index = (index,)
+
+            for i, index_key in enumerate(self.sampling.index):
+                data[index_key].extend([index[i]] * len(timestamps))
 
         # Converting dictionary to pandas DataFrame
         df = pd.DataFrame(data)

--- a/temporian/implementation/numpy/data/event.py
+++ b/temporian/implementation/numpy/data/event.py
@@ -140,17 +140,6 @@ class NumpyEvent:
             ... )
             >>> event = NumpyEvent.from_dataframe(df, index_names=["product_id"])
         """
-
-        def decode_group(
-            group: Union[Any, Tuple[Any]]
-        ) -> Union[Any, Tuple[Any]]:
-            """Replaces string bytes with strings"""
-            if isinstance(group, tuple):
-                return tuple(
-                    e.decode() if isinstance(e, bytes) else e for e in group
-                )
-            return group.decode() if isinstance(group, bytes) else group
-
         if index_names is None:
             index_names = []
 
@@ -228,10 +217,6 @@ class NumpyEvent:
             for group in group_by_indexes.groups:
                 columns = group_by_indexes.get_group(group)
                 timestamp = columns[timestamp_column].to_numpy()
-
-                # Decodes indexes, if they are string bytes they will be
-                # converted to normal strings.
-                group = decode_group(group)
 
                 # Convert group to tuple, useful when its only one value
                 if not isinstance(group, tuple):

--- a/temporian/implementation/numpy/data/event.py
+++ b/temporian/implementation/numpy/data/event.py
@@ -273,9 +273,11 @@ class NumpyEvent:
         df = pd.DataFrame(data)
 
         # Convert binary strings to strings
-        df = df.applymap(
-            lambda x: x.decode("utf-8") if isinstance(x, bytes) else x
-        )
+        for col in df.columns:
+            if df[col].dtype.type == np.object_:
+                df[col] = df[col].apply(
+                    lambda x: x.decode("utf-8") if isinstance(x, bytes) else x
+                )
 
         return df
 

--- a/temporian/implementation/numpy/data/event.py
+++ b/temporian/implementation/numpy/data/event.py
@@ -182,15 +182,15 @@ class NumpyEvent:
                         " string values"
                     )
                 # convert object column to np.string_
-                df[column] = df[column].astype(np.string_)
+                df[column] = df[column].astype("string")
 
             # convert pandas' StringDtype to np.string_
-            elif df[column].dtype.type is str:
-                df[column] = df[column].astype(np.string_)
+            elif df[column].dtype.type is np.string_:
+                df[column] = df[column].str.decode("utf-8").astype("string")
 
             elif (
                 df[column].dtype.type not in DTYPE_MAPPING
-                and df[column].dtype.type != np.string_
+                and df[column].dtype.type is not str
             ):
                 raise ValueError(
                     f"Unsupported dtype {df[column].dtype} for column"

--- a/temporian/implementation/numpy/data/event.py
+++ b/temporian/implementation/numpy/data/event.py
@@ -26,7 +26,7 @@ class NumpyFeature:
                 "NumpyFeatures can only be created from flat arrays. Passed"
                 f" input's shape: {len(data.shape)}"
             )
-        if data.dtype.type is not np.string_:
+        if data.dtype.type is not np.str_:
             if data.dtype.type not in DTYPE_MAPPING:
                 raise ValueError(
                     f"Unsupported dtype {data.dtype} for NumpyFeature: {name}."
@@ -47,13 +47,13 @@ class NumpyFeature:
         if self.name != __o.name:
             return False
 
-        if self.dtype is np.string_:
+        if self.dtype is np.str_:
             return np.array_equal(self.data, __o.data)
 
         return np.array_equal(self.data, __o.data, equal_nan=True)
 
     def core_dtype(self) -> Any:
-        if hasattr(self.dtype, "type") and self.dtype.type is np.string_:
+        if hasattr(self.dtype, "type") and self.dtype.type is np.str_:
             return dtype.STRING
         return DTYPE_MAPPING[self.dtype]
 
@@ -223,10 +223,17 @@ class NumpyEvent:
                     group = (group,)
 
                 sampling[group] = timestamp
+
                 data[group] = [
-                    NumpyFeature(feature, columns[feature].to_numpy())
+                    NumpyFeature(
+                        feature,
+                        columns[feature].to_numpy(
+                            dtype=columns[feature].dtype.type
+                        ),
+                    )
                     for feature in feature_columns
                 ]
+
         # The user did not provide an index
         else:
             timestamp = df[timestamp_column].to_numpy()
@@ -271,13 +278,6 @@ class NumpyEvent:
 
         # Converting dictionary to pandas DataFrame
         df = pd.DataFrame(data)
-
-        # Convert binary strings to strings
-        for col in df.columns:
-            if df[col].dtype.type == np.object_:
-                df[col] = df[col].apply(
-                    lambda x: x.decode("utf-8") if isinstance(x, bytes) else x
-                )
 
         return df
 

--- a/temporian/implementation/numpy/data/test/df_to_event_test.py
+++ b/temporian/implementation/numpy/data/test/df_to_event_test.py
@@ -200,19 +200,19 @@ class DataFrameToEventTest(absltest.TestCase):
 
         expected_numpy_event = NumpyEvent(
             data={
-                ("X1", "Y1"): [
+                (b"X1", b"Y1"): [
                     NumpyFeature(
                         name="a",
                         data=np.array([10.0, 11.0, 12.0]),
                     )
                 ],
-                ("X2", "Y1"): [
+                (b"X2", b"Y1"): [
                     NumpyFeature(
                         name="a",
                         data=np.array([13.0, 14.0, 15.0]),
                     )
                 ],
-                ("X2", "Y2"): [
+                (b"X2", b"Y2"): [
                     NumpyFeature(
                         name="a",
                         data=np.array([16.0, 17.0, 18.0]),
@@ -222,9 +222,9 @@ class DataFrameToEventTest(absltest.TestCase):
             sampling=NumpySampling(
                 index=["x", "y"],
                 data={
-                    ("X1", "Y1"): np.array([1, 2, 3], dtype=np.float64),
-                    ("X2", "Y1"): np.array([1.1, 2.1, 3.1], dtype=np.float64),
-                    ("X2", "Y2"): np.array([1.2, 2.2, 3.2], dtype=np.float64),
+                    (b"X1", b"Y1"): np.array([1, 2, 3], dtype=np.float64),
+                    (b"X2", b"Y1"): np.array([1.1, 2.1, 3.1], dtype=np.float64),
+                    (b"X2", b"Y2"): np.array([1.2, 2.2, 3.2], dtype=np.float64),
                 },
             ),
         )

--- a/temporian/implementation/numpy/data/test/df_to_event_test.py
+++ b/temporian/implementation/numpy/data/test/df_to_event_test.py
@@ -62,8 +62,8 @@ class DataFrameToEventTest(absltest.TestCase):
         df = pd.DataFrame(
             [
                 [666964, 1.0, "740"],
-                [666964, 2.0, "400"],
-                [574016, 3.0, "200"],
+                [666964, 2.0, "B"],
+                [574016, 3.0, ""],
             ],
             columns=["product_id", "timestamp", "costs"],
         )
@@ -80,13 +80,13 @@ class DataFrameToEventTest(absltest.TestCase):
             data={
                 (666964,): [
                     NumpyFeature(
-                        data=np.array(["740", "400"]).astype(np.string_),
+                        data=np.array(["740", "B"]).astype(np.str_),
                         name="costs",
                     )
                 ],
                 (574016,): [
                     NumpyFeature(
-                        data=np.array(["200"]).astype(np.string_), name="costs"
+                        data=np.array([""]).astype(np.str_), name="costs"
                     )
                 ],
             },
@@ -179,7 +179,7 @@ class DataFrameToEventTest(absltest.TestCase):
         # validate
         self.assertTrue(numpy_event == expected_numpy_event)
 
-    def test_binary_string_in_index(self):
+    def test_string_in_index(self):
         numpy_event = NumpyEvent.from_dataframe(
             pd.DataFrame(
                 [
@@ -200,19 +200,19 @@ class DataFrameToEventTest(absltest.TestCase):
 
         expected_numpy_event = NumpyEvent(
             data={
-                (b"X1", b"Y1"): [
+                ("X1", "Y1"): [
                     NumpyFeature(
                         name="a",
                         data=np.array([10.0, 11.0, 12.0]),
                     )
                 ],
-                (b"X2", b"Y1"): [
+                ("X2", "Y1"): [
                     NumpyFeature(
                         name="a",
                         data=np.array([13.0, 14.0, 15.0]),
                     )
                 ],
-                (b"X2", b"Y2"): [
+                ("X2", "Y2"): [
                     NumpyFeature(
                         name="a",
                         data=np.array([16.0, 17.0, 18.0]),
@@ -222,9 +222,9 @@ class DataFrameToEventTest(absltest.TestCase):
             sampling=NumpySampling(
                 index=["x", "y"],
                 data={
-                    (b"X1", b"Y1"): np.array([1, 2, 3], dtype=np.float64),
-                    (b"X2", b"Y1"): np.array([1.1, 2.1, 3.1], dtype=np.float64),
-                    (b"X2", b"Y2"): np.array([1.2, 2.2, 3.2], dtype=np.float64),
+                    ("X1", "Y1"): np.array([1, 2, 3], dtype=np.float64),
+                    ("X2", "Y1"): np.array([1.1, 2.1, 3.1], dtype=np.float64),
+                    ("X2", "Y2"): np.array([1.2, 2.2, 3.2], dtype=np.float64),
                 },
             ),
         )

--- a/temporian/implementation/numpy/data/test/df_to_event_test.py
+++ b/temporian/implementation/numpy/data/test/df_to_event_test.py
@@ -145,27 +145,27 @@ class DataFrameToEventTest(absltest.TestCase):
             data={
                 (666964,): [
                     NumpyFeature(
-                        data=np.array(["740", "400"]).astype(np.string_),
+                        data=np.array(["740", "400"]).astype(np.str_),
                         name="costs",
                     ),
                     NumpyFeature(
-                        data=np.array(["A", "B"]).astype(np.string_),
+                        data=np.array(["A", "B"]).astype(np.str_),
                         name="sales",
                     ),
                     NumpyFeature(
-                        data=np.array(["D", "E"]).astype(np.string_),
+                        data=np.array(["D", "E"]).astype(np.str_),
                         name="sales2",
                     ),
                 ],
                 (574016,): [
                     NumpyFeature(
-                        data=np.array(["200"]).astype(np.string_), name="costs"
+                        data=np.array(["200"]).astype(np.str_), name="costs"
                     ),
                     NumpyFeature(
-                        data=np.array(["C"]).astype(np.string_), name="sales"
+                        data=np.array(["C"]).astype(np.str_), name="sales"
                     ),
                     NumpyFeature(
-                        data=np.array(["F"]).astype(np.string_), name="sales2"
+                        data=np.array(["F"]).astype(np.str_), name="sales2"
                     ),
                 ],
             },

--- a/temporian/implementation/numpy/data/test/df_to_event_test.py
+++ b/temporian/implementation/numpy/data/test/df_to_event_test.py
@@ -179,6 +179,59 @@ class DataFrameToEventTest(absltest.TestCase):
         # validate
         self.assertTrue(numpy_event == expected_numpy_event)
 
+    def test_binary_string_in_index(self):
+        numpy_event = NumpyEvent.from_dataframe(
+            pd.DataFrame(
+                [
+                    ["X1", "Y1", 10.0, 1],
+                    ["X1", "Y1", 11.0, 2],
+                    ["X1", "Y1", 12.0, 3],
+                    ["X2", "Y1", 13.0, 1.1],
+                    ["X2", "Y1", 14.0, 2.1],
+                    ["X2", "Y1", 15.0, 3.1],
+                    ["X2", "Y2", 16.0, 1.2],
+                    ["X2", "Y2", 17.0, 2.2],
+                    ["X2", "Y2", 18.0, 3.2],
+                ],
+                columns=["x", "y", "a", "timestamp"],
+            ),
+            index_names=["x", "y"],
+        )
+
+        expected_numpy_event = NumpyEvent(
+            data={
+                ("X1", "Y1"): [
+                    NumpyFeature(
+                        name="a",
+                        data=np.array([10.0, 11.0, 12.0]),
+                    )
+                ],
+                ("X2", "Y1"): [
+                    NumpyFeature(
+                        name="a",
+                        data=np.array([13.0, 14.0, 15.0]),
+                    )
+                ],
+                ("X2", "Y2"): [
+                    NumpyFeature(
+                        name="a",
+                        data=np.array([16.0, 17.0, 18.0]),
+                    )
+                ],
+            },
+            sampling=NumpySampling(
+                index=["x", "y"],
+                data={
+                    ("X1", "Y1"): np.array([1, 2, 3], dtype=np.float64),
+                    ("X2", "Y1"): np.array([1.1, 2.1, 3.1], dtype=np.float64),
+                    ("X2", "Y2"): np.array([1.2, 2.2, 3.2], dtype=np.float64),
+                },
+            ),
+        )
+
+        # validate
+        self.assertTrue(numpy_event == expected_numpy_event)
+
     def test_missing_values(self) -> None:
         df = pd.DataFrame(
             [

--- a/temporian/implementation/numpy/data/test/event_to_df_test.py
+++ b/temporian/implementation/numpy/data/test/event_to_df_test.py
@@ -126,6 +126,58 @@ class EventToDataFrameTest(absltest.TestCase):
         # validate
         self.assertTrue(df.equals(expected_df))
 
+    def test_numpy_event_to_df_multiple_index(self) -> None:
+        numpy_event = NumpyEvent(
+            data={
+                ("X1", "Y1"): [
+                    NumpyFeature(
+                        name="sma_a",
+                        data=np.array([10.0, 10.5, 11.0]),
+                    )
+                ],
+                ("X2", "Y1"): [
+                    NumpyFeature(
+                        name="sma_a",
+                        data=np.array([13.0, 13.5, 14.0]),
+                    )
+                ],
+                ("X2", "Y2"): [
+                    NumpyFeature(
+                        name="sma_a",
+                        data=np.array([16.0, 16.5, 17.0]),
+                    )
+                ],
+            },
+            sampling=NumpySampling(
+                index=["x", "y"],
+                data={
+                    ("X1", "Y1"): np.array([1.0, 2.0, 3.0], dtype=np.float64),
+                    ("X2", "Y1"): np.array([1.1, 2.1, 3.1], dtype=np.float64),
+                    ("X2", "Y2"): np.array([1.2, 2.2, 3.2], dtype=np.float64),
+                },
+            ),
+        )
+
+        expected_df = pd.DataFrame(
+            [
+                ["X1", "Y1", 10.0, 1.0],
+                ["X1", "Y1", 10.5, 2.0],
+                ["X1", "Y1", 11.0, 3.0],
+                ["X2", "Y1", 13.0, 1.1],
+                ["X2", "Y1", 13.5, 2.1],
+                ["X2", "Y1", 14.0, 3.1],
+                ["X2", "Y2", 16.0, 1.2],
+                ["X2", "Y2", 16.5, 2.2],
+                ["X2", "Y2", 17.0, 3.2],
+            ],
+            columns=["x", "y", "sma_a", "timestamp"],
+        )
+
+        df = numpy_event.to_dataframe()
+
+        # validate
+        self.assertTrue(df.equals(expected_df))
+
 
 if __name__ == "__main__":
     absltest.main()

--- a/temporian/implementation/numpy/data/test/event_to_df_test.py
+++ b/temporian/implementation/numpy/data/test/event_to_df_test.py
@@ -178,6 +178,47 @@ class EventToDataFrameTest(absltest.TestCase):
         # validate
         self.assertTrue(df.equals(expected_df))
 
+    def test_numpy_event_to_df_string_feature(self) -> None:
+        numpy_sampling = NumpySampling(
+            data={
+                (666964,): np.array([1.0, 2.0]),
+                (574016,): np.array([3.0]),
+            },
+            index=["product_id"],
+        )
+
+        numpy_event = NumpyEvent(
+            data={
+                (666964,): [
+                    NumpyFeature(
+                        data=np.array(["740.0", "508.0"]).astype(np.string_),
+                        name="costs",
+                    )
+                ],
+                (574016,): [
+                    NumpyFeature(
+                        data=np.array(["573.0"]).astype(np.string_),
+                        name="costs",
+                    )
+                ],
+            },
+            sampling=numpy_sampling,
+        )
+
+        expected_df = pd.DataFrame(
+            [
+                [666964, "740.0", 1.0],
+                [666964, "508.0", 2.0],
+                [574016, "573.0", 3.0],
+            ],
+            columns=["product_id", "costs", "timestamp"],
+        )
+
+        df = numpy_event.to_dataframe()
+
+        # validate
+        self.assertTrue(df.equals(expected_df))
+
 
 if __name__ == "__main__":
     absltest.main()

--- a/temporian/implementation/numpy/data/test/event_to_df_test.py
+++ b/temporian/implementation/numpy/data/test/event_to_df_test.py
@@ -191,13 +191,13 @@ class EventToDataFrameTest(absltest.TestCase):
             data={
                 (666964,): [
                     NumpyFeature(
-                        data=np.array(["740.0", "508.0"]).astype(np.string_),
+                        data=np.array(["740.0", "508.0"]).astype(np.str_),
                         name="costs",
                     )
                 ],
                 (574016,): [
                     NumpyFeature(
-                        data=np.array(["573.0"]).astype(np.string_),
+                        data=np.array(["573.0"]).astype(np.str_),
                         name="costs",
                     )
                 ],


### PR DESCRIPTION
- [x] Fix `to_dataframe()` error when NumpyEvent had multiple str indexes.
- [x] Fix `from_dataframe()` error when NumpyEvent had multiple str indexes.

We now use np.str_ instead of np.string_. No binary string is used throughout the code. We may want to change to binary string in the future for more efficient encoding (Unicode vs ASCII).