### PR TITLE
General improvements

### DIFF
--- a/benchmark/scripts/basic.py
+++ b/benchmark/scripts/basic.py
@@ -92,7 +92,7 @@ def main():
     )
 
     # Print output's first row, useful to check reproducibility
-    print(res._first_index_features)
+    print(res.first_index_features())
 
 
 if __name__ == "__main__":

--- a/benchmark/scripts/sma.py
+++ b/benchmark/scripts/sma.py
@@ -73,7 +73,7 @@ def main():
     )
 
     # Print output's first row, useful to check reproducibility
-    print(res._first_index_features)
+    print(res.first_index_features())
 
 
 if __name__ == "__main__":

--- a/temporian/core/data/event.py
+++ b/temporian/core/data/event.py
@@ -38,7 +38,7 @@ class Event(object):
         self._creator = creator
         self._name = name
 
-    def __getitem__(self, feature_names: List[str]) -> "Event":
+    def __getitem__(self, feature_names: List[str]) -> Event:
         # import select operator
         from temporian.core.operators.select import select
 

--- a/temporian/core/data/event.py
+++ b/temporian/core/data/event.py
@@ -95,11 +95,11 @@ class Event(object):
         return self._creator
 
     @name.setter
-    def set_name(self, name: str):
+    def name(self, name: str):
         self._name = name
 
     @creator.setter
-    def set_creator(self, creator: Optional[Operator]):
+    def creator(self, creator: Optional[Operator]):
         self._creator = creator
 
 
@@ -117,7 +117,7 @@ def input_event(
             raise ValueError(
                 "Cannot call input_event on already linked features."
             )
-        feature.set_sampling(sampling)
+        feature.sampling = sampling
 
     return Event(
         features=features,

--- a/temporian/core/data/event.py
+++ b/temporian/core/data/event.py
@@ -14,11 +14,15 @@
 
 """An event is a collection (possibly empty) of timesampled feature values."""
 
-from typing import Any, List, Optional
+from __future__ import annotations
+from typing import List, Optional, TYPE_CHECKING
 
 from temporian.core.data.feature import Feature
 from temporian.core.data.sampling import Sampling
 from temporian.utils import string
+
+if TYPE_CHECKING:
+    from temporian.core.operators.base import Operator
 
 
 class Event(object):
@@ -27,9 +31,7 @@ class Event(object):
         features: List[Feature],
         sampling: Sampling,
         name: Optional[str] = None,
-        # TODO: make Operator the creator's type. I don't know how to circumvent
-        # the cyclical import error
-        creator: Optional[Any] = None,
+        creator: Optional[Operator] = None,
     ):
         self._features = features
         self._sampling = sampling
@@ -76,22 +78,28 @@ class Event(object):
 
         return divide(numerator=self, denominator=other)
 
-    def sampling(self):
+    @property
+    def sampling(self) -> Sampling:
         return self._sampling
 
-    def features(self):
+    @property
+    def features(self) -> List[Feature]:
         return self._features
 
+    @property
     def name(self) -> str:
         return self._name
 
-    def creator(self):
+    @property
+    def creator(self) -> Optional[Operator]:
         return self._creator
 
-    def set_name(self, name) -> None:
+    @name.setter
+    def set_name(self, name: str):
         self._name = name
 
-    def set_creator(self, creator):
+    @creator.setter
+    def set_creator(self, creator: Optional[Operator]):
         self._creator = creator
 
 
@@ -105,7 +113,7 @@ def input_event(
         sampling = Sampling(index=index, creator=None)
 
     for feature in features:
-        if feature.sampling() is not None:
+        if feature.sampling is not None:
             raise ValueError(
                 "Cannot call input_event on already linked features."
             )

--- a/temporian/core/data/feature.py
+++ b/temporian/core/data/feature.py
@@ -79,9 +79,9 @@ class Feature(object):
         return self._creator
 
     @sampling.setter
-    def set_sampling(self, sampling: Optional[Sampling]):
+    def sampling(self, sampling: Optional[Sampling]):
         self._sampling = sampling
 
     @creator.setter
-    def set_creator(self, creator: Optional[Operator]):
+    def creator(self, creator: Optional[Operator]):
         self._creator = creator

--- a/temporian/core/data/feature.py
+++ b/temporian/core/data/feature.py
@@ -14,28 +14,30 @@
 
 """A feature."""
 
-from typing import Any, Optional
+from __future__ import annotations
+from typing import Optional, TYPE_CHECKING
 
-from temporian.core.data import sampling as sampling_lib
+from temporian.core.data.sampling import Sampling
 from temporian.core.data import dtype as dtype_lib
+
+if TYPE_CHECKING:
+    from temporian.core.operators.base import Operator
 
 
 class Feature(object):
     def __init__(
         self,
         name: str,
-        dtype: Any = dtype_lib.FLOAT32,
-        sampling: Optional[sampling_lib.Sampling] = None,
-        creator: Optional[Any] = None,
+        dtype: dtype_lib.DType = dtype_lib.FLOAT32,
+        sampling: Optional[Sampling] = None,
+        creator: Optional[Operator] = None,
     ):
         # TODO: Find a simple, efficient and consistant way to check the type
         # of arguments in the API.
         assert isinstance(
             name, str
         ), f"`name` must be a string. Got name={name} instead."
-        assert sampling is None or isinstance(
-            sampling, sampling_lib.Sampling
-        ), (
+        assert sampling is None or isinstance(sampling, Sampling), (
             "`sampling` must be None or a Sampling. Got"
             f" sampling={sampling} instead."
         )
@@ -53,27 +55,33 @@ class Feature(object):
 
     def __repr__(self):
         return (
-            f"name: {self._name}\n"
-            f"  dtype: {self._dtype}\n"
-            f"  sampling: {self._sampling}\n"
-            f"  creator: {self.creator()}\n"
+            f"name: {self.name}\n"
+            f"  dtype: {self.dtype}\n"
+            f"  sampling: {self.sampling}\n"
+            f"  creator: {self.creator}\n"
             f"  id: {id(self)}"
         )
 
+    @property
     def name(self) -> str:
         return self._name
 
-    def dtype(self):
+    @property
+    def dtype(self) -> dtype_lib.DType:
         return self._dtype
 
-    def sampling(self) -> Optional[sampling_lib.Sampling]:
+    @property
+    def sampling(self) -> Optional[Sampling]:
         return self._sampling
 
-    def creator(self):
+    @property
+    def creator(self) -> Optional[Operator]:
         return self._creator
 
-    def set_sampling(self, sampling: sampling_lib.Sampling):
+    @sampling.setter
+    def set_sampling(self, sampling: Optional[Sampling]):
         self._sampling = sampling
 
-    def set_creator(self, creator):
+    @creator.setter
+    def set_creator(self, creator: Optional[Operator]):
         self._creator = creator

--- a/temporian/core/data/sampling.py
+++ b/temporian/core/data/sampling.py
@@ -51,5 +51,5 @@ class Sampling(object):
         return self._is_unix_timestamp
 
     @creator.setter
-    def set_creator(self, creator: Optional[Operator]):
+    def creator(self, creator: Optional[Operator]):
         self._creator = creator

--- a/temporian/core/data/sampling.py
+++ b/temporian/core/data/sampling.py
@@ -14,33 +14,42 @@
 
 """A sampling."""
 
-from typing import List, Optional, Any
+from __future__ import annotations
+from typing import List, Optional, TYPE_CHECKING
+
+
+if TYPE_CHECKING:
+    from temporian.core.operators.base import Operator
 
 
 class Sampling(object):
     def __init__(
         self,
         index: List[str],
-        creator: Optional[Any] = None,
+        creator: Optional[Operator] = None,
         is_unix_timestamp: bool = False,
     ):
         assert isinstance(index, list), f"Got {index}"
 
-        self._index: List[str] = index
+        self._index = index
         self._creator = creator
         self._is_unix_timestamp = is_unix_timestamp
 
     def __repr__(self):
-        return f"Sampling<index:{self._index},id:{id(self)}>"
+        return f"Sampling<index:{self.index},id:{id(self)}>"
 
+    @property
     def index(self) -> List[str]:
         return self._index
 
-    def creator(self):
+    @property
+    def creator(self) -> Optional[Operator]:
         return self._creator
 
-    def set_creator(self, creator):
-        self._creator = creator
-
+    @property
     def is_unix_timestamp(self) -> bool:
         return self._is_unix_timestamp
+
+    @creator.setter
+    def set_creator(self, creator: Optional[Operator]):
+        self._creator = creator

--- a/temporian/core/evaluator.py
+++ b/temporian/core/evaluator.py
@@ -187,9 +187,9 @@ def build_schedule(
 
     # Compute "event_to_op" and "op_to_num_pending_inputs".
     inputs_set = set(inputs)
-    for op in processor.operators():
+    for op in processor.operators:
         num_pending_inputs = 0
-        for input_event in op.inputs().values():
+        for input_event in op.inputs.values():
             if input_event in inputs_set:
                 # This input is already available
                 continue
@@ -212,7 +212,7 @@ def build_schedule(
 
         # Update all the ops that depends on "op". Enlist the ones that are
         # ready to be computed
-        for output in op.outputs().values():
+        for output in op.outputs.values():
             if output not in event_to_op:
                 continue
             for new_op in event_to_op[output]:

--- a/temporian/core/operators/arithmetic.py
+++ b/temporian/core/operators/arithmetic.py
@@ -76,17 +76,17 @@ class ArithmeticOperator(Operator):
         if not isinstance(resolution, Resolution):
             raise ValueError("resolution must be a Resolution.")
 
-        if event_1.sampling() is not event_2.sampling():
+        if event_1.sampling is not event_2.sampling:
             raise ValueError("event_1 and event_2 must have same sampling.")
 
-        if len(event_1.features()) != len(event_2.features()):
+        if len(event_1.features) != len(event_2.features):
             raise ValueError(
                 "event_1 and event_2 must have same number of features."
             )
 
         # check that features have same dtype
-        for feature_1, feature_2 in zip(event_1.features(), event_2.features()):
-            if feature_1.dtype() != feature_2.dtype():
+        for feature_1, feature_2 in zip(event_1.features, event_2.features):
+            if feature_1.dtype != feature_2.dtype:
                 raise ValueError(
                     (
                         "event_1 and event_2 must have same dtype for each"
@@ -96,24 +96,22 @@ class ArithmeticOperator(Operator):
                         f"feature_1: {feature_1}, feature_2: {feature_2} have"
                         " dtypes:"
                     ),
-                    f"{feature_1.dtype()}, {feature_2.dtype()}.",
+                    f"{feature_1.dtype}, {feature_2.dtype}.",
                 )
 
-        sampling = event_1.sampling()
+        sampling = event_1.sampling
 
         prefix = ArithmeticOperation.prefix(operation)
 
         # outputs
         output_features = [  # pylint: disable=g-complex-comprehension
             Feature(
-                name=f"{prefix}_{feature_1.name()}_{feature_2.name()}",
-                dtype=feature_1.dtype(),
+                name=f"{prefix}_{feature_1.name}_{feature_2.name}",
+                dtype=feature_1.dtype,
                 sampling=sampling,
                 creator=self,
             )
-            for feature_1, feature_2 in zip(
-                event_1.features(), event_2.features()
-            )
+            for feature_1, feature_2 in zip(event_1.features, event_2.features)
         ]
 
         self.add_output(

--- a/temporian/core/operators/arithmetic.py
+++ b/temporian/core/operators/arithmetic.py
@@ -176,7 +176,7 @@ def sum(
         event_2=event_2,
         operation=ArithmeticOperation.ADDITION,
         resolution=resolution,
-    ).outputs()["event"]
+    ).outputs["event"]
 
 
 def substract(
@@ -204,7 +204,7 @@ def substract(
         event_2=event_2,
         operation=ArithmeticOperation.SUBTRACTION,
         resolution=resolution,
-    ).outputs()["event"]
+    ).outputs["event"]
 
 
 def multiply(
@@ -232,7 +232,7 @@ def multiply(
         event_2=event_2,
         operation=ArithmeticOperation.MULTIPLICATION,
         resolution=resolution,
-    ).outputs()["event"]
+    ).outputs["event"]
 
 
 def divide(
@@ -260,4 +260,4 @@ def divide(
         event_2=denominator,
         operation=ArithmeticOperation.DIVISION,
         resolution=resolution,
-    ).outputs()["event"]
+    ).outputs["event"]

--- a/temporian/core/operators/base.py
+++ b/temporian/core/operators/base.py
@@ -61,17 +61,50 @@ class Operator(ABC):
     def __str__(self):
         return (
             f"Operator<key: {self.definition().key}, id: {id(self)},"
-            f" attributes: {self.attributes()}>"
+            f" attributes: {self.attributes}>"
         )
 
-    def outputs(self) -> dict[str, Event]:
-        return self._outputs
+    @property
+    def attributes(self) -> dict[str, Any]:
+        return self._attributes
 
+    @property
     def inputs(self) -> dict[str, Event]:
         return self._inputs
 
-    def attributes(self) -> dict[str, Any]:
-        return self._attributes
+    @property
+    def outputs(self) -> dict[str, Event]:
+        return self._outputs
+
+    @attributes.setter
+    def attributes(self, attributes: dict[str, Any]):
+        self._attributes = attributes
+
+    @inputs.setter
+    def inputs(self, inputs: dict[str, Event]):
+        self._inputs = inputs
+
+    @outputs.setter
+    def outputs(self, outputs: dict[str, Event]):
+        self._outputs = outputs
+
+    def add_input(self, key: str, event: Event) -> None:
+        with OperatorExceptionDecorator(self):
+            if key in self.inputs:
+                raise ValueError(f'Already existing input "{key}".')
+            self.inputs[key] = event
+
+    def add_output(self, key: str, event: Event) -> None:
+        with OperatorExceptionDecorator(self):
+            if key in self.outputs:
+                raise ValueError(f'Already existing output "{key}".')
+            self.outputs[key] = event
+
+    def add_attribute(self, key: str, value: Any) -> None:
+        with OperatorExceptionDecorator(self):
+            if key in self.attributes:
+                raise ValueError(f'Already existing attribute "{key}".')
+            self.attributes[key] = value
 
     def check(self) -> None:
         """Ensures that the operator is valid."""
@@ -102,43 +135,16 @@ class Operator(ABC):
                 if available_output not in [v.key for v in definition.outputs]:
                     raise ValueError(f'Unexpected output "{available_output}".')
 
-    def add_input(self, key: str, event: Event) -> None:
-        with OperatorExceptionDecorator(self):
-            if key in self._inputs:
-                raise ValueError(f'Already existing input "{key}".')
-            self._inputs[key] = event
-
-    def add_output(self, key: str, event: Event) -> None:
-        with OperatorExceptionDecorator(self):
-            if key in self._outputs:
-                raise ValueError(f'Already existing output "{key}".')
-            self._outputs[key] = event
-
-    def add_attribute(self, key: str, value: Any) -> None:
-        with OperatorExceptionDecorator(self):
-            if key in self._attributes:
-                raise ValueError(f'Already existing attribute "{key}".')
-            self._attributes[key] = value
-
     @classmethod
     def build_op_definition(cls) -> pb.OperatorDef:
         raise NotImplementedError()
 
     def definition(self):
-        return self.__class__.build_op_definition()
+        return self.build_op_definition()
 
     @classmethod
-    def operator_key(cls):
+    def operator_key(cls) -> str:
         return cls.build_op_definition().key
-
-    def set_inputs(self, inputs: dict[str, Event]) -> None:
-        self._inputs = inputs
-
-    def set_outputs(self, outputs: dict[str, Event]) -> None:
-        self._outputs = outputs
-
-    def set_attributes(self, attributes: dict[str, Event]) -> None:
-        self._attributes = attributes
 
     def list_matching_io_samplings(self) -> list[tuple[str, str]]:
         """List pairs of input/output pairs with the same sampling.

--- a/temporian/core/operators/base.py
+++ b/temporian/core/operators/base.py
@@ -152,7 +152,7 @@ class Operator(ABC):
         matches: list[tuple[str, str]] = []
         for output_key, output_value in self._outputs.items():
             for input_key, input_value in self._inputs.items():
-                if output_value.sampling() is input_value.sampling():
+                if output_value.sampling is input_value.sampling:
                     matches.append((input_key, output_key))
 
         return matches

--- a/temporian/core/operators/calendar/base.py
+++ b/temporian/core/operators/calendar/base.py
@@ -31,7 +31,7 @@ class BaseCalendarOperator(Operator, ABC):
     def __init__(self, sampling: Event):
         super().__init__()
 
-        if not sampling.sampling().is_unix_timestamp():
+        if not sampling.sampling.is_unix_timestamp:
             raise ValueError(
                 "Calendar operators can only be applied on events with unix"
                 " timestamps as sampling. This can be specified with"
@@ -44,7 +44,7 @@ class BaseCalendarOperator(Operator, ABC):
         output_feature = Feature(
             name=self.output_feature_name,
             dtype=dtype.INT32,
-            sampling=sampling.sampling(),
+            sampling=sampling.sampling,
             creator=self,
         )
 
@@ -53,7 +53,7 @@ class BaseCalendarOperator(Operator, ABC):
             "event",
             Event(
                 features=[output_feature],
-                sampling=sampling.sampling(),
+                sampling=sampling.sampling,
                 creator=self,
             ),
         )

--- a/temporian/core/operators/calendar/day_of_month.py
+++ b/temporian/core/operators/calendar/day_of_month.py
@@ -51,4 +51,4 @@ def calendar_day_of_month(sampling: Event) -> Event:
             each timestamp in `event`'s sampling belongs to, with the same
             sampling as `event`.
     """
-    return CalendarDayOfMonthOperator(sampling).outputs()["event"]
+    return CalendarDayOfMonthOperator(sampling).outputs["event"]

--- a/temporian/core/operators/calendar/day_of_week.py
+++ b/temporian/core/operators/calendar/day_of_week.py
@@ -51,4 +51,4 @@ def calendar_day_of_week(sampling: Event) -> Event:
             each timestamp in `event`'s sampling belongs to, with the same
             sampling as `event`.
     """
-    return CalendarDayOfWeekOperator(sampling).outputs()["event"]
+    return CalendarDayOfWeekOperator(sampling).outputs["event"]

--- a/temporian/core/operators/calendar/day_of_year.py
+++ b/temporian/core/operators/calendar/day_of_year.py
@@ -51,4 +51,4 @@ def calendar_day_of_year(sampling: Event) -> Event:
             each timestamp in `event`'s sampling belongs to, with the same
             sampling as `event`.
     """
-    return CalendarDayOfYearOperator(sampling).outputs()["event"]
+    return CalendarDayOfYearOperator(sampling).outputs["event"]

--- a/temporian/core/operators/calendar/hour.py
+++ b/temporian/core/operators/calendar/hour.py
@@ -50,4 +50,4 @@ def calendar_hour(sampling: Event) -> Event:
         event with a single feature corresponding to the hour each timestamp in
             `event`'s sampling belongs to, with the same sampling as `event`.
     """
-    return CalendarHourOperator(sampling).outputs()["event"]
+    return CalendarHourOperator(sampling).outputs["event"]

--- a/temporian/core/operators/calendar/iso_week.py
+++ b/temporian/core/operators/calendar/iso_week.py
@@ -50,4 +50,4 @@ def calendar_iso_week(sampling: Event) -> Event:
         event with a single feature corresponding to the ISO week each timestamp
             in `event`'s sampling belongs to, with the same sampling as `event`.
     """
-    return CalendarISOWeekOperator(sampling).outputs()["event"]
+    return CalendarISOWeekOperator(sampling).outputs["event"]

--- a/temporian/core/operators/calendar/minute.py
+++ b/temporian/core/operators/calendar/minute.py
@@ -50,4 +50,4 @@ def calendar_minute(sampling: Event) -> Event:
         event with a single feature corresponding to the minute each timestamp
             in `event`'s sampling belongs to, with the same sampling as `event`.
     """
-    return CalendarMinuteOperator(sampling).outputs()["event"]
+    return CalendarMinuteOperator(sampling).outputs["event"]

--- a/temporian/core/operators/calendar/month.py
+++ b/temporian/core/operators/calendar/month.py
@@ -50,4 +50,4 @@ def calendar_month(sampling: Event) -> Event:
         event with a single feature corresponding to the month each timestamp in
             `event`'s sampling belongs to, with the same sampling as `event`.
     """
-    return CalendarMonthOperator(sampling).outputs()["event"]
+    return CalendarMonthOperator(sampling).outputs["event"]

--- a/temporian/core/operators/calendar/second.py
+++ b/temporian/core/operators/calendar/second.py
@@ -50,4 +50,4 @@ def calendar_second(sampling: Event) -> Event:
         event with a single feature corresponding to the second each timestamp
             in `event`'s sampling belongs to, with the same sampling as `event`.
     """
-    return CalendarSecondOperator(sampling).outputs()["event"]
+    return CalendarSecondOperator(sampling).outputs["event"]

--- a/temporian/core/operators/calendar/year.py
+++ b/temporian/core/operators/calendar/year.py
@@ -49,4 +49,4 @@ def calendar_year(sampling: Event) -> Event:
         event with a single feature corresponding to the year each timestamp in
             `event`'s sampling belongs to, with the same sampling as `event`.
     """
-    return CalendarYearOperator(sampling).outputs()["event"]
+    return CalendarYearOperator(sampling).outputs["event"]

--- a/temporian/core/operators/glue.py
+++ b/temporian/core/operators/glue.py
@@ -127,4 +127,4 @@ def glue(
 
     # Note: The event should be called "event_{idx}" with idx in [0, MAX_NUM_ARGUMENTS).
     dict_events = {f"event_{idx}": event for idx, event in enumerate(events)}
-    return GlueOperator(**dict_events).outputs()["event"]
+    return GlueOperator(**dict_events).outputs["event"]

--- a/temporian/core/operators/glue.py
+++ b/temporian/core/operators/glue.py
@@ -52,19 +52,18 @@ class GlueOperator(Operator):
         first_sampling = None
         for key, event in dict_events.items():
             self.add_input(key, event)
-            output_features.extend(event.features())
+            output_features.extend(event.features)
 
-            for f in event.features():
-                if f.name() in feature_names:
+            for f in event.features:
+                if f.name in feature_names:
                     raise ValueError(
-                        f"Feature {f.name()} is defined in multiple "
-                        "input events."
+                        f"Feature {f.name} is defined in multiple input events."
                     )
-                feature_names.add(f.name())
+                feature_names.add(f.name)
 
             if first_sampling is None:
-                first_sampling = event.sampling()
-            elif event.sampling() is not first_sampling:
+                first_sampling = event.sampling
+            elif event.sampling is not first_sampling:
                 raise ValueError(
                     "All the events do not have the same sampling."
                 )

--- a/temporian/core/operators/lag.py
+++ b/temporian/core/operators/lag.py
@@ -41,7 +41,7 @@ class LagOperator(Operator):
 
         self.add_attribute("duration", duration)
 
-        output_sampling = Sampling(index=event.sampling().index(), creator=self)
+        output_sampling = Sampling(index=event.sampling.index, creator=self)
 
         prefix = "lag" if duration > 0 else "leak"
         duration_str = duration_abbreviation(duration)
@@ -49,12 +49,12 @@ class LagOperator(Operator):
         # outputs
         output_features = [  # pylint: disable=g-complex-comprehension
             Feature(
-                name=f"{prefix}[{duration_str}]_{f.name()}",
-                dtype=f.dtype(),
+                name=f"{prefix}[{duration_str}]_{f.name}",
+                dtype=f.dtype,
                 sampling=output_sampling,
                 creator=self,
             )
-            for f in event.features()
+            for f in event.features
         ]
 
         self.add_output(

--- a/temporian/core/operators/lag.py
+++ b/temporian/core/operators/lag.py
@@ -114,10 +114,10 @@ def _implementation(
         return LagOperator(
             event=event,
             duration=used_duration[0],
-        ).outputs()["event"]
+        ).outputs["event"]
 
     return [
-        LagOperator(event=event, duration=d).outputs()["event"]
+        LagOperator(event=event, duration=d).outputs["event"]
         for d in used_duration
     ]
 

--- a/temporian/core/operators/prefix.py
+++ b/temporian/core/operators/prefix.py
@@ -40,19 +40,19 @@ class Prefix(Operator):
         # new one.
         output_features = [  # pylint: disable=g-complex-comprehension
             Feature(
-                name=prefix + f.name(),
-                dtype=f.dtype(),
-                sampling=event.sampling(),
+                name=prefix + f.name,
+                dtype=f.dtype,
+                sampling=event.sampling,
                 creator=self,
             )
-            for f in event.features()
+            for f in event.features
         ]
 
         self.add_output(
             "event",
             Event(
                 features=output_features,
-                sampling=event.sampling(),
+                sampling=event.sampling,
                 creator=self,
             ),
         )

--- a/temporian/core/operators/prefix.py
+++ b/temporian/core/operators/prefix.py
@@ -60,7 +60,7 @@ class Prefix(Operator):
         self.check()
 
     def prefix(self):
-        return self.attributes()["prefix"]
+        return self.attributes["prefix"]
 
     @classmethod
     def build_op_definition(cls) -> pb.OperatorDef:
@@ -108,4 +108,4 @@ def prefix(
         Prefixed event.
     """
 
-    return Prefix(prefix=prefix, event=event).outputs()["event"]
+    return Prefix(prefix=prefix, event=event).outputs["event"]

--- a/temporian/core/operators/propagate.py
+++ b/temporian/core/operators/propagate.py
@@ -155,4 +155,4 @@ def propagate(
     return Propagate(
         event=event,
         to=to,
-    ).outputs()["event"]
+    ).outputs["event"]

--- a/temporian/core/operators/propagate.py
+++ b/temporian/core/operators/propagate.py
@@ -40,16 +40,16 @@ class Propagate(Operator):
 
         # TODO: Constraint the type of features supported in "add_event".
 
-        if event.sampling() != to.sampling():
+        if event.sampling != to.sampling:
             raise ValueError("event and to should have the same sampling")
 
-        if len(to.features()) == 0:
+        if len(to.features) == 0:
             raise ValueError("to contains no features")
 
-        self._added_index = [k.name() for k in to.features()]
+        self._added_index = [k.name for k in to.features]
 
         overlap_features = set(self._added_index).intersection(
-            event.sampling().index()
+            event.sampling.index
         )
         if len(overlap_features) > 0:
             raise ValueError(
@@ -57,17 +57,17 @@ class Propagate(Operator):
                 f" index: {list(overlap_features)}"
             )
 
-        new_index = event.sampling().index() + self._added_index
+        new_index = event.sampling.index + self._added_index
         sampling = Sampling(index=new_index, creator=self)
 
         output_features = [  # pylint: disable=g-complex-comprehension
             Feature(
-                name=f.name(),
-                dtype=f.dtype(),
+                name=f.name,
+                dtype=f.dtype,
                 sampling=sampling,
                 creator=self,
             )
-            for f in event.features()
+            for f in event.features
         ]
 
         self.add_output(
@@ -148,7 +148,7 @@ def propagate(
         to_set = set(to)
         to = select(event, to)
         remaining_features = [
-            f.name() for f in event.features() if f.name not in to_set
+            f.name for f in event.features if f.name not in to_set
         ]
         event = select(event, remaining_features)
 

--- a/temporian/core/operators/sample.py
+++ b/temporian/core/operators/sample.py
@@ -105,4 +105,4 @@ def sample(
         A sampled event.
     """
 
-    return Sample(event=event, sampling=sampling).outputs()["event"]
+    return Sample(event=event, sampling=sampling).outputs["event"]

--- a/temporian/core/operators/sample.py
+++ b/temporian/core/operators/sample.py
@@ -38,19 +38,19 @@ class Sample(Operator):
 
         output_features = [  # pylint: disable=g-complex-comprehension
             Feature(
-                name=f.name(),
-                dtype=f.dtype(),
-                sampling=sampling.sampling(),
+                name=f.name,
+                dtype=f.dtype,
+                sampling=sampling.sampling,
                 creator=self,
             )
-            for f in event.features()
+            for f in event.features
         ]
 
         self.add_output(
             "event",
             Event(
                 features=output_features,
-                sampling=sampling.sampling(),
+                sampling=sampling.sampling,
                 creator=self,
             ),
         )

--- a/temporian/core/operators/select.py
+++ b/temporian/core/operators/select.py
@@ -40,9 +40,7 @@ class SelectOperator(Operator):
 
         # verify all selected features exist in the input event
         selected_features_set = set(feature_names)
-        event_features_set = set(
-            [feature.name() for feature in event.features()]
-        )
+        event_features_set = set([feature.name for feature in event.features])
         if not set(selected_features_set).issubset(event_features_set):
             raise KeyError(selected_features_set.difference(event_features_set))
 
@@ -52,13 +50,13 @@ class SelectOperator(Operator):
         # outputs
         output_features = []
         for feature_name in feature_names:
-            for feature in event.features():
+            for feature in event.features:
                 # TODO: maybe implement features attributes of Event as dict
                 # so we can index by name?
-                if feature.name() == feature_name:
+                if feature.name == feature_name:
                     output_features.append(feature)
 
-        output_sampling = event.sampling()
+        output_sampling = event.sampling
         self.add_output(
             "event",
             Event(

--- a/temporian/core/operators/select.py
+++ b/temporian/core/operators/select.py
@@ -103,4 +103,4 @@ def select(
             f" str. Got '{feature_names}' instead."
         )
 
-    return SelectOperator(event, feature_names).outputs()["event"]
+    return SelectOperator(event, feature_names).outputs["event"]

--- a/temporian/core/operators/window/base.py
+++ b/temporian/core/operators/window/base.py
@@ -44,21 +44,21 @@ class BaseWindowOperator(Operator, ABC):
 
         if sampling is not None:
             self.add_input("sampling", sampling)
-            effective_sampling = sampling.sampling()
+            effective_sampling = sampling.sampling
         else:
-            effective_sampling = event.sampling()
+            effective_sampling = event.sampling
 
         self.add_input("event", event)
 
         # TODO: Remve auto prefix
         output_features = [  # pylint: disable=g-complex-comprehension
             Feature(
-                name=f"{self.prefix}_{f.name()}",
+                name=f"{self.prefix}_{f.name}",
                 dtype=self.get_feature_dtype(f),
                 sampling=effective_sampling,
                 creator=self,
             )
-            for f in event.features()
+            for f in event.features
         ]
 
         # output

--- a/temporian/core/operators/window/base.py
+++ b/temporian/core/operators/window/base.py
@@ -73,7 +73,8 @@ class BaseWindowOperator(Operator, ABC):
 
         self.check()
 
-    def window_length(self):
+    @property
+    def window_length(self) -> Duration:
         return self._window_length
 
     @classmethod

--- a/temporian/core/operators/window/moving_count.py
+++ b/temporian/core/operators/window/moving_count.py
@@ -86,4 +86,4 @@ def moving_count(
         event=event,
         window_length=window_length,
         sampling=sampling,
-    ).outputs()["event"]
+    ).outputs["event"]

--- a/temporian/core/operators/window/moving_standard_deviation.py
+++ b/temporian/core/operators/window/moving_standard_deviation.py
@@ -88,4 +88,4 @@ def moving_standard_deviation(
         event=event,
         window_length=window_length,
         sampling=sampling,
-    ).outputs()["event"]
+    ).outputs["event"]

--- a/temporian/core/operators/window/moving_standard_deviation.py
+++ b/temporian/core/operators/window/moving_standard_deviation.py
@@ -48,7 +48,7 @@ class MovingStandardDeviationOperator(BaseWindowOperator):
         Returns:
             str: The dtype of the output feature.
         """
-        return FLOAT32 if feature.dtype() == FLOAT32 else FLOAT64
+        return FLOAT32 if feature.dtype == FLOAT32 else FLOAT64
 
 
 operator_lib.register_operator(MovingStandardDeviationOperator)

--- a/temporian/core/operators/window/moving_sum.py
+++ b/temporian/core/operators/window/moving_sum.py
@@ -46,7 +46,7 @@ class MovingSumOperator(BaseWindowOperator):
         Returns:
             str: The dtype of the output feature.
         """
-        return feature.dtype()
+        return feature.dtype
 
 
 operator_lib.register_operator(MovingSumOperator)

--- a/temporian/core/operators/window/moving_sum.py
+++ b/temporian/core/operators/window/moving_sum.py
@@ -84,4 +84,4 @@ def moving_sum(
         event=event,
         window_length=window_length,
         sampling=sampling,
-    ).outputs()["event"]
+    ).outputs["event"]

--- a/temporian/core/operators/window/simple_moving_average.py
+++ b/temporian/core/operators/window/simple_moving_average.py
@@ -48,7 +48,7 @@ class SimpleMovingAverageOperator(BaseWindowOperator):
         Returns:
             str: The dtype of the output feature.
         """
-        return FLOAT32 if feature.dtype() == FLOAT32 else FLOAT64
+        return FLOAT32 if feature.dtype == FLOAT32 else FLOAT64
 
 
 operator_lib.register_operator(SimpleMovingAverageOperator)

--- a/temporian/core/operators/window/simple_moving_average.py
+++ b/temporian/core/operators/window/simple_moving_average.py
@@ -87,4 +87,4 @@ def simple_moving_average(
         event=event,
         window_length=window_length,
         sampling=sampling,
-    ).outputs()["event"]
+    ).outputs["event"]

--- a/temporian/core/processor.py
+++ b/temporian/core/processor.py
@@ -35,13 +35,13 @@ def normalize_multiple_event_arg(src: MultipleEventArg) -> Dict[str, Event]:
     if isinstance(src, list):
         new_src = {}
         for event in src:
-            if event.name() is None:
+            if event.name is None:
                 raise ValueError(
                     "Input / output event or list events need to be named "
-                    'with "set_name(...)". Alternatively, provide a '
+                    'with "event.name = ...". Alternatively, provide a '
                     "dictionary of events."
                 )
-            new_src[event.name()] = event
+            new_src[event.name] = event
         src = new_src
 
     if not isinstance(src, dict):
@@ -103,11 +103,11 @@ class Preprocessor(object):
         return {
             feature
             for event in self.inputs().values()
-            for feature in event.features()
+            for feature in event.features
         }
 
     def input_samplings(self) -> Set[Sampling]:
-        return {event.sampling() for event in self.inputs().values()}
+        return {event.sampling for event in self.inputs().values()}
 
     def __repr__(self):
         s = "Preprocessor\n============\n"
@@ -202,16 +202,16 @@ def infer_processor(
             # The feature is provided by the user.
             continue
 
-        if event.creator() is None:
+        if event.creator is None:
             # The event does not have a source.
             missing_events.add(event)
             continue
 
         # Record the operator.
-        p.add_operator(event.creator())
+        p.add_operator(event.creator)
 
         # Add the parent events to the pending list.
-        for input_event in event.creator().inputs().values():
+        for input_event in event.creator.inputs().values():
             if input_event in done_events:
                 # Already processed.
                 continue
@@ -220,16 +220,16 @@ def infer_processor(
 
         # Record the operator outputs. While the user did not request
         # them, they will be created (and so, we need to track them).
-        for output_event in event.creator().outputs().values():
+        for output_event in event.creator.outputs().values():
             p.add_event(output_event)
 
     if inputs is None:
         # Infer the inputs
         infered_inputs: Dict[str, Event] = {}
         for event in missing_events:
-            if event.name() is None:
+            if event.name is None:
                 raise ValueError(f"Cannot infer input on unnamed event {event}")
-            infered_inputs[event.name()] = event
+            infered_inputs[event.name] = event
         p.set_inputs(infered_inputs)
 
     else:
@@ -242,8 +242,8 @@ def infer_processor(
 
     # Record all the features and samplings.
     for e in p.events():
-        p.add_sampling(e.sampling())
-        for f in e.features():
+        p.add_sampling(e.sampling)
+        for f in e.features:
             p.add_feature(f)
 
     return p

--- a/temporian/core/serialize.py
+++ b/temporian/core/serialize.py
@@ -132,18 +132,18 @@ def unserialize(src: pb.Processor) -> processor.Preprocessor:
 
     for src_event in src.events:
         if src_event.creator_operator_id:
-            events[src_event.id].set_creator(
-                get_creator(src_event.creator_operator_id)
+            events[src_event.id].creator = get_creator(
+                src_event.creator_operator_id
             )
     for src_feature in src.features:
         if src_feature.creator_operator_id:
-            features[src_feature.id].set_creator(
-                get_creator(src_feature.creator_operator_id)
+            features[src_feature.id].creator = get_creator(
+                src_feature.creator_operator_id
             )
     for src_sampling in src.samplings:
         if src_sampling.creator_operator_id:
-            samplings[src_sampling.id].set_creator(
-                get_creator(src_sampling.creator_operator_id)
+            samplings[src_sampling.id].creator = get_creator(
+                src_sampling.creator_operator_id
             )
 
     # Copy extracted items.
@@ -252,11 +252,11 @@ def _unserialize_operator(
 def _serialize_event(src: Event) -> pb.Event:
     return pb.Event(
         id=_identifier(src),
-        sampling_id=_identifier(src.sampling()),
-        feature_ids=[_identifier(f) for f in src.features()],
-        name=src.name(),
+        sampling_id=_identifier(src.sampling),
+        feature_ids=[_identifier(f) for f in src.features],
+        name=src.name,
         creator_operator_id=(
-            _identifier(src.creator()) if src.creator() is not None else None
+            _identifier(src.creator) if src.creator is not None else None
         ),
     )
 
@@ -283,11 +283,11 @@ def _unserialize_event(
 def _serialize_feature(src: Feature) -> pb.Feature:
     return pb.Feature(
         id=_identifier(src),
-        name=src.name(),
-        dtype=_serialize_dtype(src.dtype()),
-        sampling_id=_identifier(src.sampling()),
+        name=src.name,
+        dtype=_serialize_dtype(src.dtype),
+        sampling_id=_identifier(src.sampling),
         creator_operator_id=(
-            _identifier(src.creator()) if src.creator() is not None else None
+            _identifier(src.creator) if src.creator is not None else None
         ),
     )
 
@@ -309,9 +309,9 @@ def _unserialize_feature(
 def _serialize_sampling(src: Sampling) -> pb.Sampling:
     return pb.Sampling(
         id=_identifier(src),
-        index=src.index(),
+        index=src.index,
         creator_operator_id=(
-            _identifier(src.creator()) if src.creator() is not None else None
+            _identifier(src.creator) if src.creator is not None else None
         ),
     )
 

--- a/temporian/core/serialize.py
+++ b/temporian/core/serialize.py
@@ -85,8 +85,8 @@ def load(
         proto = text_format.Parse(f.read(), pb.Processor())
     p = unserialize(proto)
 
-    inputs = p.inputs()
-    outputs = p.outputs()
+    inputs = p.inputs
+    outputs = p.outputs
 
     if squeeze and len(inputs) == 1:
         inputs = list(inputs.values())[0]
@@ -101,14 +101,12 @@ def serialize(src: processor.Preprocessor) -> pb.Processor:
     """Serializes a processor into an equivalent protobuffer."""
 
     return pb.Processor(
-        operators=[_serialize_operator(o) for o in src.operators()],
-        events=[_serialize_event(e) for e in src.events()],
-        features=[_serialize_feature(f) for f in src.features()],
-        samplings=[_serialize_sampling(s) for s in src.samplings()],
-        inputs=[_serialize_io_signature(k, e) for k, e in src.inputs().items()],
-        outputs=[
-            _serialize_io_signature(k, e) for k, e in src.outputs().items()
-        ],
+        operators=[_serialize_operator(o) for o in src.operators],
+        events=[_serialize_event(e) for e in src.events],
+        features=[_serialize_feature(f) for f in src.features],
+        samplings=[_serialize_sampling(s) for s in src.samplings],
+        inputs=[_serialize_io_signature(k, e) for k, e in src.inputs.items()],
+        outputs=[_serialize_io_signature(k, e) for k, e in src.outputs.items()],
     )
 
 
@@ -149,13 +147,13 @@ def unserialize(src: pb.Processor) -> processor.Preprocessor:
     # Copy extracted items.
     p = processor.Preprocessor()
     for sampling in samplings.values():
-        p.samplings().add(sampling)
+        p.samplings.add(sampling)
     for event in events.values():
-        p.events().add(event)
+        p.events.add(event)
     for feature in features.values():
-        p.features().add(feature)
+        p.features.add(feature)
     for operator in operators.values():
-        p.operators().add(operator)
+        p.operators.add(operator)
 
     # IO Signature
     def get_event(event_id: str) -> Event:
@@ -164,10 +162,10 @@ def unserialize(src: pb.Processor) -> processor.Preprocessor:
         return events[event_id]
 
     for item in src.inputs:
-        p.inputs()[item.key] = get_event(item.event_id)
+        p.inputs[item.key] = get_event(item.event_id)
 
     for item in src.outputs:
-        p.outputs()[item.key] = get_event(item.event_id)
+        p.outputs[item.key] = get_event(item.event_id)
 
     return p
 
@@ -190,14 +188,14 @@ def _serialize_operator(src: base.Operator) -> pb.Operator:
         operator_def_key=src.definition().key,
         inputs=[
             pb.Operator.EventArgument(key=k, event_id=_identifier(v))
-            for k, v in src.inputs().items()
+            for k, v in src.inputs.items()
         ],
         outputs=[
             pb.Operator.EventArgument(key=k, event_id=_identifier(v))
-            for k, v in src.outputs().items()
+            for k, v in src.outputs.items()
         ],
         attributes=[
-            _attribute_to_proto(k, v) for k, v in src.attributes().items()
+            _attribute_to_proto(k, v) for k, v in src.attributes.items()
         ],
     )
 
@@ -220,32 +218,32 @@ def _unserialize_operator(
     op = operator_class(**input_args, **attribute_args)
 
     # Check that the operator signature matches the expected one.
-    if op.inputs().keys() != input_args.keys():
+    if op.inputs.keys() != input_args.keys():
         raise ValueError(
             f"Restoring the operator {src.operator_def_key} lead "
             "to an unexpected input signature. "
-            f"Expected: {input_args.keys()} Effective: {op.inputs().keys()}"
+            f"Expected: {input_args.keys()} Effective: {op.inputs.keys()}"
         )
 
-    if op.outputs().keys() != output_args.keys():
+    if op.outputs.keys() != output_args.keys():
         raise ValueError(
             f"Restoring the operator {src.operator_def_key} lead "
             "to an unexpected output signature. "
-            f"Expected: {output_args.keys()} Effective: {op.outputs().keys()}"
+            f"Expected: {output_args.keys()} Effective: {op.outputs.keys()}"
         )
 
-    if op.attributes().keys() != attribute_args.keys():
+    if op.attributes.keys() != attribute_args.keys():
         raise ValueError(
             f"Restoring the operator {src.operator_def_key} lead to an"
             " unexpected attributes signature. Expected:"
-            f" {attribute_args.keys()} Effective: {op.attributes().keys()}"
+            f" {attribute_args.keys()} Effective: {op.attributes.keys()}"
         )
     # TODO: Deep check of equality of the inputs / outputs / attributes
 
     # Override the inputs / outputs / attributes
-    op.set_inputs(input_args)
-    op.set_outputs(output_args)
-    op.set_attributes(attribute_args)
+    op.inputs = input_args
+    op.outputs = output_args
+    op.attributes = attribute_args
     return op
 
 

--- a/temporian/core/serialize.py
+++ b/temporian/core/serialize.py
@@ -215,7 +215,7 @@ def _unserialize_operator(
     attribute_args = {x.key: _attribute_from_proto(x) for x in src.attributes}
 
     # We construct the operator.
-    op = operator_class(**input_args, **attribute_args)
+    op: base.Operator = operator_class(**input_args, **attribute_args)
 
     # Check that the operator signature matches the expected one.
     if op.inputs.keys() != input_args.keys():

--- a/temporian/core/test/evaluator_test.py
+++ b/temporian/core/test/evaluator_test.py
@@ -26,7 +26,7 @@ class EvaluatorTest(absltest.TestCase):
 
         schedule = evaluator.build_schedule(
             inputs=[a],
-            outputs=[b.outputs()["output"]],
+            outputs=[b.outputs["output"]],
         )
         self.assertEqual(schedule, [b])
 
@@ -44,10 +44,10 @@ class EvaluatorTest(absltest.TestCase):
         i2 = utils.create_input_event()
         o1 = utils.OpI1O1(i1)
         o2 = utils.OpI1O1(i2)
-        o3 = utils.OpI2O1(o1.outputs()["output"], o2.outputs()["output"])
+        o3 = utils.OpI2O1(o1.outputs["output"], o2.outputs["output"])
         schedule = evaluator.build_schedule(
             inputs=[i1, i2],
-            outputs=[o3.outputs()["output"]],
+            outputs=[o3.outputs["output"]],
         )
         self.assertTrue(
             (schedule == [o2, o1, o3]) or (schedule == [o1, o2, o3])
@@ -57,12 +57,12 @@ class EvaluatorTest(absltest.TestCase):
         i1 = utils.create_input_event()
         o2 = utils.OpI1O1(i1)
         i3 = utils.create_input_event()
-        o4 = utils.OpI2O1(o2.outputs()["output"], i3)
-        o5 = utils.OpI1O2(o4.outputs()["output"])
+        o4 = utils.OpI2O1(o2.outputs["output"], i3)
+        o5 = utils.OpI1O2(o4.outputs["output"])
 
         schedule = evaluator.build_schedule(
             inputs=[i1, i3],
-            outputs=[o5.outputs()["output_1"], o4.outputs()["output"]],
+            outputs=[o5.outputs["output_1"], o4.outputs["output"]],
         )
         self.assertTrue(
             (schedule == [o2, o4, o5]) or (schedule == [o4, o2, o5])
@@ -71,13 +71,13 @@ class EvaluatorTest(absltest.TestCase):
     def test_schedule_mid_chain(self):
         i1 = utils.create_input_event()
         o2 = utils.OpI1O1(i1)
-        o3 = utils.OpI1O1(o2.outputs()["output"])
-        o4 = utils.OpI1O1(o3.outputs()["output"])
-        o5 = utils.OpI1O1(o4.outputs()["output"])
+        o3 = utils.OpI1O1(o2.outputs["output"])
+        o4 = utils.OpI1O1(o3.outputs["output"])
+        o5 = utils.OpI1O1(o4.outputs["output"])
 
         schedule = evaluator.build_schedule(
-            inputs=[o3.outputs()["output"]],
-            outputs=[o5.outputs()["output"]],
+            inputs=[o3.outputs["output"]],
+            outputs=[o5.outputs["output"]],
         )
         self.assertEqual(schedule, [o4, o5])
 

--- a/temporian/core/test/processor_test.py
+++ b/temporian/core/test/processor_test.py
@@ -94,10 +94,10 @@ class ProcessorTest(absltest.TestCase):
         """Infer automatically the input."""
 
         i1 = utils.create_input_event()
-        i1.set_name("io_input_1")
+        i1.name = "io_input_1"
         o2 = utils.OpI1O1(i1)
         i3 = utils.create_input_event()
-        i3.set_name("io_input_2")
+        i3.name = "io_input_2"
         o4 = utils.OpI2O1(o2.outputs()["output"], i3)
         o5 = utils.OpI1O2(o4.outputs()["output"])
 
@@ -131,7 +131,7 @@ class ProcessorTest(absltest.TestCase):
         """Automated inference when the input is the same as the output."""
 
         i1 = utils.create_input_event()
-        i1.set_name("io_1")
+        i1.name = "io_1"
 
         p = processor.infer_processor(None, {"io_2": i1})
 

--- a/temporian/core/test/processor_test.py
+++ b/temporian/core/test/processor_test.py
@@ -26,8 +26,8 @@ class ProcessorTest(absltest.TestCase):
         i1 = utils.create_input_event()
         o2 = utils.OpI1O1(i1)
         i3 = utils.create_input_event()
-        o4 = utils.OpI2O1(o2.outputs()["output"], i3)
-        o5 = utils.OpI1O2(o4.outputs()["output"])
+        o4 = utils.OpI2O1(o2.outputs["output"], i3)
+        o5 = utils.OpI1O2(o4.outputs["output"])
 
         p = processor.infer_processor(
             {
@@ -35,48 +35,48 @@ class ProcessorTest(absltest.TestCase):
                 "io_input_2": i3,
             },
             {
-                "io_output_1": o5.outputs()["output_1"],
-                "io_output_2": o4.outputs()["output"],
+                "io_output_1": o5.outputs["output_1"],
+                "io_output_2": o4.outputs["output"],
             },
         )
-        self.assertLen(p.operators(), 3)
-        self.assertLen(p.samplings(), 3)
-        self.assertLen(p.events(), 6)
-        self.assertLen(p.features(), 10)
+        self.assertLen(p.operators, 3)
+        self.assertLen(p.samplings, 3)
+        self.assertLen(p.events, 6)
+        self.assertLen(p.features, 10)
 
     def test_infer_processor_passing_op(self):
         """With an opt that just passes features."""
 
         a = utils.create_input_event()
         b = utils.OpI1O1NotCreator(a)
-        c = utils.OpI1O1(b.outputs()["output"])
+        c = utils.OpI1O1(b.outputs["output"])
 
         p = processor.infer_processor(
             {"my_input": a},
-            {"my_output": c.outputs()["output"]},
+            {"my_output": c.outputs["output"]},
         )
 
-        self.assertLen(p.operators(), 2)
-        self.assertLen(p.samplings(), 2)
-        self.assertLen(p.events(), 3)
-        self.assertLen(p.features(), 4)
+        self.assertLen(p.operators, 2)
+        self.assertLen(p.samplings, 2)
+        self.assertLen(p.events, 3)
+        self.assertLen(p.features, 4)
 
     def test_infer_processor_input_is_not_feature_creator(self):
         """When the user input is not the feature creator."""
 
         a = utils.create_input_event()
         b = utils.OpI1O1NotCreator(a)
-        c = utils.OpI1O1(b.outputs()["output"])
+        c = utils.OpI1O1(b.outputs["output"])
 
         p = processor.infer_processor(
-            {"my_input": b.outputs()["output"]},
-            {"my_output": c.outputs()["output"]},
+            {"my_input": b.outputs["output"]},
+            {"my_output": c.outputs["output"]},
         )
 
-        self.assertLen(p.operators(), 1)
-        self.assertLen(p.samplings(), 2)
-        self.assertLen(p.events(), 2)
-        self.assertLen(p.features(), 4)
+        self.assertLen(p.operators, 1)
+        self.assertLen(p.samplings, 2)
+        self.assertLen(p.events, 2)
+        self.assertLen(p.features, 4)
 
     def test_infer_processor_missing_input(self):
         """The input is missing."""
@@ -88,7 +88,7 @@ class ProcessorTest(absltest.TestCase):
             ValueError,
             "but not provided as input",
         ):
-            processor.infer_processor({}, {"io_output": o2.outputs()["output"]})
+            processor.infer_processor({}, {"io_output": o2.outputs["output"]})
 
     def test_infer_processor_automatic_input(self):
         """Infer automatically the input."""
@@ -98,21 +98,21 @@ class ProcessorTest(absltest.TestCase):
         o2 = utils.OpI1O1(i1)
         i3 = utils.create_input_event()
         i3.name = "io_input_2"
-        o4 = utils.OpI2O1(o2.outputs()["output"], i3)
-        o5 = utils.OpI1O2(o4.outputs()["output"])
+        o4 = utils.OpI2O1(o2.outputs["output"], i3)
+        o5 = utils.OpI1O2(o4.outputs["output"])
 
         p = processor.infer_processor(
             None,
             {
-                "io_output_1": o5.outputs()["output_1"],
-                "io_output_2": o4.outputs()["output"],
+                "io_output_1": o5.outputs["output_1"],
+                "io_output_2": o4.outputs["output"],
             },
         )
 
-        self.assertLen(p.operators(), 3)
-        self.assertLen(p.samplings(), 3)
-        self.assertLen(p.events(), 6)
-        self.assertLen(p.features(), 10)
+        self.assertLen(p.operators, 3)
+        self.assertLen(p.samplings, 3)
+        self.assertLen(p.events, 6)
+        self.assertLen(p.features, 10)
 
     def test_automatic_input_missing_name(self):
         """Automated input is not allowed if the input event is not named."""
@@ -124,7 +124,7 @@ class ProcessorTest(absltest.TestCase):
             ValueError, "Cannot infer input on unnamed event"
         ):
             processor.infer_processor(
-                None, {"io_output_1": o2.outputs()["output"]}
+                None, {"io_output_1": o2.outputs["output"]}
             )
 
     def test_automatic_input_equality_graph(self):
@@ -135,12 +135,12 @@ class ProcessorTest(absltest.TestCase):
 
         p = processor.infer_processor(None, {"io_2": i1})
 
-        self.assertLen(p.operators(), 0)
-        self.assertLen(p.events(), 1)
-        self.assertLen(p.samplings(), 1)
-        self.assertLen(p.inputs(), 1)
-        self.assertLen(p.outputs(), 1)
-        self.assertEqual(p.inputs()["io_1"], p.outputs()["io_2"])
+        self.assertLen(p.operators, 0)
+        self.assertLen(p.events, 1)
+        self.assertLen(p.samplings, 1)
+        self.assertLen(p.inputs, 1)
+        self.assertLen(p.outputs, 1)
+        self.assertEqual(p.inputs["io_1"], p.outputs["io_2"])
 
 
 if __name__ == "__main__":

--- a/temporian/core/test/serialize_test.py
+++ b/temporian/core/test/serialize_test.py
@@ -17,12 +17,6 @@ from absl.testing import absltest
 
 from temporian.core import serialize
 from temporian.core import processor
-from temporian.core.data import dtype
-from temporian.core.data.event import Event
-from temporian.core.data.feature import Feature
-from temporian.core.data.sampling import Sampling
-from temporian.core.operators import base
-from temporian.proto import core_pb2 as pb
 from temporian.core.test import utils
 
 
@@ -31,8 +25,8 @@ class SerializeTest(absltest.TestCase):
         i1 = utils.create_input_event()
         o2 = utils.OpI1O1(i1)
         i3 = utils.create_input_event()
-        o4 = utils.OpI2O1(o2.outputs()["output"], i3)
-        o5 = utils.OpI1O2(o4.outputs()["output"])
+        o4 = utils.OpI2O1(o2.outputs["output"], i3)
+        o5 = utils.OpI1O2(o4.outputs["output"])
 
         original = processor.infer_processor(
             {
@@ -40,8 +34,8 @@ class SerializeTest(absltest.TestCase):
                 "io_input_2": i3,
             },
             {
-                "io_output_1": o5.outputs()["output_1"],
-                "io_output_2": o4.outputs()["output"],
+                "io_output_1": o5.outputs["output_1"],
+                "io_output_2": o4.outputs["output"],
             },
         )
         logging.info("original:\n%s", original)
@@ -52,38 +46,38 @@ class SerializeTest(absltest.TestCase):
         restored = serialize.unserialize(proto)
         logging.info("restored:\n%s", restored)
 
-        self.assertEqual(len(original.samplings()), len(restored.samplings()))
-        self.assertEqual(len(original.features()), len(restored.features()))
-        self.assertEqual(len(original.operators()), len(restored.operators()))
-        self.assertEqual(len(original.events()), len(restored.events()))
-        self.assertEqual(original.inputs().keys(), restored.inputs().keys())
-        self.assertEqual(original.outputs().keys(), restored.outputs().keys())
+        self.assertEqual(len(original.samplings), len(restored.samplings))
+        self.assertEqual(len(original.features), len(restored.features))
+        self.assertEqual(len(original.operators), len(restored.operators))
+        self.assertEqual(len(original.events), len(restored.events))
+        self.assertEqual(original.inputs.keys(), restored.inputs.keys())
+        self.assertEqual(original.outputs.keys(), restored.outputs.keys())
         # TODO: Deep equality tests.
 
         # Ensures that "original" and "restored" don't link to the same objects.
         self.assertFalse(
-            serialize.all_identifier(original.samplings())
-            & serialize.all_identifier(restored.samplings())
+            serialize.all_identifier(original.samplings)
+            & serialize.all_identifier(restored.samplings)
         )
         self.assertFalse(
-            serialize.all_identifier(original.features())
-            & serialize.all_identifier(restored.features())
+            serialize.all_identifier(original.features)
+            & serialize.all_identifier(restored.features)
         )
         self.assertFalse(
-            serialize.all_identifier(original.operators())
-            & serialize.all_identifier(restored.operators())
+            serialize.all_identifier(original.operators)
+            & serialize.all_identifier(restored.operators)
         )
         self.assertFalse(
-            serialize.all_identifier(original.events())
-            & serialize.all_identifier(restored.events())
+            serialize.all_identifier(original.events)
+            & serialize.all_identifier(restored.events)
         )
         self.assertFalse(
-            serialize.all_identifier(original.inputs().values())
-            & serialize.all_identifier(restored.inputs().values())
+            serialize.all_identifier(original.inputs.values())
+            & serialize.all_identifier(restored.inputs.values())
         )
         self.assertFalse(
-            serialize.all_identifier(original.outputs().values())
-            & serialize.all_identifier(restored.outputs().values())
+            serialize.all_identifier(original.outputs.values())
+            & serialize.all_identifier(restored.outputs.values())
         )
 
 

--- a/temporian/core/test/utils.py
+++ b/temporian/core/test/utils.py
@@ -58,13 +58,13 @@ class OpI1O1(base.Operator):
                     Feature(
                         "f3",
                         dtype.FLOAT64,
-                        sampling=event.sampling(),
+                        sampling=event.sampling,
                         creator=self,
                     ),
                     Feature(
                         "f4",
                         dtype.FLOAT64,
-                        sampling=event.sampling(),
+                        sampling=event.sampling,
                         creator=self,
                     ),
                 ],
@@ -95,8 +95,8 @@ class OpI1O1NotCreator(base.Operator):
         self.add_output(
             "output",
             Event(
-                features=[f for f in event.features()],
-                sampling=event.sampling(),
+                features=[f for f in event.features],
+                sampling=event.sampling,
                 creator=self,
             ),
         )
@@ -129,17 +129,17 @@ class OpI2O1(base.Operator):
                     Feature(
                         "f5",
                         dtype.FLOAT64,
-                        sampling=event_1.sampling(),
+                        sampling=event_1.sampling,
                         creator=self,
                     ),
                     Feature(
                         "f6",
                         dtype.FLOAT64,
-                        sampling=event_1.sampling(),
+                        sampling=event_1.sampling,
                         creator=self,
                     ),
                 ],
-                sampling=event_1.sampling(),
+                sampling=event_1.sampling,
                 creator=self,
             ),
         )
@@ -173,11 +173,11 @@ class OpI1O2(base.Operator):
                     Feature(
                         "f1",
                         dtype.FLOAT64,
-                        sampling=event.sampling(),
+                        sampling=event.sampling,
                         creator=self,
                     )
                 ],
-                sampling=event.sampling(),
+                sampling=event.sampling,
                 creator=self,
             ),
         )
@@ -188,11 +188,11 @@ class OpI1O2(base.Operator):
                     Feature(
                         "f1",
                         dtype.FLOAT64,
-                        sampling=event.sampling(),
+                        sampling=event.sampling,
                         creator=self,
                     )
                 ],
-                sampling=event.sampling(),
+                sampling=event.sampling,
                 creator=self,
             ),
         )

--- a/temporian/implementation/numpy/data/BUILD
+++ b/temporian/implementation/numpy/data/BUILD
@@ -17,14 +17,23 @@ py_library(
     srcs = ["event.py"],
     srcs_version = "PY3",
     deps = [
-        # pandas dep,
+        ":feature",
         ":sampling",
+        "//temporian/core/data:dtype",
         "//temporian/core/data:duration",
         "//temporian/core/data:event",
-        "//temporian/core/data:feature",
         "//temporian/core/data:sampling",
-        "//temporian/core/data:dtype",
         "//temporian/utils:string",
+    ],
+)
+
+py_library(
+    name = "feature",
+    srcs = ["feature.py"],
+    srcs_version = "PY3",
+    deps = [
+        "//temporian/core/data:dtype",
+        "//temporian/core/data:feature",
     ],
 )
 
@@ -41,5 +50,5 @@ py_library(
     name = "plotter",
     srcs = ["plotter.py"],
     srcs_version = "PY3",
-    deps = [ ":event"  ],
+    deps = [":event"],
 )

--- a/temporian/implementation/numpy/data/event.py
+++ b/temporian/implementation/numpy/data/event.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 from typing import Any, Dict, List, Tuple, Sequence
 
 import numpy as np
@@ -75,7 +76,7 @@ class NumpyEvent:
         df: pd.DataFrame,
         index_names: List[str] = None,
         timestamp_column: str = "timestamp",
-    ) -> "NumpyEvent":
+    ) -> NumpyEvent:
         """Convert a pandas DataFrame to a NumpyEvent.
         Args:
             df: DataFrame to convert to NumpyEvent.

--- a/temporian/implementation/numpy/data/event.py
+++ b/temporian/implementation/numpy/data/event.py
@@ -35,6 +35,10 @@ class NumpyEvent:
     def sampling(self) -> NumpySampling:
         return self._sampling
 
+    @sampling.setter
+    def sampling(self, sampling: NumpySampling) -> None:
+        self._sampling = sampling
+
     def first_index_value(self) -> Tuple:
         if self.data is None or len(self.data) == 0:
             return None

--- a/temporian/implementation/numpy/data/feature.py
+++ b/temporian/implementation/numpy/data/feature.py
@@ -1,0 +1,67 @@
+from typing import Any
+
+import numpy as np
+from temporian.core.data.event import Feature
+from temporian.core.data import dtype
+
+DTYPE_MAPPING = {
+    np.float64: dtype.FLOAT64,
+    np.float32: dtype.FLOAT32,
+    np.int64: dtype.INT64,
+    np.int32: dtype.INT32,
+}
+
+DTYPE_REVERSE_MAPPING = {v: k for k, v in DTYPE_MAPPING.items()}
+DTYPE_REVERSE_MAPPING[dtype.STRING] = np.str_
+
+
+def dtype_to_np_dtype(src: dtype.DType) -> Any:
+    return DTYPE_REVERSE_MAPPING[src]
+
+
+class NumpyFeature:
+    def __init__(self, name: str, data: np.ndarray) -> None:
+        if len(data.shape) > 1:
+            raise ValueError(
+                "NumpyFeatures can only be created from flat arrays. Passed"
+                f" input's shape: {len(data.shape)}"
+            )
+        if data.dtype.type is np.str_ or data.dtype.type is np.string_:
+            self.dtype: dtype.DType = dtype.STRING
+        else:
+            if data.dtype.type not in DTYPE_MAPPING:
+                raise ValueError(
+                    f"Unsupported dtype {data.dtype} for NumpyFeature: {name}."
+                    f" Supported dtypes: {DTYPE_MAPPING.keys()}, np.str_ and "
+                    "np.string_"
+                )
+            self.dtype: dtype.DType = DTYPE_MAPPING[data.dtype.type]
+
+        self._name = name
+        self._data = data
+
+    @property
+    def name(self) -> str:
+        return self._name
+
+    @property
+    def data(self) -> np.ndarray:
+        return self._data
+
+    def __repr__(self) -> str:
+        return f"{self.name}: {self.data.__repr__()}"
+
+    def __eq__(self, __o: object) -> bool:
+        if not isinstance(__o, NumpyFeature):
+            return False
+
+        if self.name != __o.name:
+            return False
+
+        if self.dtype == dtype.STRING:
+            return np.array_equal(self.data, __o.data)
+
+        return np.array_equal(self.data, __o.data, equal_nan=True)
+
+    def schema(self) -> Feature:
+        return Feature(self.name, self.dtype)

--- a/temporian/implementation/numpy/data/plotter.py
+++ b/temporian/implementation/numpy/data/plotter.py
@@ -32,7 +32,7 @@ def plot(
     """Plots an event.
 
     Args:
-        index: The index of the event to plot. Use 'event.index()' for the
+        index: The index of the event to plot. Use 'event.index' for the
             list of available indices. If index=None, select arbitrarily
             (non deterministically) an index to plot.
         backend: Plotting library to use.
@@ -85,7 +85,7 @@ def _plot_matplotlib(events: List[NumpyEvent], index: tuple, options: Options):
         if index not in event.data:
             raise ValueError(
                 f"Index '{index}' does not exist in event. Check the available"
-                " indexes with 'event.index()' and provide one of those index"
+                " indexes with 'event.index' and provide one of those index"
                 " to the 'index' argument of 'plot'. Alternatively, set "
                 '"index=None" to select a random index value (e.g., '
                 f"{event._first_index_value}."

--- a/temporian/implementation/numpy/data/plotter.py
+++ b/temporian/implementation/numpy/data/plotter.py
@@ -49,7 +49,7 @@ def plot(
         events = [event]
 
     if index is None and len(events) > 0:
-        index = events[0]._first_index_value
+        index = events[0].first_index_value()
 
     if not isinstance(index, tuple):
         index = (index,)
@@ -88,9 +88,9 @@ def _plot_matplotlib(events: List[NumpyEvent], index: tuple, options: Options):
                 " indexes with 'event.index' and provide one of those index"
                 " to the 'index' argument of 'plot'. Alternatively, set "
                 '"index=None" to select a random index value (e.g., '
-                f"{event._first_index_value}."
+                f"{event.first_index_value()}."
             )
-        num_features = len(event.feature_names)
+        num_features = len(event.feature_names())
         if num_features == 0:
             # We plot the sampling
             num_features = 1
@@ -107,7 +107,7 @@ def _plot_matplotlib(events: List[NumpyEvent], index: tuple, options: Options):
 
     plot_idx = 0
     for event in events:
-        feature_names = event.feature_names
+        feature_names = event.feature_names()
 
         xs = event.sampling.data[index]
         if options.max_points is not None and len(xs) > options.max_points:

--- a/temporian/implementation/numpy/data/sampling.py
+++ b/temporian/implementation/numpy/data/sampling.py
@@ -15,9 +15,21 @@ class NumpySampling:
         data: Dict[Tuple, np.ndarray],
         is_unix_timestamp: bool = False,
     ) -> None:
-        self.index = index
-        self.data = data
-        self.is_unix_timestamp = is_unix_timestamp
+        self._index = index
+        self._data = data
+        self._is_unix_timestamp = is_unix_timestamp
+
+    @property
+    def index(self) -> List[str]:
+        return self._index
+
+    @property
+    def data(self) -> Dict[Tuple, np.ndarray]:
+        return self._data
+
+    @property
+    def is_unix_timestamp(self) -> bool:
+        return self._is_unix_timestamp
 
     @property
     def has_repeated_timestamps(self) -> bool:

--- a/temporian/implementation/numpy/data/test/BUILD
+++ b/temporian/implementation/numpy/data/test/BUILD
@@ -12,6 +12,7 @@ py_test(
     deps = [
         # absl/testing:absltest dep,
         "//temporian/implementation/numpy/data:event",
+        "//temporian/implementation/numpy/data:feature",
         "//temporian/implementation/numpy/data:sampling",
     ],
 )
@@ -23,6 +24,7 @@ py_test(
     deps = [
         # absl/testing:absltest dep,
         "//temporian/implementation/numpy/data:event",
+        "//temporian/implementation/numpy/data:feature",
         "//temporian/implementation/numpy/data:sampling",
     ],
 )
@@ -47,5 +49,8 @@ py_test(
     name = "plotter_test",
     srcs = ["plotter_test.py"],
     srcs_version = "PY3",
-    deps = ["//temporian/implementation/numpy/data:event","//temporian/implementation/numpy/data:plotter"],
+    deps = [
+        "//temporian/implementation/numpy/data:event",
+        "//temporian/implementation/numpy/data:plotter",
+    ],
 )

--- a/temporian/implementation/numpy/data/test/df_to_event_test.py
+++ b/temporian/implementation/numpy/data/test/df_to_event_test.py
@@ -18,7 +18,7 @@ import numpy as np
 import pandas as pd
 
 from temporian.implementation.numpy.data.event import NumpyEvent
-from temporian.implementation.numpy.data.event import NumpyFeature
+from temporian.implementation.numpy.data.feature import NumpyFeature
 from temporian.implementation.numpy.data.sampling import NumpySampling
 
 

--- a/temporian/implementation/numpy/data/test/event_to_df_test.py
+++ b/temporian/implementation/numpy/data/test/event_to_df_test.py
@@ -16,7 +16,7 @@ import pandas as pd
 import numpy as np
 from absl.testing import absltest
 from temporian.implementation.numpy.data.event import NumpyEvent
-from temporian.implementation.numpy.data.event import NumpyFeature
+from temporian.implementation.numpy.data.feature import NumpyFeature
 from temporian.implementation.numpy.data.sampling import NumpySampling
 
 

--- a/temporian/implementation/numpy/evaluator.py
+++ b/temporian/implementation/numpy/evaluator.py
@@ -60,7 +60,7 @@ def evaluate_schedule(
         # Construct operator inputs
         operator_inputs = {
             input_key: data[input_event]
-            for input_key, input_event in operator.inputs().items()
+            for input_key, input_event in operator.inputs.items()
         }
 
         # Compute output
@@ -77,7 +77,7 @@ def evaluate_schedule(
             print(f"Duration: {end_time - begin_time} s", file=sys.stderr)
 
         # materialize data in output events
-        for output_key, output_event in operator.outputs().items():
+        for output_key, output_event in operator.outputs.items():
             data[output_event] = operator_outputs[output_key]
 
     # TODO: Only return the required data.

--- a/temporian/implementation/numpy/operators/BUILD
+++ b/temporian/implementation/numpy/operators/BUILD
@@ -16,8 +16,8 @@ py_library(
         ":lag",
         ":prefix",
         ":propagate",
-        ":select",
         ":sample",
+        ":select",
         "//temporian/implementation/numpy/operators/calendar:day_of_month",
         "//temporian/implementation/numpy/operators/calendar:day_of_week",
         "//temporian/implementation/numpy/operators/window:moving_count",
@@ -43,10 +43,12 @@ py_library(
     name = "arithmetic",
     srcs = ["arithmetic.py"],
     srcs_version = "PY3",
-    deps = [ ":base",
+    deps = [
+        ":base",
         "//temporian/core/operators:arithmetic",
         "//temporian/implementation/numpy:implementation_lib",
         "//temporian/implementation/numpy/data:event",
+        "//temporian/implementation/numpy/data:feature",
     ],
 )
 
@@ -67,11 +69,13 @@ py_library(
     name = "lag",
     srcs = ["lag.py"],
     srcs_version = "PY3",
-    deps = [ ":base",
+    deps = [
+        ":base",
         "//temporian/core/data:duration",
         "//temporian/core/operators:lag",
         "//temporian/implementation/numpy:implementation_lib",
         "//temporian/implementation/numpy/data:event",
+        "//temporian/implementation/numpy/data:feature",
         "//temporian/implementation/numpy/data:sampling",
     ],
 )
@@ -80,7 +84,8 @@ py_library(
     name = "select",
     srcs = ["select.py"],
     srcs_version = "PY3",
-    deps = [ ":base",
+    deps = [
+        ":base",
         "//temporian/core/operators:select",
         "//temporian/implementation/numpy:implementation_lib",
         "//temporian/implementation/numpy/data:event",
@@ -91,7 +96,8 @@ py_library(
     name = "propagate",
     srcs = ["propagate.py"],
     srcs_version = "PY3",
-    deps = [ ":base",
+    deps = [
+        ":base",
         "//temporian/core/data:duration",
         "//temporian/core/operators:propagate",
         "//temporian/implementation/numpy:implementation_lib",
@@ -105,7 +111,8 @@ py_library(
     name = "sample",
     srcs = ["sample.py"],
     srcs_version = "PY3",
-    deps = [ ":base",
+    deps = [
+        ":base",
         "//temporian/core/data:duration",
         "//temporian/core/operators:sample",
         "//temporian/implementation/numpy:implementation_lib",
@@ -116,12 +123,12 @@ py_library(
     ],
 )
 
-
 py_library(
     name = "prefix",
     srcs = ["prefix.py"],
     srcs_version = "PY3",
-    deps = [ ":base",
+    deps = [
+        ":base",
         "//temporian/core/data:duration",
         "//temporian/core/operators:prefix",
         "//temporian/implementation/numpy:implementation_lib",

--- a/temporian/implementation/numpy/operators/arithmetic.py
+++ b/temporian/implementation/numpy/operators/arithmetic.py
@@ -43,8 +43,8 @@ class ArithmeticNumpyImplementation(OperatorImplementation):
             ValueError: If sampling of both events is not equal.
             NotImplementedError: If resolution is PER_FEATURE_NAME.
         """
-        resolution = self.operator.attributes()["resolution"]
-        operation = self.operator.attributes()["operation"]
+        resolution = self.operator.attributes["resolution"]
+        operation = self.operator.attributes["operation"]
 
         if event_1.sampling is not event_2.sampling:
             raise ValueError("Sampling of both events must be equal.")

--- a/temporian/implementation/numpy/operators/arithmetic.py
+++ b/temporian/implementation/numpy/operators/arithmetic.py
@@ -49,7 +49,7 @@ class ArithmeticNumpyImplementation(OperatorImplementation):
         if event_1.sampling is not event_2.sampling:
             raise ValueError("Sampling of both events must be equal.")
 
-        if event_1.feature_count != event_2.feature_count:
+        if event_1.feature_count() != event_2.feature_count():
             raise ValueError(
                 "Both events must have the same number of features."
             )

--- a/temporian/implementation/numpy/operators/arithmetic.py
+++ b/temporian/implementation/numpy/operators/arithmetic.py
@@ -18,7 +18,7 @@ from temporian.core.operators.arithmetic import ArithmeticOperation
 from temporian.core.operators.arithmetic import ArithmeticOperator
 from temporian.core.operators.arithmetic import Resolution
 from temporian.implementation.numpy.data.event import NumpyEvent
-from temporian.implementation.numpy.data.event import NumpyFeature
+from temporian.implementation.numpy.data.feature import NumpyFeature
 from temporian.implementation.numpy import implementation_lib
 from temporian.implementation.numpy.operators.base import OperatorImplementation
 

--- a/temporian/implementation/numpy/operators/base.py
+++ b/temporian/implementation/numpy/operators/base.py
@@ -85,14 +85,14 @@ def _check_input(
     with OperatorExceptionDecorator(operator):
         # Check input keys
         effective_input_keys = set(inputs.keys())
-        expected_input_keys = set(operator.inputs().keys())
+        expected_input_keys = set(operator.inputs.keys())
         if effective_input_keys != expected_input_keys:
             raise RuntimeError(
                 "Non matching number of inputs. "
                 f"{effective_input_keys} vs {expected_input_keys}"
             )
 
-        _check_features(inputs, definitions=operator.inputs(), label="input")
+        _check_features(inputs, definitions=operator.inputs, label="input")
 
 
 def _check_output(
@@ -105,14 +105,14 @@ def _check_output(
     with OperatorExceptionDecorator(operator):
         # Check output keys
         effective_output_keys = set(outputs.keys())
-        expected_output_keys = set(operator.outputs().keys())
+        expected_output_keys = set(operator.outputs.keys())
         if effective_output_keys != expected_output_keys:
             raise RuntimeError(
                 "Non matching number of outputs. "
                 f"{effective_output_keys} vs {expected_output_keys}"
             )
 
-        for output_key, output_def in operator.outputs().items():
+        for output_key, output_def in operator.outputs.items():
             output_real = outputs[output_key]
 
             # Check sampling
@@ -126,7 +126,7 @@ def _check_output(
 
             # Check copy or referencing of sampling data.
             matching_samplings = set(operator.list_matching_io_samplings())
-            for input_key in operator.inputs().keys():
+            for input_key in operator.inputs.keys():
                 input_real = inputs[input_key]
                 expected_matching_sampling = (
                     input_key,
@@ -161,6 +161,4 @@ def _check_output(
                     )
 
         # Check features
-        _check_features(
-            outputs, definitions=operator.outputs(), label="outputs"
-        )
+        _check_features(outputs, definitions=operator.outputs, label="outputs")

--- a/temporian/implementation/numpy/operators/base.py
+++ b/temporian/implementation/numpy/operators/base.py
@@ -51,7 +51,7 @@ def _check_features(
                 f"expected={item_def.sampling.index}"
             )
         # Check features
-        features = item_real._first_index_features
+        features = item_real.first_index_features()
 
         if len(item_def.features) != len(features):
             raise RuntimeError(

--- a/temporian/implementation/numpy/operators/base.py
+++ b/temporian/implementation/numpy/operators/base.py
@@ -40,38 +40,38 @@ def _check_features(
     # TODO: Check that the index and features have the same number of
     # observations.
 
-    for key, item_def in definitions:
+    for key, item_def in definitions.items():
         item_real = values[key]
 
         # Check sampling
-        if item_real.sampling.index != item_def.sampling().index():
+        if item_real.sampling.index != item_def.sampling.index:
             raise RuntimeError(
                 f"Non matching {label} sampling. "
                 f"effective={item_real.sampling.index} vs "
-                f"expected={item_def.sampling().index()}"
+                f"expected={item_def.sampling.index}"
             )
         # Check features
         features = item_real._first_index_features
 
-        if len(item_def.features()) != len(features):
+        if len(item_def.features) != len(features):
             raise RuntimeError(
                 f"Non matching number of {label} features. "
-                f"expected={len(item_def.features())} vs "
+                f"expected={len(item_def.features)} vs "
                 f"effective={len(features)}"
             )
 
-        for feature_def, feature in zip(item_def.features(), features):
-            if feature_def.name() != feature.name:
+        for feature_def, feature in zip(item_def.features, features):
+            if feature_def.name != feature.name:
                 raise RuntimeError(
                     f"Non matching {label} feature name. "
-                    f"expected={feature_def.name()} vs "
+                    f"expected={feature_def.name} vs "
                     f"effective={feature.name}"
                 )
 
-            if feature_def.dtype() != feature.dtype:
+            if feature_def.dtype != feature.dtype:
                 raise RuntimeError(
                     f"Non matching {label} feature dtype. "
-                    f"expected={feature_def.dtype()} vs "
+                    f"expected={feature_def.dtype} vs "
                     f"effective={feature.dtype}"
                 )
 
@@ -92,9 +92,7 @@ def _check_input(
                 f"{effective_input_keys} vs {expected_input_keys}"
             )
 
-        _check_features(
-            inputs, definitions=operator.inputs().items(), label="input"
-        )
+        _check_features(inputs, definitions=operator.inputs(), label="input")
 
 
 def _check_output(
@@ -118,10 +116,10 @@ def _check_output(
             output_real = outputs[output_key]
 
             # Check sampling
-            if output_real.sampling.index != output_def.sampling().index():
+            if output_real.sampling.index != output_def.sampling.index:
                 raise RuntimeError(
                     f"Non matching sampling. {output_real.sampling.index} vs"
-                    f" {output_def.sampling().index()}"
+                    f" {output_def.sampling.index}"
                 )
 
             # TODO: Check copy or referencing of feature data.
@@ -164,5 +162,5 @@ def _check_output(
 
         # Check features
         _check_features(
-            outputs, definitions=operator.outputs().items(), label="outputs"
+            outputs, definitions=operator.outputs(), label="outputs"
         )

--- a/temporian/implementation/numpy/operators/calendar/BUILD
+++ b/temporian/implementation/numpy/operators/calendar/BUILD
@@ -17,9 +17,10 @@ py_library(
     srcs = ["base.py"],
     srcs_version = "PY3",
     deps = [
-        "//temporian/implementation/numpy/operators:base",
         "//temporian/core/operators/calendar:base",
         "//temporian/implementation/numpy/data:event",
+        "//temporian/implementation/numpy/data:feature",
+        "//temporian/implementation/numpy/operators:base",
     ],
 )
 

--- a/temporian/implementation/numpy/operators/calendar/base.py
+++ b/temporian/implementation/numpy/operators/calendar/base.py
@@ -12,14 +12,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from abc import ABC, abstractmethod
+from abc import abstractmethod
 from datetime import datetime, timezone
 from typing import Dict, Any
 
 import numpy as np
 from temporian.core.operators.calendar.base import BaseCalendarOperator
 from temporian.implementation.numpy.data.event import NumpyEvent
-from temporian.implementation.numpy.data.event import NumpyFeature
+from temporian.implementation.numpy.data.feature import NumpyFeature
 from temporian.implementation.numpy.operators.base import OperatorImplementation
 
 

--- a/temporian/implementation/numpy/operators/glue.py
+++ b/temporian/implementation/numpy/operators/glue.py
@@ -14,12 +14,10 @@
 
 """Implementation for the Glue operator."""
 
-from typing import Dict, Optional
-import numpy as np
+from typing import Dict
 import copy
 
 from temporian.implementation.numpy.data.event import NumpyEvent
-from temporian.implementation.numpy.data.event import NumpyFeature
 from temporian.core.operators.glue import GlueOperator
 from temporian.implementation.numpy import implementation_lib
 from temporian.implementation.numpy.operators.base import OperatorImplementation

--- a/temporian/implementation/numpy/operators/lag.py
+++ b/temporian/implementation/numpy/operators/lag.py
@@ -14,7 +14,7 @@ class LagNumpyImplementation(OperatorImplementation):
         super().__init__(operator)
 
     def __call__(self, event: NumpyEvent) -> Dict[str, NumpyEvent]:
-        duration = self.operator.attributes()["duration"]
+        duration = self.operator.attributes["duration"]
 
         sampling_data = {}
         output_data = {}

--- a/temporian/implementation/numpy/operators/lag.py
+++ b/temporian/implementation/numpy/operators/lag.py
@@ -3,7 +3,7 @@ from typing import Dict
 from temporian.core.data.duration import duration_abbreviation
 from temporian.core.operators.lag import LagOperator
 from temporian.implementation.numpy.data.event import NumpyEvent
-from temporian.implementation.numpy.data.event import NumpyFeature
+from temporian.implementation.numpy.data.feature import NumpyFeature
 from temporian.implementation.numpy.data.sampling import NumpySampling
 from temporian.implementation.numpy import implementation_lib
 from temporian.implementation.numpy.operators.base import OperatorImplementation

--- a/temporian/implementation/numpy/operators/sample.py
+++ b/temporian/implementation/numpy/operators/sample.py
@@ -28,11 +28,11 @@ class SampleNumpyImplementation(OperatorImplementation):
         dst_event = NumpyEvent(data={}, sampling=sampling.sampling)
 
         # Type and replacement values
-        output_features = self._operator.outputs()["event"].features()
+        output_features = self._operator.outputs()["event"].features
         output_missing_and_np_dtypes = [
             (
-                dtype.MissingValue(f.dtype()),
-                dtype_to_np_dtype(f.dtype()),
+                dtype.MissingValue(f.dtype),
+                dtype_to_np_dtype(f.dtype),
             )
             for f in output_features
         ]

--- a/temporian/implementation/numpy/operators/sample.py
+++ b/temporian/implementation/numpy/operators/sample.py
@@ -3,8 +3,8 @@
 from typing import Dict
 import numpy as np
 
-from temporian.implementation.numpy.data.event import (
-    NumpyEvent,
+from temporian.implementation.numpy.data.event import NumpyEvent
+from temporian.implementation.numpy.data.feature import (
     NumpyFeature,
     dtype_to_np_dtype,
 )

--- a/temporian/implementation/numpy/operators/sample.py
+++ b/temporian/implementation/numpy/operators/sample.py
@@ -28,7 +28,7 @@ class SampleNumpyImplementation(OperatorImplementation):
         dst_event = NumpyEvent(data={}, sampling=sampling.sampling)
 
         # Type and replacement values
-        output_features = self._operator.outputs()["event"].features
+        output_features = self._operator.outputs["event"].features
         output_missing_and_np_dtypes = [
             (
                 dtype.MissingValue(f.dtype),

--- a/temporian/implementation/numpy/operators/select.py
+++ b/temporian/implementation/numpy/operators/select.py
@@ -13,7 +13,7 @@ class SelectNumpyImplementation(OperatorImplementation):
         super().__init__(operator)
 
     def __call__(self, event: NumpyEvent) -> Dict[str, NumpyEvent]:
-        feature_names = self.operator.attributes()["feature_names"]
+        feature_names = self.operator.attributes["feature_names"]
 
         output_event = NumpyEvent(
             {

--- a/temporian/implementation/numpy/operators/test/BUILD
+++ b/temporian/implementation/numpy/operators/test/BUILD
@@ -10,13 +10,12 @@ py_test(
     srcs = ["arithmetic_test.py"],
     srcs_version = "PY3",
     deps = [
-        # absl/testing:absltest dep,
         "//temporian/core/data:event",
         "//temporian/core/data:sampling",
         "//temporian/core/operators:arithmetic",
+        "//temporian/implementation/numpy:evaluator",
         "//temporian/implementation/numpy/data:event",
         "//temporian/implementation/numpy/operators:arithmetic",
-         "//temporian/implementation/numpy:evaluator",
     ],
 )
 
@@ -25,14 +24,11 @@ py_test(
     srcs = ["glue_test.py"],
     srcs_version = "PY3",
     deps = [
-        # absl/testing:absltest dep,
-        "//temporian/core/data:event",
         "//temporian/core/data:sampling",
         "//temporian/core/operators:glue",
+        "//temporian/implementation/numpy:evaluator",
         "//temporian/implementation/numpy/data:event",
-        "//temporian/implementation/numpy/data:sampling",
-       "//temporian/implementation/numpy/operators:glue",
-         "//temporian/implementation/numpy:evaluator",
+        "//temporian/implementation/numpy/operators:glue",
     ],
 )
 
@@ -41,14 +37,14 @@ py_test(
     srcs = ["calendar_day_of_month_test.py"],
     srcs_version = "PY3",
     deps = [
-        # absl/testing:absltest dep,
         "//temporian/core/data:event",
         "//temporian/core/data:sampling",
         "//temporian/core/operators/calendar:day_of_month",
+        "//temporian/implementation/numpy:evaluator",
         "//temporian/implementation/numpy/data:event",
+        "//temporian/implementation/numpy/data:feature",
         "//temporian/implementation/numpy/data:sampling",
         "//temporian/implementation/numpy/operators/calendar:day_of_month",
-         "//temporian/implementation/numpy:evaluator",
     ],
 )
 
@@ -57,14 +53,14 @@ py_test(
     srcs = ["calendar_day_of_week_test.py"],
     srcs_version = "PY3",
     deps = [
-        # absl/testing:absltest dep,
         "//temporian/core/data:event",
         "//temporian/core/data:sampling",
         "//temporian/core/operators/calendar:day_of_week",
+        "//temporian/implementation/numpy:evaluator",
         "//temporian/implementation/numpy/data:event",
+        "//temporian/implementation/numpy/data:feature",
         "//temporian/implementation/numpy/data:sampling",
         "//temporian/implementation/numpy/operators/calendar:day_of_week",
-         "//temporian/implementation/numpy:evaluator",
     ],
 )
 
@@ -73,14 +69,14 @@ py_test(
     srcs = ["calendar_day_of_year_test.py"],
     srcs_version = "PY3",
     deps = [
-        # absl/testing:absltest dep,
         "//temporian/core/data:event",
         "//temporian/core/data:sampling",
         "//temporian/core/operators/calendar:day_of_year",
+        "//temporian/implementation/numpy:evaluator",
         "//temporian/implementation/numpy/data:event",
+        "//temporian/implementation/numpy/data:feature",
         "//temporian/implementation/numpy/data:sampling",
         "//temporian/implementation/numpy/operators/calendar:day_of_year",
-         "//temporian/implementation/numpy:evaluator",
     ],
 )
 
@@ -89,14 +85,14 @@ py_test(
     srcs = ["calendar_hour_test.py"],
     srcs_version = "PY3",
     deps = [
-        # absl/testing:absltest dep,
         "//temporian/core/data:event",
         "//temporian/core/data:sampling",
         "//temporian/core/operators/calendar:hour",
+        "//temporian/implementation/numpy:evaluator",
         "//temporian/implementation/numpy/data:event",
+        "//temporian/implementation/numpy/data:feature",
         "//temporian/implementation/numpy/data:sampling",
         "//temporian/implementation/numpy/operators/calendar:hour",
-         "//temporian/implementation/numpy:evaluator",
     ],
 )
 
@@ -105,14 +101,14 @@ py_test(
     srcs = ["calendar_iso_week_test.py"],
     srcs_version = "PY3",
     deps = [
-        # absl/testing:absltest dep,
         "//temporian/core/data:event",
         "//temporian/core/data:sampling",
         "//temporian/core/operators/calendar:iso_week",
+        "//temporian/implementation/numpy:evaluator",
         "//temporian/implementation/numpy/data:event",
+        "//temporian/implementation/numpy/data:feature",
         "//temporian/implementation/numpy/data:sampling",
         "//temporian/implementation/numpy/operators/calendar:iso_week",
-         "//temporian/implementation/numpy:evaluator",
     ],
 )
 
@@ -121,14 +117,14 @@ py_test(
     srcs = ["calendar_minute_test.py"],
     srcs_version = "PY3",
     deps = [
-        # absl/testing:absltest dep,
         "//temporian/core/data:event",
         "//temporian/core/data:sampling",
         "//temporian/core/operators/calendar:minute",
+        "//temporian/implementation/numpy:evaluator",
         "//temporian/implementation/numpy/data:event",
+        "//temporian/implementation/numpy/data:feature",
         "//temporian/implementation/numpy/data:sampling",
         "//temporian/implementation/numpy/operators/calendar:minute",
-         "//temporian/implementation/numpy:evaluator",
     ],
 )
 
@@ -137,14 +133,14 @@ py_test(
     srcs = ["calendar_second_test.py"],
     srcs_version = "PY3",
     deps = [
-        # absl/testing:absltest dep,
         "//temporian/core/data:event",
         "//temporian/core/data:sampling",
         "//temporian/core/operators/calendar:second",
+        "//temporian/implementation/numpy:evaluator",
         "//temporian/implementation/numpy/data:event",
+        "//temporian/implementation/numpy/data:feature",
         "//temporian/implementation/numpy/data:sampling",
         "//temporian/implementation/numpy/operators/calendar:second",
-         "//temporian/implementation/numpy:evaluator",
     ],
 )
 
@@ -153,14 +149,14 @@ py_test(
     srcs = ["calendar_year_test.py"],
     srcs_version = "PY3",
     deps = [
-        # absl/testing:absltest dep,
         "//temporian/core/data:event",
         "//temporian/core/data:sampling",
         "//temporian/core/operators/calendar:year",
+        "//temporian/implementation/numpy:evaluator",
         "//temporian/implementation/numpy/data:event",
+        "//temporian/implementation/numpy/data:feature",
         "//temporian/implementation/numpy/data:sampling",
         "//temporian/implementation/numpy/operators/calendar:year",
-         "//temporian/implementation/numpy:evaluator",
     ],
 )
 
@@ -169,11 +165,10 @@ py_test(
     srcs = ["lag_test.py"],
     srcs_version = "PY3",
     deps = [
-        # absl/testing:absltest dep,
         "//temporian/core:evaluator",
         "//temporian/core/operators:lag",
+        "//temporian/implementation/numpy:evaluator",
         "//temporian/implementation/numpy/operators:lag",
-         "//temporian/implementation/numpy:evaluator",
     ],
 )
 
@@ -182,12 +177,11 @@ py_test(
     srcs = ["select_test.py"],
     srcs_version = "PY3",
     deps = [
-        # absl/testing:absltest dep,
         "//temporian/core:evaluator",
         "//temporian/core/operators:select",
+        "//temporian/implementation/numpy:evaluator",
         "//temporian/implementation/numpy/data:event",
         "//temporian/implementation/numpy/operators:select",
-         "//temporian/implementation/numpy:evaluator",
     ],
 )
 
@@ -196,14 +190,12 @@ py_test(
     srcs = ["simple_moving_average_test.py"],
     srcs_version = "PY3",
     deps = [
-        # absl/testing:absltest dep,
-        # pandas dep,
+        "//temporian/core/data:dtype",
         "//temporian/core/data:event",
         "//temporian/core/data:feature",
-        "//temporian/core/data:dtype",
         "//temporian/core/operators/window:simple_moving_average",
+        "//temporian/implementation/numpy:evaluator",
         "//temporian/implementation/numpy/operators/window:simple_moving_average",
-         "//temporian/implementation/numpy:evaluator",
     ],
 )
 
@@ -212,11 +204,9 @@ py_test(
     srcs = ["moving_standard_deviation_test.py"],
     srcs_version = "PY3",
     deps = [
-        # absl/testing:absltest dep,
-        # pandas dep,
+        "//temporian/core/data:dtype",
         "//temporian/core/data:event",
         "//temporian/core/data:feature",
-        "//temporian/core/data:dtype",
         "//temporian/core/operators/window:moving_standard_deviation",
         "//temporian/implementation/numpy/operators/window:moving_standard_deviation",
     ],
@@ -227,11 +217,9 @@ py_test(
     srcs = ["moving_sum_test.py"],
     srcs_version = "PY3",
     deps = [
-        # absl/testing:absltest dep,
-        # pandas dep,
+        "//temporian/core/data:dtype",
         "//temporian/core/data:event",
         "//temporian/core/data:feature",
-        "//temporian/core/data:dtype",
         "//temporian/core/operators/window:moving_sum",
         "//temporian/implementation/numpy/operators/window:moving_sum",
     ],
@@ -242,11 +230,9 @@ py_test(
     srcs = ["moving_count_test.py"],
     srcs_version = "PY3",
     deps = [
-        # absl/testing:absltest dep,
-        # pandas dep,
+        "//temporian/core/data:dtype",
         "//temporian/core/data:event",
         "//temporian/core/data:feature",
-        "//temporian/core/data:dtype",
         "//temporian/core/operators/window:moving_count",
         "//temporian/implementation/numpy/operators/window:moving_count",
     ],
@@ -261,8 +247,8 @@ py_test(
         "//temporian/core/data:event",
         "//temporian/core/data:feature",
         "//temporian/core/operators:propagate",
+        "//temporian/implementation/numpy:evaluator",
         "//temporian/implementation/numpy/operators:propagate",
-         "//temporian/implementation/numpy:evaluator",
     ],
 )
 
@@ -275,8 +261,8 @@ py_test(
         "//temporian/core/data:event",
         "//temporian/core/data:feature",
         "//temporian/core/operators:sample",
+        "//temporian/implementation/numpy:evaluator",
         "//temporian/implementation/numpy/operators:sample",
-         "//temporian/implementation/numpy:evaluator",
     ],
 )
 
@@ -289,7 +275,7 @@ py_test(
         "//temporian/core/data:event",
         "//temporian/core/data:feature",
         "//temporian/core/operators:prefix",
-        "//temporian/implementation/numpy/operators:prefix",
         "//temporian/implementation/numpy:evaluator",
+        "//temporian/implementation/numpy/operators:prefix",
     ],
 )

--- a/temporian/implementation/numpy/operators/test/calendar_day_of_month_test.py
+++ b/temporian/implementation/numpy/operators/test/calendar_day_of_month_test.py
@@ -22,7 +22,7 @@ from temporian.core.operators.calendar.day_of_month import (
     CalendarDayOfMonthOperator,
 )
 from temporian.implementation.numpy.data.event import NumpyEvent
-from temporian.implementation.numpy.data.event import NumpyFeature
+from temporian.implementation.numpy.data.feature import NumpyFeature
 from temporian.implementation.numpy.operators.calendar.day_of_month import (
     CalendarDayOfMonthNumpyImplementation,
 )
@@ -66,7 +66,7 @@ class CalendarDayOfMonthNumpyImplementationTest(absltest.TestCase):
 
         self.assertTrue(output_event_data == output["event"])
         self.assertTrue(
-            output["event"]._first_index_features[0].dtype == dtype.INT32
+            output["event"].first_index_features()[0].dtype == dtype.INT32
         )
 
     def test_with_index(self) -> None:
@@ -111,7 +111,7 @@ class CalendarDayOfMonthNumpyImplementationTest(absltest.TestCase):
 
         self.assertTrue(output_event_data == output["event"])
         self.assertTrue(
-            output["event"]._first_index_features[0].dtype == dtype.INT32
+            output["event"].first_index_features()[0].dtype == dtype.INT32
         )
 
     # TODO: move this test to core operators' test suite when created

--- a/temporian/implementation/numpy/operators/test/calendar_day_of_week_test.py
+++ b/temporian/implementation/numpy/operators/test/calendar_day_of_week_test.py
@@ -20,7 +20,7 @@ from temporian.core.operators.calendar.day_of_week import (
     CalendarDayOfWeekOperator,
 )
 from temporian.implementation.numpy.data.event import NumpyEvent
-from temporian.implementation.numpy.data.event import NumpyFeature
+from temporian.implementation.numpy.data.feature import NumpyFeature
 from temporian.implementation.numpy.operators.calendar.day_of_week import (
     CalendarDayOfWeekNumpyImplementation,
 )
@@ -65,7 +65,7 @@ class CalendarDayOfWeekNumpyImplementationTest(absltest.TestCase):
 
         self.assertTrue(output_event_data == output["event"])
         self.assertTrue(
-            output["event"]._first_index_features[0].dtype == dtype.INT32
+            output["event"].first_index_features()[0].dtype == dtype.INT32
         )
 
 

--- a/temporian/implementation/numpy/operators/test/calendar_day_of_year_test.py
+++ b/temporian/implementation/numpy/operators/test/calendar_day_of_year_test.py
@@ -20,7 +20,7 @@ from temporian.core.operators.calendar.day_of_year import (
     CalendarDayOfYearOperator,
 )
 from temporian.implementation.numpy.data.event import NumpyEvent
-from temporian.implementation.numpy.data.event import NumpyFeature
+from temporian.implementation.numpy.data.feature import NumpyFeature
 from temporian.implementation.numpy.operators.calendar.day_of_year import (
     CalendarDayOfYearNumpyImplementation,
 )
@@ -68,7 +68,7 @@ class CalendarDayOfYearNumpyImplementationTest(absltest.TestCase):
 
         self.assertTrue(output_event_data == output["event"])
         self.assertTrue(
-            output["event"]._first_index_features[0].dtype == dtype.INT32
+            output["event"].first_index_features()[0].dtype == dtype.INT32
         )
 
 

--- a/temporian/implementation/numpy/operators/test/calendar_hour_test.py
+++ b/temporian/implementation/numpy/operators/test/calendar_hour_test.py
@@ -20,7 +20,7 @@ from temporian.core.operators.calendar.hour import (
     CalendarHourOperator,
 )
 from temporian.implementation.numpy.data.event import NumpyEvent
-from temporian.implementation.numpy.data.event import NumpyFeature
+from temporian.implementation.numpy.data.feature import NumpyFeature
 from temporian.implementation.numpy.operators.calendar.hour import (
     CalendarHourNumpyImplementation,
 )
@@ -65,7 +65,7 @@ class CalendarHourNumpyImplementationTest(absltest.TestCase):
 
         self.assertTrue(output_event_data == output["event"])
         self.assertTrue(
-            output["event"]._first_index_features[0].dtype == dtype.INT32
+            output["event"].first_index_features()[0].dtype == dtype.INT32
         )
 
 

--- a/temporian/implementation/numpy/operators/test/calendar_iso_week_test.py
+++ b/temporian/implementation/numpy/operators/test/calendar_iso_week_test.py
@@ -20,7 +20,7 @@ from temporian.core.operators.calendar.iso_week import (
     CalendarISOWeekOperator,
 )
 from temporian.implementation.numpy.data.event import NumpyEvent
-from temporian.implementation.numpy.data.event import NumpyFeature
+from temporian.implementation.numpy.data.feature import NumpyFeature
 from temporian.implementation.numpy.operators.calendar.iso_week import (
     CalendarISOWeekNumpyImplementation,
 )
@@ -80,7 +80,7 @@ class CalendarISOWeekNumpyImplementationTest(absltest.TestCase):
 
         self.assertTrue(output_event_data == output["event"])
         self.assertTrue(
-            output["event"]._first_index_features[0].dtype == dtype.INT32
+            output["event"].first_index_features()[0].dtype == dtype.INT32
         )
 
 

--- a/temporian/implementation/numpy/operators/test/calendar_minute_test.py
+++ b/temporian/implementation/numpy/operators/test/calendar_minute_test.py
@@ -20,7 +20,7 @@ from temporian.core.operators.calendar.minute import (
     CalendarMinuteOperator,
 )
 from temporian.implementation.numpy.data.event import NumpyEvent
-from temporian.implementation.numpy.data.event import NumpyFeature
+from temporian.implementation.numpy.data.feature import NumpyFeature
 from temporian.implementation.numpy.operators.calendar.minute import (
     CalendarMinuteNumpyImplementation,
 )
@@ -66,7 +66,7 @@ class CalendarMinuteNumpyImplementationTest(absltest.TestCase):
 
         self.assertTrue(output_event_data == output["event"])
         self.assertTrue(
-            output["event"]._first_index_features[0].dtype == dtype.INT32
+            output["event"].first_index_features()[0].dtype == dtype.INT32
         )
 
 

--- a/temporian/implementation/numpy/operators/test/calendar_month_test.py
+++ b/temporian/implementation/numpy/operators/test/calendar_month_test.py
@@ -20,7 +20,7 @@ from temporian.core.operators.calendar.month import (
     CalendarMonthOperator,
 )
 from temporian.implementation.numpy.data.event import NumpyEvent
-from temporian.implementation.numpy.data.event import NumpyFeature
+from temporian.implementation.numpy.data.feature import NumpyFeature
 from temporian.implementation.numpy.operators.calendar.month import (
     CalendarMonthNumpyImplementation,
 )
@@ -66,7 +66,7 @@ class CalendarMonthNumpyImplementationTest(absltest.TestCase):
 
         self.assertTrue(output_event_data == output["event"])
         self.assertTrue(
-            output["event"]._first_index_features[0].dtype == dtype.INT32
+            output["event"].first_index_features()[0].dtype == dtype.INT32
         )
 
 

--- a/temporian/implementation/numpy/operators/test/calendar_second_test.py
+++ b/temporian/implementation/numpy/operators/test/calendar_second_test.py
@@ -20,7 +20,7 @@ from temporian.core.operators.calendar.second import (
     CalendarSecondOperator,
 )
 from temporian.implementation.numpy.data.event import NumpyEvent
-from temporian.implementation.numpy.data.event import NumpyFeature
+from temporian.implementation.numpy.data.feature import NumpyFeature
 from temporian.implementation.numpy.operators.calendar.second import (
     CalendarSecondNumpyImplementation,
 )
@@ -65,7 +65,7 @@ class CalendarSecondNumpyImplementationTest(absltest.TestCase):
 
         self.assertTrue(output_event_data == output["event"])
         self.assertTrue(
-            output["event"]._first_index_features[0].dtype == dtype.INT32
+            output["event"].first_index_features()[0].dtype == dtype.INT32
         )
 
 

--- a/temporian/implementation/numpy/operators/test/calendar_year_test.py
+++ b/temporian/implementation/numpy/operators/test/calendar_year_test.py
@@ -20,7 +20,7 @@ from temporian.core.operators.calendar.year import (
     CalendarYearOperator,
 )
 from temporian.implementation.numpy.data.event import NumpyEvent
-from temporian.implementation.numpy.data.event import NumpyFeature
+from temporian.implementation.numpy.data.feature import NumpyFeature
 from temporian.implementation.numpy.operators.calendar.year import (
     CalendarYearNumpyImplementation,
 )
@@ -66,7 +66,7 @@ class CalendarYearNumpyImplementationTest(absltest.TestCase):
 
         self.assertTrue(output_event_data == output["event"])
         self.assertTrue(
-            output["event"]._first_index_features[0].dtype == dtype.INT32
+            output["event"].first_index_features()[0].dtype == dtype.INT32
         )
 
 

--- a/temporian/implementation/numpy/operators/test/glue_test.py
+++ b/temporian/implementation/numpy/operators/test/glue_test.py
@@ -17,7 +17,6 @@ from absl.testing import absltest
 import numpy as np
 import pandas as pd
 
-from temporian.core.data.event import Event
 from temporian.core.data.event import Feature
 from temporian.core.data.sampling import Sampling
 from temporian.core.operators.glue import GlueOperator
@@ -25,8 +24,6 @@ from temporian.core.data import event as event_lib
 from temporian.core.data import dtype as dtype_lib
 
 from temporian.implementation.numpy.data.event import NumpyEvent
-from temporian.implementation.numpy.data.event import NumpyFeature
-from temporian.implementation.numpy.data.sampling import NumpySampling
 from temporian.implementation.numpy.operators.glue import (
     GlueNumpyImplementation,
 )

--- a/temporian/implementation/numpy/operators/window/BUILD
+++ b/temporian/implementation/numpy/operators/window/BUILD
@@ -17,10 +17,11 @@ py_library(
     srcs = ["base.py"],
     srcs_version = "PY3",
     deps = [
-        "//temporian/implementation/numpy/operators:base",
         "//temporian/core/data:duration",
         "//temporian/core/operators/window:base",
         "//temporian/implementation/numpy/data:event",
+        "//temporian/implementation/numpy/data:feature",
+        "//temporian/implementation/numpy/operators:base",
     ],
 )
 

--- a/temporian/implementation/numpy/operators/window/base.py
+++ b/temporian/implementation/numpy/operators/window/base.py
@@ -12,14 +12,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from abc import ABC, abstractmethod
+from abc import abstractmethod
 from typing import Dict, Optional
 
 import numpy as np
 from temporian.core.data.duration import Duration
 from temporian.core.operators.window.base import BaseWindowOperator
 from temporian.implementation.numpy.data.event import NumpyEvent
-from temporian.implementation.numpy.data.event import NumpyFeature
+from temporian.implementation.numpy.data.feature import NumpyFeature
 from temporian.implementation.numpy.operators.base import OperatorImplementation
 
 

--- a/temporian/implementation/numpy/operators/window/base.py
+++ b/temporian/implementation/numpy/operators/window/base.py
@@ -57,7 +57,7 @@ class BaseWindowNumpyImplementation(OperatorImplementation):
             mask = self._build_accumulator_mask(
                 src_timestamps,
                 sampling_timestamps,
-                self.operator.window_length(),
+                self.operator.window_length,
             )
 
             # For each feature

--- a/temporian/test/api_test.py
+++ b/temporian/test/api_test.py
@@ -89,7 +89,7 @@ class TFPTest(absltest.TestCase):
             name="my_input_event",
         )
         b = t.simple_moving_average(event=a, window_length=7)
-        b.set_name("my_output_event")
+        b.name = "my_output_event"
 
         with tempfile.TemporaryDirectory() as tempdir:
             path = os.path.join(tempdir, "my_processor.tem")
@@ -113,7 +113,7 @@ class TFPTest(absltest.TestCase):
             name="my_input_event",
         )
         b = t.simple_moving_average(event=a, window_length=7)
-        b.set_name("my_output_event")
+        b.name = "my_output_event"
 
         with tempfile.TemporaryDirectory() as tempdir:
             path = os.path.join(tempdir, "my_processor.tem")
@@ -125,8 +125,8 @@ class TFPTest(absltest.TestCase):
 
             i, o = t.load(path=path, squeeze=True)
 
-        self.assertEqual(i.name(), "my_input_event")
-        self.assertEqual(o.name(), "my_output_event")
+        self.assertEqual(i.name, "my_input_event")
+        self.assertEqual(o.name, "my_output_event")
 
     def test_serialization_infer_inputs(self):
         a = t.input_event(
@@ -137,7 +137,7 @@ class TFPTest(absltest.TestCase):
             name="my_input_event",
         )
         b = t.simple_moving_average(event=a, window_length=7)
-        b.set_name("my_output_event")
+        b.name = "my_output_event"
 
         with tempfile.TemporaryDirectory() as tempdir:
             path = os.path.join(tempdir, "my_processor.tem")
@@ -145,8 +145,8 @@ class TFPTest(absltest.TestCase):
 
             i, o = t.load(path=path, squeeze=True)
 
-        self.assertEqual(i.name(), "my_input_event")
-        self.assertEqual(o.name(), "my_output_event")
+        self.assertEqual(i.name, "my_input_event")
+        self.assertEqual(o.name, "my_output_event")
 
     def test_list_registered_operators(self):
         logging.info("The operators:")


### PR DESCRIPTION
Closes #46 

- Use `@property` and `@property.setter` where applicable
- Moved `NumpyFeature` to its own `feature` module (was in `event` module before)
- Fixed circular import problem so that now `creator` properties in core can be of type `Operator`
- Removed unused imports and unused build deps
- Change `"Event"` and `"NumpyEvent"` return types to `Event` and `NumpyEvent`