### PR TITLE
Change core and NumPy index to dict mapping names to dtypes

### DIFF
--- a/temporian/core/data/event.py
+++ b/temporian/core/data/event.py
@@ -14,9 +14,10 @@
 
 """An event is a collection (possibly empty) of timesampled feature values."""
 
-from typing import Any, List, Optional
+from typing import Any, Dict, List, Optional
 
 from temporian.core.data.feature import Feature
+from temporian.core.data.sampling import IndexDtypes
 from temporian.core.data.sampling import Sampling
 from temporian.utils import string
 
@@ -97,7 +98,7 @@ class Event(object):
 
 def input_event(
     features: List[Feature],
-    index: List[str] = [],
+    index: Dict[str, IndexDtypes] = {},
     name: Optional[str] = None,
     sampling: Optional[Sampling] = None,
 ) -> Event:

--- a/temporian/core/data/sampling.py
+++ b/temporian/core/data/sampling.py
@@ -14,26 +14,31 @@
 
 """A sampling."""
 
-from typing import List, Optional, Any
+from typing import Any, Dict, Optional, Union
+
+from temporian.core.data import dtype as dtype_lib
+
+
+IndexDtypes = Union[dtype_lib.INT32, dtype_lib.INT64, dtype_lib.STRING]
 
 
 class Sampling(object):
     def __init__(
         self,
-        index: List[str],
+        index: Dict[str, IndexDtypes],
         creator: Optional[Any] = None,
         is_unix_timestamp: bool = False,
     ):
-        assert isinstance(index, list), f"Got {index}"
+        assert isinstance(index, dict), f"Got {index}"
 
-        self._index: List[str] = index
+        self._index: Dict[str, IndexDtypes] = index
         self._creator = creator
         self._is_unix_timestamp = is_unix_timestamp
 
     def __repr__(self):
         return f"Sampling<index:{self._index},id:{id(self)}>"
 
-    def index(self) -> List[str]:
+    def index(self) -> Dict[str, IndexDtypes]:
         return self._index
 
     def creator(self):

--- a/temporian/core/operators/propagate.py
+++ b/temporian/core/operators/propagate.py
@@ -46,10 +46,10 @@ class Propagate(Operator):
         if len(to.features()) == 0:
             raise ValueError("to contains no features")
 
-        self._added_index = [k.name() for k in to.features()]
+        self._added_index = {k.name(): k.dtype() for k in to.features()}
 
         overlap_features = set(self._added_index).intersection(
-            event.sampling().index()
+            set(event.sampling().index())
         )
         if len(overlap_features) > 0:
             raise ValueError(
@@ -57,7 +57,7 @@ class Propagate(Operator):
                 f" index: {list(overlap_features)}"
             )
 
-        new_index = event.sampling().index() + self._added_index
+        new_index = {**event.sampling().index(), **self._added_index}
         sampling = Sampling(index=new_index, creator=self)
 
         output_features = [  # pylint: disable=g-complex-comprehension

--- a/temporian/core/operators/test/propagate_test.py
+++ b/temporian/core/operators/test/propagate_test.py
@@ -28,7 +28,7 @@ class PropagateOperatorTest(absltest.TestCase):
         pass
 
     def test_basic(self):
-        sampling = Sampling(index=["x"])
+        sampling = Sampling(index={"x": dtype_lib.STRING})
         event = event_lib.input_event(
             [
                 Feature("a", dtype_lib.FLOAT64),
@@ -46,7 +46,7 @@ class PropagateOperatorTest(absltest.TestCase):
         _ = propagate(event=event, to=to)
 
     def test_str_add_event(self):
-        sampling = Sampling(index=["x"])
+        sampling = Sampling(index={"x": dtype_lib.STRING})
         event = event_lib.input_event(
             [
                 Feature("a", dtype_lib.FLOAT64),
@@ -59,7 +59,7 @@ class PropagateOperatorTest(absltest.TestCase):
         _ = propagate(event=event, to=["c", "d"])
 
     def test_error_unknown_to(self):
-        sampling = Sampling(index=["x"])
+        sampling = Sampling(index={"x": dtype_lib.STRING})
         event = event_lib.input_event(
             [
                 Feature("a", dtype_lib.FLOAT64),
@@ -72,7 +72,7 @@ class PropagateOperatorTest(absltest.TestCase):
             _ = propagate(event=event, to=["c2"])
 
     def test_error_empty_to(self):
-        sampling = Sampling(index=["x"])
+        sampling = Sampling(index={"x": dtype_lib.STRING})
         event = event_lib.input_event(
             [
                 Feature("a", dtype_lib.FLOAT64),
@@ -90,14 +90,14 @@ class PropagateOperatorTest(absltest.TestCase):
                 Feature("a", dtype_lib.FLOAT64),
                 Feature("b", dtype_lib.FLOAT64),
             ],
-            sampling=Sampling(index=["x"]),
+            sampling=Sampling(index={"x": dtype_lib.STRING}),
         )
         to = event_lib.input_event(
             [
                 Feature("c", dtype_lib.STRING),
                 Feature("d", dtype_lib.STRING),
             ],
-            sampling=Sampling(index=["x"]),
+            sampling=Sampling(index={"x": dtype_lib.STRING}),
         )
         with self.assertRaisesRegex(
             ValueError, "event and to should have the same sampling"

--- a/temporian/core/serialize.py
+++ b/temporian/core/serialize.py
@@ -317,26 +317,26 @@ def _serialize_sampling(src: Sampling) -> pb.Sampling:
 
 
 def _unserialize_sampling(src: pb.Sampling) -> Sampling:
-    return Sampling(index=list(src.index), creator=None)
+    return Sampling(index=dict(src.index), creator=None)
 
 
-def _serialize_dtype(dtype) -> pb.Feature.DType:
+def _serialize_dtype(dtype) -> pb.DType:
     if dtype not in DTYPE_MAPPING:
         raise ValueError(f"Non supported type {dtype}")
     return DTYPE_MAPPING[dtype]
 
 
-def _unserialize_dtype(dtype: pb.Feature.DType):
+def _unserialize_dtype(dtype: pb.DType):
     if dtype not in INV_DTYPE_MAPPING:
         raise ValueError(f"Non supported type {dtype}")
     return INV_DTYPE_MAPPING[dtype]
 
 
 DTYPE_MAPPING = {
-    dtype_lib.FLOAT64: pb.Feature.DType.FLOAT64,
-    dtype_lib.FLOAT32: pb.Feature.DType.FLOAT32,
-    dtype_lib.INT64: pb.Feature.DType.INT64,
-    dtype_lib.INT32: pb.Feature.DType.INT32,
+    dtype_lib.FLOAT64: pb.DType.FLOAT64,
+    dtype_lib.FLOAT32: pb.DType.FLOAT32,
+    dtype_lib.INT64: pb.DType.INT64,
+    dtype_lib.INT32: pb.DType.INT32,
 }
 INV_DTYPE_MAPPING = {v: k for k, v in DTYPE_MAPPING.items()}
 

--- a/temporian/core/test/operator_test.py
+++ b/temporian/core/test/operator_test.py
@@ -40,7 +40,7 @@ class OperatorTest(absltest.TestCase):
                 raise NotImplementedError()
 
         def build_fake_event():
-            return Event(features=[], sampling=Sampling(index=[]), creator=None)
+            return Event(features=[], sampling=Sampling(index={}), creator=None)
 
         t = ToyOperator()
         with self.assertRaisesRegex(ValueError, 'Missing input "input"'):

--- a/temporian/core/test/utils.py
+++ b/temporian/core/test/utils.py
@@ -68,7 +68,7 @@ class OpI1O1(base.Operator):
                         creator=self,
                     ),
                 ],
-                sampling=Sampling(index=[], creator=self),
+                sampling=Sampling(index={}, creator=self),
                 creator=self,
             ),
         )

--- a/temporian/implementation/numpy/data/event.py
+++ b/temporian/implementation/numpy/data/event.py
@@ -112,7 +112,13 @@ class NumpyEvent:
                 feature.schema() for feature in list(self.data.values())[0]
             ],
             sampling=Sampling(
-                index=self.sampling.index,
+                index={
+                    # TODO: create .schema() NumpySampling method
+                    index_name: dtype.STRING
+                    if index_dtype is np.str_
+                    else DTYPE_MAPPING[index_dtype]
+                    for index_name, index_dtype in self.sampling.index.items()
+                },
                 is_unix_timestamp=self.sampling.is_unix_timestamp,
             ),
         )
@@ -256,7 +262,12 @@ class NumpyEvent:
             ]
 
         numpy_sampling = NumpySampling(
-            index=index_names,
+            index={
+                index_name: df.dtypes[index_name].type
+                if df.dtypes[index_name].type is not str
+                else np.str_
+                for index_name in index_names
+            },
             data=sampling,
             is_unix_timestamp=is_unix_timestamp,
         )
@@ -272,7 +283,7 @@ class NumpyEvent:
         # Creating an empty dictionary to store the data
         data = {}
 
-        columns = self.sampling.index + self.feature_names + ["timestamp"]
+        columns = list(self.sampling.index) + self.feature_names + ["timestamp"]
         for column_name in columns:
             data[column_name] = []
 

--- a/temporian/implementation/numpy/data/sampling.py
+++ b/temporian/implementation/numpy/data/sampling.py
@@ -1,4 +1,4 @@
-from typing import Dict, List, Tuple
+from typing import Dict, Tuple
 
 import numpy as np
 
@@ -11,10 +11,11 @@ MAX_NUM_PRINTED_INDEX = 5
 class NumpySampling:
     def __init__(
         self,
-        index: List[str],
+        index: Dict[str, np.dtype],
         data: Dict[Tuple, np.ndarray],
         is_unix_timestamp: bool = False,
     ) -> None:
+        assert isinstance(index, dict)
         self.index = index
         self.data = data
         self.is_unix_timestamp = is_unix_timestamp

--- a/temporian/implementation/numpy/data/test/df_to_event_test.py
+++ b/temporian/implementation/numpy/data/test/df_to_event_test.py
@@ -38,7 +38,7 @@ class DataFrameToEventTest(absltest.TestCase):
                 (666964,): np.array([1.0, 2.0]),
                 (574016,): np.array([3.0]),
             },
-            index=["product_id"],
+            index={"product_id": np.int64},
         )
 
         expected_numpy_event = NumpyEvent(
@@ -54,7 +54,6 @@ class DataFrameToEventTest(absltest.TestCase):
         numpy_event = NumpyEvent.from_dataframe(
             df, index_names=["product_id"], timestamp_column="timestamp"
         )
-
         # validate
         self.assertTrue(numpy_event == expected_numpy_event)
 
@@ -73,7 +72,7 @@ class DataFrameToEventTest(absltest.TestCase):
                 (666964,): np.array([1.0, 2.0]),
                 (574016,): np.array([3.0]),
             },
-            index=["product_id"],
+            index={"product_id": np.int64},
         )
 
         expected_numpy_event = NumpyEvent(
@@ -138,7 +137,7 @@ class DataFrameToEventTest(absltest.TestCase):
                 (666964,): np.array([1.0, 2.0]),
                 (574016,): np.array([3.0]),
             },
-            index=["product_id"],
+            index={"product_id": np.int64},
         )
 
         expected_numpy_event = NumpyEvent(
@@ -220,7 +219,7 @@ class DataFrameToEventTest(absltest.TestCase):
                 ],
             },
             sampling=NumpySampling(
-                index=["x", "y"],
+                index={"x": np.str_, "y": np.str_},
                 data={
                     ("X1", "Y1"): np.array([1, 2, 3], dtype=np.float64),
                     ("X2", "Y1"): np.array([1.1, 2.1, 3.1], dtype=np.float64),
@@ -228,7 +227,6 @@ class DataFrameToEventTest(absltest.TestCase):
                 },
             ),
         )
-
         # validate
         self.assertTrue(numpy_event == expected_numpy_event)
 
@@ -247,7 +245,7 @@ class DataFrameToEventTest(absltest.TestCase):
                 (666964,): np.array([1.0, 2.0]),
                 (574016,): np.array([3.0]),
             },
-            index=["product_id"],
+            index={"product_id": np.int64},
         )
 
         expected_numpy_event = NumpyEvent(
@@ -284,7 +282,7 @@ class DataFrameToEventTest(absltest.TestCase):
                 (666964,): np.array([1640995200, 1641081600]),
                 (574016,): np.array([1641168000]),
             },
-            index=["product_id"],
+            index={"product_id": np.int64},
         )
 
         expected_numpy_event = NumpyEvent(
@@ -321,7 +319,7 @@ class DataFrameToEventTest(absltest.TestCase):
                 (666964,): np.array([1640995200, 1641081600]),
                 (574016,): np.array([1641168000]),
             },
-            index=["product_id"],
+            index={"product_id": np.int64},
         )
 
         expected_numpy_event = NumpyEvent(
@@ -370,7 +368,7 @@ class DataFrameToEventTest(absltest.TestCase):
                 (666964,): np.array([1640995200, 1641081600]),
                 (574016,): np.array([1641168000]),
             },
-            index=["product_id"],
+            index={"product_id": np.int64},
         )
 
         expected_numpy_event = NumpyEvent(
@@ -405,7 +403,7 @@ class DataFrameToEventTest(absltest.TestCase):
             data={
                 (): np.array([1.0, 2.0, 3.0]),
             },
-            index=[],
+            index={},
         )
 
         expected_numpy_event = NumpyEvent(

--- a/temporian/implementation/numpy/data/test/event_test.py
+++ b/temporian/implementation/numpy/data/test/event_test.py
@@ -20,7 +20,7 @@ class EventTest(absltest.TestCase):
                 ],
             },
             sampling=NumpySampling(
-                index=["x"],
+                index={"x": np.int32},
                 data={
                     (1,): np.array([0.1, 0.2, 0.3]),
                     (2,): np.array([0.4, 0.5]),
@@ -38,7 +38,7 @@ class EventTest(absltest.TestCase):
         a <INT64>: [7 8]
         b <INT64>: [ 9 10]
 sampling:
-    index: ['x']
+    index: {'x': <class 'numpy.int32'>}
     data (2):
         (1,): [0.1 0.2 0.3]
         (2,): [0.4 0.5]

--- a/temporian/implementation/numpy/data/test/event_to_df_test.py
+++ b/temporian/implementation/numpy/data/test/event_to_df_test.py
@@ -27,7 +27,7 @@ class EventToDataFrameTest(absltest.TestCase):
                 (666964,): np.array([1.0, 2.0]),
                 (574016,): np.array([3.0]),
             },
-            index=["product_id"],
+            index={"product_id": np.int64},
         )
 
         numpy_event = NumpyEvent(
@@ -61,7 +61,7 @@ class EventToDataFrameTest(absltest.TestCase):
                 (666964,): np.array([1, 2]),
                 (574016,): np.array([3]),
             },
-            index=["product_id"],
+            index={"product_id": np.int64},
         )
 
         numpy_event = NumpyEvent(
@@ -94,7 +94,7 @@ class EventToDataFrameTest(absltest.TestCase):
             data={
                 (): np.array([1.0, 2.0, 3.0]),
             },
-            index=[],
+            index={},
         )
 
         numpy_event = NumpyEvent(
@@ -149,7 +149,7 @@ class EventToDataFrameTest(absltest.TestCase):
                 ],
             },
             sampling=NumpySampling(
-                index=["x", "y"],
+                index={"x": np.str_, "y": np.str_},
                 data={
                     ("X1", "Y1"): np.array([1.0, 2.0, 3.0], dtype=np.float64),
                     ("X2", "Y1"): np.array([1.1, 2.1, 3.1], dtype=np.float64),
@@ -184,7 +184,7 @@ class EventToDataFrameTest(absltest.TestCase):
                 (666964,): np.array([1.0, 2.0]),
                 (574016,): np.array([3.0]),
             },
-            index=["product_id"],
+            index={"product_id": np.int64},
         )
 
         numpy_event = NumpyEvent(

--- a/temporian/implementation/numpy/operators/propagate.py
+++ b/temporian/implementation/numpy/operators/propagate.py
@@ -3,9 +3,10 @@
 
 from typing import Dict
 
+from temporian.core.operators.propagate import Propagate
+from temporian.implementation.numpy.data.event import DTYPE_REVERSE_MAPPING
 from temporian.implementation.numpy.data.event import NumpyEvent, NumpyFeature
 from temporian.implementation.numpy.data.sampling import NumpySampling
-from temporian.core.operators.propagate import Propagate
 from temporian.implementation.numpy import implementation_lib
 from temporian.implementation.numpy.operators.base import OperatorImplementation
 
@@ -21,11 +22,14 @@ class PropagateNumpyImplementation(OperatorImplementation):
         self, event: NumpyEvent, to: NumpyEvent
     ) -> Dict[str, NumpyEvent]:
         # All the features of "to" are added as part of the new index.
-        added_index = self._operator.added_index()
+        added_index = {
+            index_name: DTYPE_REVERSE_MAPPING[index_dtype]
+            for index_name, index_dtype in self._operator.added_index().items()
+        }
         num_new_index = len(added_index)
 
         dst_sampling = NumpySampling(
-            index=event.sampling.index + added_index, data={}
+            index={**event.sampling.index, **added_index}, data={}
         )
         dst_event = NumpyEvent(data={}, sampling=dst_sampling)
 

--- a/temporian/implementation/numpy/operators/test/arithmetic_test.py
+++ b/temporian/implementation/numpy/operators/test/arithmetic_test.py
@@ -16,6 +16,7 @@ import numpy as np
 import pandas as pd
 from absl.testing import absltest
 
+from temporian.core.data import dtype as dtype_lib
 from temporian.core.data.event import Event, Feature
 from temporian.core.data.sampling import Sampling
 from temporian.core.operators.arithmetic import (
@@ -62,7 +63,7 @@ class ArithmeticNumpyImplementationTest(absltest.TestCase):
 
         self.numpy_event_2.sampling = self.numpy_event_1.sampling
 
-        self.sampling = Sampling(["store_id"])
+        self.sampling = Sampling({"store_id": dtype_lib.INT64})
         self.event_1 = Event(
             [Feature("sales", dtype_lib.FLOAT64)],
             sampling=self.sampling,

--- a/temporian/implementation/numpy/operators/test/calendar_day_of_month_test.py
+++ b/temporian/implementation/numpy/operators/test/calendar_day_of_month_test.py
@@ -123,7 +123,7 @@ class CalendarDayOfMonthNumpyImplementationTest(absltest.TestCase):
         sampling.
         """
         input_event = Event(
-            features=[], sampling=Sampling(index=[], is_unix_timestamp=False)
+            features=[], sampling=Sampling(index={}, is_unix_timestamp=False)
         )
         with self.assertRaises(ValueError):
             CalendarDayOfMonthOperator(input_event)

--- a/temporian/implementation/numpy/operators/test/glue_test.py
+++ b/temporian/implementation/numpy/operators/test/glue_test.py
@@ -122,11 +122,11 @@ class GlueNumpyImplementationTest(absltest.TestCase):
             _ = GlueOperator(
                 event_0=event_lib.input_event(
                     [Feature(name="a", dtype=dtype_lib.FLOAT64)],
-                    sampling=Sampling(index=["x"]),
+                    sampling=Sampling(index={"x": dtype_lib.STRING}),
                 ),
                 event_1=event_lib.input_event(
                     [Feature(name="b", dtype=dtype_lib.FLOAT64)],
-                    sampling=Sampling(index=["x"]),
+                    sampling=Sampling(index={"x": dtype_lib.STRING}),
                 ),
             )
 
@@ -135,7 +135,7 @@ class GlueNumpyImplementationTest(absltest.TestCase):
             ValueError,
             "Feature a is defined in multiple input events",
         ):
-            sampling = Sampling(index=["x"])
+            sampling = Sampling(index={"x": dtype_lib.STRING})
             _ = GlueOperator(
                 event_0=event_lib.input_event(
                     [Feature(name="a", dtype=dtype_lib.FLOAT64)],

--- a/temporian/implementation/numpy/operators/test/lag_test.py
+++ b/temporian/implementation/numpy/operators/test/lag_test.py
@@ -14,7 +14,6 @@
 
 from absl.testing import absltest
 
-import numpy as np
 import pandas as pd
 
 from temporian.core import evaluator
@@ -69,7 +68,7 @@ class LagNumpyImplementationTest(absltest.TestCase):
 
         event = Event(
             [Feature("sales", dtype_lib.FLOAT64)],
-            sampling=Sampling(["store_id"]),
+            sampling=Sampling({"store_id": dtype_lib.INT64}),
             creator=None,
         )
 
@@ -211,7 +210,7 @@ class LagNumpyImplementationTest(absltest.TestCase):
 
         event = Event(
             [Feature("sales", dtype_lib.FLOAT64)],
-            sampling=Sampling(["store_id"]),
+            sampling=Sampling({"store_id": dtype_lib.INT64}),
             creator=None,
         )
 

--- a/temporian/implementation/numpy/operators/test/propagate_test.py
+++ b/temporian/implementation/numpy/operators/test/propagate_test.py
@@ -34,7 +34,7 @@ class PropagateOperatorTest(absltest.TestCase):
 
     def test_base(self):
         # Define input
-        sampling = Sampling(index=["x"])
+        sampling = Sampling(index={"x": dtype_lib.STRING})
         event = event_lib.input_event(
             [
                 feature_lib.Feature(name="a", dtype=dtype_lib.FLOAT64),
@@ -54,7 +54,7 @@ class PropagateOperatorTest(absltest.TestCase):
         # TODO: Use "from_dataframe" when it suppose sampling sharing.
 
         sampling = NumpySampling(
-            index=["x"],
+            index={"x": np.str_},
             data={
                 ("X1",): np.array([0.1, 0.2, 0.3], dtype=np.float64),
                 ("X2",): np.array([0.4, 0.5], dtype=np.float64),
@@ -91,7 +91,7 @@ class PropagateOperatorTest(absltest.TestCase):
 
         # Expected output
         expected_sampling = NumpySampling(
-            index=["x", "c", "d"],
+            index={"x": np.str_, "c": np.int64, "d": np.int64},
             data={
                 ("X1", 1, 1): np.array([0.1, 0.2, 0.3], dtype=np.float64),
                 ("X1", 1, 2): np.array([0.1, 0.2, 0.3], dtype=np.float64),

--- a/temporian/proto/core.proto
+++ b/temporian/proto/core.proto
@@ -92,6 +92,15 @@ message Event {
   optional string creator_operator_id = 5;
 }
 
+// Data types for Features and Samplings
+enum DType {
+  UNDEFINED = 0;
+  FLOAT64 = 1;
+  INT64 = 2;
+  FLOAT32 = 3;
+  INT32 = 4;
+}
+
 // Schema of a feature
 message Feature {
   // Identifier of the feature. Should be unique in all the features in the
@@ -106,14 +115,6 @@ message Feature {
   optional string sampling_id = 4;
 
   optional string creator_operator_id = 5;
-
-  enum DType {
-    UNDEFINED = 0;
-    FLOAT64 = 1;
-    INT64 = 2;
-    FLOAT32 = 3;
-    INT32 = 4;
-  }
 }
 
 // Schema of a sampling.
@@ -123,7 +124,7 @@ message Sampling {
   optional string id = 1;
 
   // Index of the sampling.
-  repeated string index = 2;
+  map<string, DType> index = 2;
 
   // Index of the event id who's operator creator also created this feature.
   optional string creator_operator_id = 3;


### PR DESCRIPTION
This PR changes the definition of the core and NumPy index from a list of string to a dictionary mapping `strings` to `dtype`s. This is needed in order to specify kept feature `dtype`s when using the `DropIndex` operator. 

For future work: implement this logic as separate `Index` and `NumpyIndex` classes. 