### PR TITLE
Add index data type

### DIFF
--- a/temporian/core/data/event.py
+++ b/temporian/core/data/event.py
@@ -15,10 +15,11 @@
 """An event is a collection (possibly empty) of timesampled feature values."""
 
 from __future__ import annotations
-from typing import List, Optional, TYPE_CHECKING
+from typing import List, Optional, Tuple, TYPE_CHECKING
 
 from temporian.core.data.feature import Feature
 from temporian.core.data.sampling import Sampling
+from temporian.core.data.sampling import IndexDtypes
 from temporian.utils import string
 
 if TYPE_CHECKING:
@@ -105,7 +106,7 @@ class Event(object):
 
 def input_event(
     features: List[Feature],
-    index: List[str] = [],
+    index: List[Tuple[str, IndexDtypes]] = [],
     name: Optional[str] = None,
     sampling: Optional[Sampling] = None,
 ) -> Event:

--- a/temporian/core/data/sampling.py
+++ b/temporian/core/data/sampling.py
@@ -15,23 +15,34 @@
 """A sampling."""
 
 from __future__ import annotations
-from typing import List, Optional, TYPE_CHECKING
+from typing import List, NamedTuple, Optional, Tuple, TYPE_CHECKING, Union
 
+from temporian.core.data import dtype as dtype_lib
 
 if TYPE_CHECKING:
     from temporian.core.operators.base import Operator
 
 
+IndexDtypes = Union[dtype_lib.INT32, dtype_lib.INT64, dtype_lib.STRING]
+
+
+class IndexLevel(NamedTuple):
+    name: str
+    dtype: IndexDtypes
+
+
 class Sampling(object):
     def __init__(
         self,
-        index: List[str],
+        index: List[Union[Tuple[str, IndexDtypes], IndexLevel]],
         creator: Optional[Operator] = None,
         is_unix_timestamp: bool = False,
     ):
         assert isinstance(index, list), f"Got {index}"
+        if len(index) > 0:
+            assert isinstance(index[0], tuple), f"Got {index[0]}"
 
-        self._index = index
+        self._index = self._parse_index(index)
         self._creator = creator
         self._is_unix_timestamp = is_unix_timestamp
 
@@ -39,8 +50,12 @@ class Sampling(object):
         return f"Sampling<index:{self.index},id:{id(self)}>"
 
     @property
-    def index(self) -> List[str]:
+    def index(self) -> List[IndexLevel]:
         return self._index
+
+    @property
+    def index_names(self) -> List[str]:
+        return [index_level.name for index_level in self._index]
 
     @property
     def creator(self) -> Optional[Operator]:
@@ -53,3 +68,14 @@ class Sampling(object):
     @creator.setter
     def creator(self, creator: Optional[Operator]):
         self._creator = creator
+
+    def _parse_index(
+        self, index: List[Union[Tuple[str, IndexDtypes], IndexLevel]]
+    ) -> List[IndexLevel]:
+        if all([isinstance(index_level, IndexLevel) for index_level in index]):
+            return index
+
+        return [
+            IndexLevel(index_name, index_dtype)
+            for index_name, index_dtype in index
+        ]

--- a/temporian/core/operators/propagate.py
+++ b/temporian/core/operators/propagate.py
@@ -22,6 +22,7 @@ from temporian.core.data.feature import Feature
 from temporian.core.operators.base import Operator
 from temporian.proto import core_pb2 as pb
 from temporian.core.operators.select import select
+from temporian.core.data.sampling import IndexLevel
 from temporian.core.data.sampling import Sampling
 
 
@@ -46,7 +47,7 @@ class Propagate(Operator):
         if len(to.features) == 0:
             raise ValueError("to contains no features")
 
-        self._added_index = [k.name for k in to.features]
+        self._added_index = [IndexLevel(k.name, k.dtype) for k in to.features]
 
         overlap_features = set(self._added_index).intersection(
             event.sampling.index

--- a/temporian/core/operators/test/propagate_test.py
+++ b/temporian/core/operators/test/propagate_test.py
@@ -28,7 +28,7 @@ class PropagateOperatorTest(absltest.TestCase):
         pass
 
     def test_basic(self):
-        sampling = Sampling(index=["x"])
+        sampling = Sampling(index=[("x", dtype_lib.STRING)])
         event = event_lib.input_event(
             [
                 Feature("a", dtype_lib.FLOAT64),
@@ -46,7 +46,7 @@ class PropagateOperatorTest(absltest.TestCase):
         _ = propagate(event=event, to=to)
 
     def test_str_add_event(self):
-        sampling = Sampling(index=["x"])
+        sampling = Sampling(index=[("x", dtype_lib.STRING)])
         event = event_lib.input_event(
             [
                 Feature("a", dtype_lib.FLOAT64),
@@ -59,7 +59,7 @@ class PropagateOperatorTest(absltest.TestCase):
         _ = propagate(event=event, to=["c", "d"])
 
     def test_error_unknown_to(self):
-        sampling = Sampling(index=["x"])
+        sampling = Sampling(index=[("x", dtype_lib.STRING)])
         event = event_lib.input_event(
             [
                 Feature("a", dtype_lib.FLOAT64),
@@ -72,7 +72,7 @@ class PropagateOperatorTest(absltest.TestCase):
             _ = propagate(event=event, to=["c2"])
 
     def test_error_empty_to(self):
-        sampling = Sampling(index=["x"])
+        sampling = Sampling(index=[("x", dtype_lib.STRING)])
         event = event_lib.input_event(
             [
                 Feature("a", dtype_lib.FLOAT64),
@@ -90,14 +90,14 @@ class PropagateOperatorTest(absltest.TestCase):
                 Feature("a", dtype_lib.FLOAT64),
                 Feature("b", dtype_lib.FLOAT64),
             ],
-            sampling=Sampling(index=["x"]),
+            sampling=Sampling(index=[("x", dtype_lib.STRING)]),
         )
         to = event_lib.input_event(
             [
                 Feature("c", dtype_lib.STRING),
                 Feature("d", dtype_lib.STRING),
             ],
-            sampling=Sampling(index=["x"]),
+            sampling=Sampling(index=[("x", dtype_lib.STRING)]),
         )
         with self.assertRaisesRegex(
             ValueError, "event and to should have the same sampling"

--- a/temporian/implementation/numpy/operators/base.py
+++ b/temporian/implementation/numpy/operators/base.py
@@ -44,11 +44,11 @@ def _check_features(
         item_real = values[key]
 
         # Check sampling
-        if item_real.sampling.index != item_def.sampling.index:
+        if item_real.sampling.index != item_def.sampling.index_names:
             raise RuntimeError(
                 f"Non matching {label} sampling. "
                 f"effective={item_real.sampling.index} vs "
-                f"expected={item_def.sampling.index}"
+                f"expected={item_def.sampling.index_names}"
             )
         # Check features
         features = item_real.first_index_features()
@@ -116,10 +116,10 @@ def _check_output(
             output_real = outputs[output_key]
 
             # Check sampling
-            if output_real.sampling.index != output_def.sampling.index:
+            if output_real.sampling.index != output_def.sampling.index_names:
                 raise RuntimeError(
                     f"Non matching sampling. {output_real.sampling.index} vs"
-                    f" {output_def.sampling.index}"
+                    f" {output_def.sampling.index_names}"
                 )
 
             # TODO: Check copy or referencing of feature data.

--- a/temporian/implementation/numpy/operators/propagate.py
+++ b/temporian/implementation/numpy/operators/propagate.py
@@ -21,7 +21,9 @@ class PropagateNumpyImplementation(OperatorImplementation):
         self, event: NumpyEvent, to: NumpyEvent
     ) -> Dict[str, NumpyEvent]:
         # All the features of "to" are added as part of the new index.
-        added_index = self._operator.added_index()
+        added_index = [
+            index_level.name for index_level in self._operator.added_index()
+        ]
         num_new_index = len(added_index)
 
         dst_sampling = NumpySampling(

--- a/temporian/implementation/numpy/operators/test/arithmetic_test.py
+++ b/temporian/implementation/numpy/operators/test/arithmetic_test.py
@@ -62,7 +62,7 @@ class ArithmeticNumpyImplementationTest(absltest.TestCase):
 
         self.numpy_event_2.sampling = self.numpy_event_1.sampling
 
-        self.sampling = Sampling(["store_id"])
+        self.sampling = Sampling([("store_id", dtype_lib.INT64)])
         self.event_1 = Event(
             [Feature("sales", dtype_lib.FLOAT64)],
             sampling=self.sampling,

--- a/temporian/implementation/numpy/operators/test/glue_test.py
+++ b/temporian/implementation/numpy/operators/test/glue_test.py
@@ -119,11 +119,11 @@ class GlueNumpyImplementationTest(absltest.TestCase):
             _ = GlueOperator(
                 event_0=event_lib.input_event(
                     [Feature(name="a", dtype=dtype_lib.FLOAT64)],
-                    sampling=Sampling(index=["x"]),
+                    sampling=Sampling(index=[("x", dtype_lib.INT64)]),
                 ),
                 event_1=event_lib.input_event(
                     [Feature(name="b", dtype=dtype_lib.FLOAT64)],
-                    sampling=Sampling(index=["x"]),
+                    sampling=Sampling(index=[("x", dtype_lib.INT64)]),
                 ),
             )
 
@@ -132,7 +132,7 @@ class GlueNumpyImplementationTest(absltest.TestCase):
             ValueError,
             "Feature a is defined in multiple input events",
         ):
-            sampling = Sampling(index=["x"])
+            sampling = Sampling(index=[("x", dtype_lib.INT64)])
             _ = GlueOperator(
                 event_0=event_lib.input_event(
                     [Feature(name="a", dtype=dtype_lib.FLOAT64)],

--- a/temporian/implementation/numpy/operators/test/lag_test.py
+++ b/temporian/implementation/numpy/operators/test/lag_test.py
@@ -69,7 +69,7 @@ class LagNumpyImplementationTest(absltest.TestCase):
 
         event = Event(
             [Feature("sales", dtype_lib.FLOAT64)],
-            sampling=Sampling(["store_id"]),
+            sampling=Sampling([("store_id", dtype_lib.INT64)]),
             creator=None,
         )
 
@@ -211,7 +211,7 @@ class LagNumpyImplementationTest(absltest.TestCase):
 
         event = Event(
             [Feature("sales", dtype_lib.FLOAT64)],
-            sampling=Sampling(["store_id"]),
+            sampling=Sampling([("store_id", dtype_lib.INT64)]),
             creator=None,
         )
 

--- a/temporian/implementation/numpy/operators/test/propagate_test.py
+++ b/temporian/implementation/numpy/operators/test/propagate_test.py
@@ -34,7 +34,7 @@ class PropagateOperatorTest(absltest.TestCase):
 
     def test_base(self):
         # Define input
-        sampling = Sampling(index=["x"])
+        sampling = Sampling(index=[("x", dtype_lib.STRING)])
         event = event_lib.input_event(
             [
                 feature_lib.Feature(name="a", dtype=dtype_lib.FLOAT64),


### PR DESCRIPTION
As per our last sync, this PR changes the definition of the core and NumPy index from a list of string to a list of tuples containing index level names and dtypes. This is needed in order to specify kept feature `dtype`s when using the `DropIndex` operator. 

For future work: implement this logic as separate `Index` and `NumpyIndex` classes. PR #51 depends on this.