### PR TITLE
Dtype Promotion

### DIFF
--- a/temporian/core/data/dtype.py
+++ b/temporian/core/data/dtype.py
@@ -38,3 +38,43 @@ def MissingValue(dtype: DType) -> Any:
         return ""
     else:
         raise ValueError(f"Non implemented type {dtype}")
+
+
+def get_resulting_dtype(dtype1: DType, dtype2: DType) -> DType:
+    """
+    Get the resulting dtype when combining two arrays with the specified dtypes.
+
+    This function takes two dtypes as input and returns the expected
+    output dtype based on a simplified dtype hierarchy.
+
+    Args:
+        dtype1: The dtype of the first array.
+        dtype2: The dtype of the second array.
+
+    Returns:
+        DType: The resulting dtype
+
+    Raises:
+        ValueError: If either of the input dtypes is not supported.
+    """
+    dtype_hierarchy = {
+        INT32: 1,
+        INT64: 2,
+        FLOAT32: 3,
+        FLOAT64: 4,
+    }
+
+    if dtype1 not in dtype_hierarchy or dtype2 not in dtype_hierarchy:
+        raise ValueError(
+            "Invalid dtype(s). Supported dtypes: int32, int64, float32, float64"
+        )
+
+    # Find the highest hierarchy value between the two input dtypes
+    max_hierarchy = max(dtype_hierarchy[dtype1], dtype_hierarchy[dtype2])
+
+    # Get the key (dtype) corresponding to the highest hierarchy
+    resulting_dtype = next(
+        key for key, value in dtype_hierarchy.items() if value == max_hierarchy
+    )
+
+    return resulting_dtype

--- a/temporian/core/data/dtype.py
+++ b/temporian/core/data/dtype.py
@@ -66,7 +66,8 @@ def get_resulting_dtype(dtype1: DType, dtype2: DType) -> DType:
 
     if dtype1 not in dtype_hierarchy or dtype2 not in dtype_hierarchy:
         raise ValueError(
-            "Invalid dtype(s). Supported dtypes: int32, int64, float32, float64"
+            f"Invalid dtype(s): [{dtype1}, {dtype2}]. Supported dtypes: int32,"
+            " int64, float32, float64"
         )
 
     # Find the highest hierarchy value between the two input dtypes

--- a/temporian/core/data/dtype.py
+++ b/temporian/core/data/dtype.py
@@ -65,9 +65,10 @@ def get_resulting_dtype(dtype1: DType, dtype2: DType) -> DType:
     }
 
     if dtype1 not in dtype_hierarchy or dtype2 not in dtype_hierarchy:
+        supported_dtypes = ", ".join(dtype_hierarchy.keys())
         raise ValueError(
-            f"Invalid dtype(s): [{dtype1}, {dtype2}]. Supported dtypes: int32,"
-            " int64, float32, float64"
+            f"Invalid dtype(s): [{dtype1}, {dtype2}]. Supported dtypes:"
+            f" {supported_dtypes}"
         )
 
     # Find the highest hierarchy value between the two input dtypes

--- a/temporian/core/data/dtype.py
+++ b/temporian/core/data/dtype.py
@@ -59,8 +59,8 @@ def get_resulting_dtype(dtype1: DType, dtype2: DType) -> DType:
     """
     dtype_hierarchy = {
         INT32: 1,
-        INT64: 2,
-        FLOAT32: 3,
+        FLOAT32: 2,
+        INT64: 3,
         FLOAT64: 4,
     }
 
@@ -73,6 +73,12 @@ def get_resulting_dtype(dtype1: DType, dtype2: DType) -> DType:
 
     # Find the highest hierarchy value between the two input dtypes
     max_hierarchy = max(dtype_hierarchy[dtype1], dtype_hierarchy[dtype2])
+
+    # handle special case with int64 and float32
+    if (dtype1 == INT64 and dtype2 == FLOAT32) or (
+        dtype1 == FLOAT32 and dtype2 == INT64
+    ):
+        return FLOAT64
 
     # Get the key (dtype) corresponding to the highest hierarchy
     resulting_dtype = next(

--- a/temporian/core/operators/arithmetic.py
+++ b/temporian/core/operators/arithmetic.py
@@ -17,6 +17,7 @@
 from enum import Enum
 
 from temporian.core import operator_lib
+from temporian.core.data.dtype import get_resulting_dtype
 from temporian.core.data.event import Event
 from temporian.core.data.feature import Feature
 from temporian.core.operators.base import Operator
@@ -84,21 +85,6 @@ class ArithmeticOperator(Operator):
                 "event_1 and event_2 must have same number of features."
             )
 
-        # check that features have same dtype
-        for feature_1, feature_2 in zip(event_1.features(), event_2.features()):
-            if feature_1.dtype() != feature_2.dtype():
-                raise ValueError(
-                    (
-                        "event_1 and event_2 must have same dtype for each"
-                        " feature."
-                    ),
-                    (
-                        f"feature_1: {feature_1}, feature_2: {feature_2} have"
-                        " dtypes:"
-                    ),
-                    f"{feature_1.dtype()}, {feature_2.dtype()}.",
-                )
-
         sampling = event_1.sampling()
 
         prefix = ArithmeticOperation.prefix(operation)
@@ -107,7 +93,7 @@ class ArithmeticOperator(Operator):
         output_features = [  # pylint: disable=g-complex-comprehension
             Feature(
                 name=f"{prefix}_{feature_1.name()}_{feature_2.name()}",
-                dtype=feature_1.dtype(),
+                dtype=get_resulting_dtype(feature_1.dtype(), feature_2.dtype()),
                 sampling=sampling,
                 creator=self,
             )

--- a/temporian/implementation/numpy/data/event.py
+++ b/temporian/implementation/numpy/data/event.py
@@ -33,7 +33,7 @@ class NumpyFeature:
                 "NumpyFeatures can only be created from flat arrays. Passed"
                 f" input's shape: {len(data.shape)}"
             )
-        if data.dtype.type is np.str_ or data.dtype.type is np.string_:
+        if data.dtype.type is np.str_:
             self.dtype: dtype.DType = dtype.STRING
         else:
             if data.dtype.type not in DTYPE_MAPPING:

--- a/temporian/implementation/numpy/operators/test/arithmetic_test.py
+++ b/temporian/implementation/numpy/operators/test/arithmetic_test.py
@@ -59,17 +59,9 @@ class ArithmeticNumpyImplementationTest(absltest.TestCase):
             index_names=["store_id"],
         )
 
-        self.sampling = Sampling(["store_id"])
-        self.event_1 = Event(
-            [Feature("sales", float)],
-            sampling=self.sampling,
-            creator=None,
-        )
-        self.event_2 = Event(
-            [Feature("costs", float)],
-            sampling=self.sampling,
-            creator=None,
-        )
+        self.event_1 = self.numpy_event_1.schema()
+        self.event_2 = self.numpy_event_2.schema()
+        self.event_1.sampling = self.event_2.sampling
 
     def test_correct_sum(self) -> None:
         """Test correct sum operator."""


### PR DESCRIPTION
In this PR I introduce a type promotion hierarchy for Temporian DTypes. This enables us to dynamically understand the output of an operator if the resulting dtype follows [numpy type promotion rules.](https://numpy.org/doc/stable/reference/generated/numpy.result_type.html)

This addition enables the Arithmetic operator to support different feature types.

Expected dtype outputs:

| dtype1  | dtype2  | Output dtype |
|---------|---------|--------------|
| INT32   | INT32   | INT32        |
| INT32   | INT64   | INT64        |
| INT32   | FLOAT32 | FLOAT32      |
| INT32   | FLOAT64 | FLOAT64      |
| INT64   | INT64   | INT64        |
| INT64   | FLOAT32 | FLOAT64      |
| INT64   | FLOAT64 | FLOAT64      |
| FLOAT32 | FLOAT32 | FLOAT32      |
| FLOAT32 | FLOAT64 | FLOAT64      |
| FLOAT64 | FLOAT64 | FLOAT64      |
| STRING | * | ERROR      |
| * | STRING | ERROR      |

>__Note__:The division operator should always output FLOAT64 with any input dtype.