### PR TITLE
Sort DataFrame by Timestamps

### DIFF
--- a/temporian/implementation/numpy/data/event.py
+++ b/temporian/implementation/numpy/data/event.py
@@ -163,6 +163,11 @@ class NumpyEvent:
             convert_date_to_duration
         )
 
+        # sort by timestamp
+        # TODO: we may consider using kind="mergesort" if we know that most of
+        # the time the data will be sorted.
+        df = df.sort_values(by=timestamp_column)
+
         # check column dtypes, every dtype should be a key of DTYPE_MAPPING
         for column in df.columns:
             # if dtype is object, check if it only contains string values

--- a/temporian/implementation/numpy/data/event.py
+++ b/temporian/implementation/numpy/data/event.py
@@ -101,6 +101,7 @@ class NumpyEvent:
         df: pd.DataFrame,
         index_names: List[str] = None,
         timestamp_column: str = "timestamp",
+        is_sorted: bool = False,
     ) -> NumpyEvent:
         """Convert a pandas DataFrame to a NumpyEvent.
         Args:
@@ -110,6 +111,9 @@ class NumpyEvent:
             timestamp_column: Column containing timestamps. Supported date types:
                 {np.datetime64, pd.Timestamp, datetime.datetime}. Timestamps of
                 these types are converted implicitly to UTC epoch float.
+            is_sorted: If True, the DataFrame is assumed to be sorted by
+                timestamp. If False, the DataFrame will be sorted by timestamp.
+
 
         Returns:
             NumpyEvent: NumpyEvent created from DataFrame.
@@ -163,10 +167,11 @@ class NumpyEvent:
             convert_date_to_duration
         )
 
-        # sort by timestamp
+        # sort by timestamp if it's not sorted
         # TODO: we may consider using kind="mergesort" if we know that most of
         # the time the data will be sorted.
-        df = df.sort_values(by=timestamp_column)
+        if not is_sorted and not np.all(np.diff(df[timestamp_column]) >= 0):
+            df = df.sort_values(by=timestamp_column)
 
         # check column dtypes, every dtype should be a key of DTYPE_MAPPING
         for column in df.columns:

--- a/temporian/implementation/numpy/data/test/df_to_event_test.py
+++ b/temporian/implementation/numpy/data/test/df_to_event_test.py
@@ -58,6 +58,39 @@ class DataFrameToEventTest(absltest.TestCase):
         # validate
         self.assertTrue(numpy_event == expected_numpy_event)
 
+    def test_timestamp_order(self) -> None:
+        df = pd.DataFrame(
+            [
+                [1.0, 100.0],
+                [3.0, 300.0],
+                [2.0, 200.0],
+            ],
+            columns=["timestamp", "costs"],
+        )
+
+        numpy_sampling = NumpySampling(
+            data={
+                (): np.array([1.0, 2.0, 3.0]),
+            },
+            index=[],
+        )
+
+        expected_numpy_event = NumpyEvent(
+            data={
+                (): [
+                    NumpyFeature(
+                        data=np.array([100.0, 200.0, 300.0]), name="costs"
+                    )
+                ],
+            },
+            sampling=numpy_sampling,
+        )
+
+        numpy_event = NumpyEvent.from_dataframe(df)
+
+        # validate
+        self.assertTrue(numpy_event == expected_numpy_event)
+
     def test_string_column(self) -> None:
         df = pd.DataFrame(
             [


### PR DESCRIPTION
In this PR I fix a bug when the `from_dataframe()` function was used and the timestamps of the DataFrame were not sorted. 

It addresses issue #59 

The PR sorts DataFrame values by default using the timestamp column. We may consider using mergesort as the default value. Here are some pros and cons:

## Quicksort (default):

### Pros:

* **Fast average-case performance:** Quicksort has an average-case time complexity of O(n log n), which is generally faster than other sorting algorithms like bubble sort, selection sort, or insertion sort.

* **In-place sorting:** Quicksort sorts the data in place, meaning it doesn't require additional memory to be allocated for temporary storage, making it more memory-efficient.

### Cons:

* **Worst-case performance:** Quicksort has a worst-case time complexity of O(n^2), which can occur when the input data is already sorted or nearly sorted. In practice, however, this is usually mitigated by using randomized pivots or switching to a different sorting algorithm when the recursion depth exceeds a certain threshold.

* **Not stable:** Quicksort is not a stable sorting algorithm, which means that the relative order of equal elements might not be preserved. This can be an issue in some applications where the order of equal elements matters.

## Mergesort:

### Pros:

* **Stable sorting:** Mergesort is a stable sorting algorithm, which means that the relative order of equal elements is preserved. This can be important in some applications where the order of equal elements matters.

* **Consistent performance:** Mergesort has a worst-case, average-case, and best-case time complexity of O(n log n), which means it performs consistently well regardless of the input data.

### Cons:

* **Additional memory:** Mergesort requires additional memory for temporary storage, as it is not an in-place sorting algorithm. This can be a disadvantage when working with large datasets where memory usage is a concern.

* **Slower average-case performance:** Although mergesort has a consistent O(n log n) time complexity, it is generally slower than quicksort in practice for average-case scenarios due to its higher constant factors and memory overhead.