### PR TITLE
Implement window operators in c++

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -4,3 +4,6 @@ build --announce_rc
 build --noincompatible_strict_action_env
 build:linux --copt=-fdiagnostics-color=always
 build --color=yes
+
+build --cxxopt=-std=c++17
+build --host_cxxopt=-std=c++17

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -19,9 +19,7 @@
   "python.linting.flake8Enabled": false,
   "python.linting.pylintEnabled": true,
   "python.linting.enabled": true,
-  "editor.rulers": [
-      80
-  ],
+  "editor.rulers": [ 80 ],
   "editor.codeActionsOnSave": {
       "source.organizeImports": false
   },

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -29,6 +29,7 @@
     "system_error": "cpp",
     "type_traits": "cpp",
     "xtr1common": "cpp",
-    "xutility": "cpp"
+    "xutility": "cpp",
+    "limits": "cpp"
   }
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,30 +1,34 @@
 {
-    "python.envFile": "${workspaceFolder}/.venv",
-    // hide bazel-* directories from file viewer and search
-    "files.exclude": {
-        "**/.venv/": true,
-        "**/bazel-*/**": true,
-    },
-    "search.exclude": {
-        "**/.venv/": true,
-        "**/bazel-*/**": true,
-    },
-    "files.watcherExclude": {
-        "**/.venv/**": true,
-        "**/bazel-*/**": true,
-    },
-    "python.formatting.provider": "black",
-    "editor.tabSize": 4,
-    "editor.formatOnSave": true,
-    "python.linting.flake8Enabled": false,
-    "python.linting.pylintEnabled": true,
-    "python.linting.enabled": true,
-    "editor.rulers": [
-        80
-    ],
-    "editor.codeActionsOnSave": {
-        "source.organizeImports": false
-    },
-    "files.trimFinalNewlines": true,
-    "files.trimTrailingWhitespace": true,
+  "python.envFile": "${workspaceFolder}/.venv",
+  // hide bazel-* directories from file viewer and search
+  "files.exclude": {
+    "**/.venv/": true,
+    "**/bazel-*/**": true
+  },
+  "search.exclude": {
+    "**/.venv/": true,
+    "**/bazel-*/**": true
+  },
+  "files.watcherExclude": {
+    "**/.venv/**": true,
+    "**/bazel-*/**": true
+  },
+  "python.formatting.provider": "black",
+  "editor.tabSize": 4,
+  "editor.formatOnSave": true,
+  "python.linting.flake8Enabled": false,
+  "python.linting.pylintEnabled": true,
+  "python.linting.enabled": true,
+  "editor.rulers": [80],
+  "editor.codeActionsOnSave": {
+    "source.organizeImports": false
+  },
+  "files.trimFinalNewlines": true,
+  "files.trimTrailingWhitespace": true,
+  "files.associations": {
+    "system_error": "cpp",
+    "type_traits": "cpp",
+    "xtr1common": "cpp",
+    "xutility": "cpp"
+  }
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -2,16 +2,16 @@
   "python.envFile": "${workspaceFolder}/.venv",
   // hide bazel-* directories from file viewer and search
   "files.exclude": {
-    "**/.venv/": true,
-    "**/bazel-*/**": true
+      "**/.venv/": true,
+      "**/bazel-*/**": true,
   },
   "search.exclude": {
-    "**/.venv/": true,
-    "**/bazel-*/**": true
+      "**/.venv/": true,
+      "**/bazel-*/**": true,
   },
   "files.watcherExclude": {
-    "**/.venv/**": true,
-    "**/bazel-*/**": true
+      "**/.venv/**": true,
+      "**/bazel-*/**": true,
   },
   "python.formatting.provider": "black",
   "editor.tabSize": 4,
@@ -19,9 +19,11 @@
   "python.linting.flake8Enabled": false,
   "python.linting.pylintEnabled": true,
   "python.linting.enabled": true,
-  "editor.rulers": [80],
+  "editor.rulers": [
+      80
+  ],
   "editor.codeActionsOnSave": {
-    "source.organizeImports": false
+      "source.organizeImports": false
   },
   "files.trimFinalNewlines": true,
   "files.trimTrailingWhitespace": true,

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,35 +1,37 @@
 {
-  "python.envFile": "${workspaceFolder}/.venv",
-  // hide bazel-* directories from file viewer and search
-  "files.exclude": {
-      "**/.venv/": true,
-      "**/bazel-*/**": true,
-  },
-  "search.exclude": {
-      "**/.venv/": true,
-      "**/bazel-*/**": true,
-  },
-  "files.watcherExclude": {
-      "**/.venv/**": true,
-      "**/bazel-*/**": true,
-  },
-  "python.formatting.provider": "black",
-  "editor.tabSize": 4,
-  "editor.formatOnSave": true,
-  "python.linting.flake8Enabled": false,
-  "python.linting.pylintEnabled": true,
-  "python.linting.enabled": true,
-  "editor.rulers": [ 80 ],
-  "editor.codeActionsOnSave": {
-      "source.organizeImports": false
-  },
-  "files.trimFinalNewlines": true,
-  "files.trimTrailingWhitespace": true,
-  "files.associations": {
-    "system_error": "cpp",
-    "type_traits": "cpp",
-    "xtr1common": "cpp",
-    "xutility": "cpp",
-    "limits": "cpp"
-  }
+    "python.envFile": "${workspaceFolder}/.venv",
+    // hide bazel-* directories from file viewer and search
+    "files.exclude": {
+        "**/.venv/": true,
+        "**/bazel-*/**": true,
+    },
+    "search.exclude": {
+        "**/.venv/": true,
+        "**/bazel-*/**": true,
+    },
+    "files.watcherExclude": {
+        "**/.venv/**": true,
+        "**/bazel-*/**": true,
+    },
+    "python.formatting.provider": "black",
+    "editor.tabSize": 4,
+    "editor.formatOnSave": true,
+    "python.linting.flake8Enabled": false,
+    "python.linting.pylintEnabled": true,
+    "python.linting.enabled": true,
+    "editor.rulers": [
+        80
+    ],
+    "editor.codeActionsOnSave": {
+        "source.organizeImports": false
+    },
+    "files.trimFinalNewlines": true,
+    "files.trimTrailingWhitespace": true,
+	"files.associations": {
+        "system_error": "cpp",
+        "type_traits": "cpp",
+        "xtr1common": "cpp",
+        "xutility": "cpp",
+        "limits": "cpp"
+	}
 }

--- a/README.md
+++ b/README.md
@@ -48,10 +48,10 @@ output_event = tp.evaluate(
 
 Temporian currently supports the following features for pre-processing your temporal data:
 
--   **Simple Moving Average:** calculates the average value of each feature over a specified time window.
--   **Lag:** creates new features by shifting the time series data backwards in time by a specified period.
--   **Arithmetic Operations:** allows you to perform arithmetic operations (such as addition, subtraction, multiplication, and division) on time series data, between different events.
--   More features coming soon!
+- **Simple Moving Average:** calculates the average value of each feature over a specified time window.
+- **Lag:** creates new features by shifting the time series data backwards in time by a specified period.
+- **Arithmetic Operations:** allows you to perform arithmetic operations (such as addition, subtraction, multiplication, and division) on time series data, between different events.
+- More features coming soon!
 
 ## Environment Setup
 
@@ -120,8 +120,8 @@ bazel test //...:all
 Time and memory benchmarking is available through the following commands:
 
 ```shell
-bazel run benchmark:time -- [name]
-bazel run benchmark:memory -- [name] [-p]
+bazel -c opt run benchmark:time -- [name]
+bazel -c opt run benchmark:memory -- [name] [-p]
 ```
 
 where `[name]` is the name of one of the python scripts in

--- a/temporian/core/operators/window/base.py
+++ b/temporian/core/operators/window/base.py
@@ -62,7 +62,7 @@ class BaseWindowOperator(Operator, ABC):
             )
             for f in event.features
         ]
-        self._output_dtypes = [feature.dtype() for feature in output_features]
+        self._output_dtypes = [feature.dtype for feature in output_features]
 
         # output
         self.add_output(
@@ -80,9 +80,11 @@ class BaseWindowOperator(Operator, ABC):
     def window_length(self) -> Duration:
         return self._window_length
 
+    @property
     def has_sampling(self) -> bool:
         return self._has_sampling
 
+    @property
     def output_dtypes(self) -> List[dtype.DType]:
         return self._output_dtypes
 

--- a/temporian/core/operators/window/moving_count.py
+++ b/temporian/core/operators/window/moving_count.py
@@ -16,7 +16,7 @@
 from typing import Optional, List
 
 from temporian.core import operator_lib
-from temporian.core.data.dtype import INT64
+from temporian.core.data.dtype import INT32
 from temporian.core.data.duration import Duration
 from temporian.core.data.event import Event
 from temporian.core.data.feature import Feature
@@ -34,10 +34,6 @@ class MovingCountOperator(BaseWindowOperator):
     def operator_def_key(cls) -> str:
         return "MOVING_COUNT"
 
-    @property
-    def prefix(self) -> str:
-        return "moving_count"
-
     def get_feature_dtype(self, feature: Feature) -> str:
         """Returns the dtype of the output feature.
 
@@ -47,7 +43,7 @@ class MovingCountOperator(BaseWindowOperator):
         Returns:
             str: The dtype of the output feature.
         """
-        return INT64
+        return INT32
 
 
 operator_lib.register_operator(MovingCountOperator)

--- a/temporian/core/operators/window/moving_standard_deviation.py
+++ b/temporian/core/operators/window/moving_standard_deviation.py
@@ -35,10 +35,6 @@ class MovingStandardDeviationOperator(BaseWindowOperator):
     def operator_def_key(cls) -> str:
         return "MOVING_STANDARD_DEVIATION"
 
-    @property
-    def prefix(self) -> str:
-        return "msd"
-
     def get_feature_dtype(self, feature: Feature) -> str:
         """Returns the dtype of the output feature.
 

--- a/temporian/core/operators/window/moving_sum.py
+++ b/temporian/core/operators/window/moving_sum.py
@@ -33,10 +33,6 @@ class MovingSumOperator(BaseWindowOperator):
     def operator_def_key(cls) -> str:
         return "MOVING_SUM"
 
-    @property
-    def prefix(self) -> str:
-        return "moving_sum"
-
     def get_feature_dtype(self, feature: Feature) -> str:
         """Returns the dtype of the output feature.
 

--- a/temporian/core/operators/window/simple_moving_average.py
+++ b/temporian/core/operators/window/simple_moving_average.py
@@ -35,10 +35,6 @@ class SimpleMovingAverageOperator(BaseWindowOperator):
     def operator_def_key(cls) -> str:
         return "SIMPLE_MOVING_AVERAGE"
 
-    @property
-    def prefix(self) -> str:
-        return "sma"
-
     def get_feature_dtype(self, feature: Feature) -> str:
         """Returns the dtype of the output feature.
 

--- a/temporian/implementation/numpy/data/event.py
+++ b/temporian/implementation/numpy/data/event.py
@@ -306,7 +306,7 @@ class NumpyEvent:
             return "\n".join(feature_repr)
 
         # Representation of the "data" field
-        with np.printoptions(precision=4, threshold=6):
+        with np.printoptions(precision=4, threshold=20):
             data_repr = []
             for idx, (k, v) in enumerate(self.data.items()):
                 if idx > MAX_NUM_PRINTED_INDEX:

--- a/temporian/implementation/numpy/data/sampling.py
+++ b/temporian/implementation/numpy/data/sampling.py
@@ -33,7 +33,7 @@ class NumpySampling:
         return False
 
     def __repr__(self) -> str:
-        with np.printoptions(precision=4, threshold=6):
+        with np.printoptions(precision=4, threshold=20):
             data_repr = []
             for idx, (k, v) in enumerate(self.data.items()):
                 if idx > MAX_NUM_PRINTED_INDEX:

--- a/temporian/implementation/numpy/operators/test/BUILD
+++ b/temporian/implementation/numpy/operators/test/BUILD
@@ -16,7 +16,7 @@ py_test(
         "//temporian/core/operators:arithmetic",
         "//temporian/implementation/numpy/data:event",
         "//temporian/implementation/numpy/operators:arithmetic",
-         "//temporian/implementation/numpy:evaluator",
+        "//temporian/implementation/numpy:evaluator",
     ],
 )
 
@@ -31,8 +31,8 @@ py_test(
         "//temporian/core/operators:glue",
         "//temporian/implementation/numpy/data:event",
         "//temporian/implementation/numpy/data:sampling",
-       "//temporian/implementation/numpy/operators:glue",
-         "//temporian/implementation/numpy:evaluator",
+        "//temporian/implementation/numpy/operators:glue",
+        "//temporian/implementation/numpy:evaluator",
     ],
 )
 
@@ -48,7 +48,7 @@ py_test(
         "//temporian/implementation/numpy/data:event",
         "//temporian/implementation/numpy/data:sampling",
         "//temporian/implementation/numpy/operators/calendar:day_of_month",
-         "//temporian/implementation/numpy:evaluator",
+        "//temporian/implementation/numpy:evaluator",
     ],
 )
 
@@ -64,7 +64,7 @@ py_test(
         "//temporian/implementation/numpy/data:event",
         "//temporian/implementation/numpy/data:sampling",
         "//temporian/implementation/numpy/operators/calendar:day_of_week",
-         "//temporian/implementation/numpy:evaluator",
+        "//temporian/implementation/numpy:evaluator",
     ],
 )
 
@@ -80,7 +80,7 @@ py_test(
         "//temporian/implementation/numpy/data:event",
         "//temporian/implementation/numpy/data:sampling",
         "//temporian/implementation/numpy/operators/calendar:day_of_year",
-         "//temporian/implementation/numpy:evaluator",
+        "//temporian/implementation/numpy:evaluator",
     ],
 )
 
@@ -96,7 +96,7 @@ py_test(
         "//temporian/implementation/numpy/data:event",
         "//temporian/implementation/numpy/data:sampling",
         "//temporian/implementation/numpy/operators/calendar:hour",
-         "//temporian/implementation/numpy:evaluator",
+        "//temporian/implementation/numpy:evaluator",
     ],
 )
 
@@ -112,7 +112,7 @@ py_test(
         "//temporian/implementation/numpy/data:event",
         "//temporian/implementation/numpy/data:sampling",
         "//temporian/implementation/numpy/operators/calendar:iso_week",
-         "//temporian/implementation/numpy:evaluator",
+        "//temporian/implementation/numpy:evaluator",
     ],
 )
 
@@ -128,7 +128,7 @@ py_test(
         "//temporian/implementation/numpy/data:event",
         "//temporian/implementation/numpy/data:sampling",
         "//temporian/implementation/numpy/operators/calendar:minute",
-         "//temporian/implementation/numpy:evaluator",
+        "//temporian/implementation/numpy:evaluator",
     ],
 )
 
@@ -144,7 +144,7 @@ py_test(
         "//temporian/implementation/numpy/data:event",
         "//temporian/implementation/numpy/data:sampling",
         "//temporian/implementation/numpy/operators/calendar:second",
-         "//temporian/implementation/numpy:evaluator",
+        "//temporian/implementation/numpy:evaluator",
     ],
 )
 
@@ -160,7 +160,7 @@ py_test(
         "//temporian/implementation/numpy/data:event",
         "//temporian/implementation/numpy/data:sampling",
         "//temporian/implementation/numpy/operators/calendar:year",
-         "//temporian/implementation/numpy:evaluator",
+        "//temporian/implementation/numpy:evaluator",
     ],
 )
 
@@ -173,7 +173,7 @@ py_test(
         "//temporian/core:evaluator",
         "//temporian/core/operators:lag",
         "//temporian/implementation/numpy/operators:lag",
-         "//temporian/implementation/numpy:evaluator",
+        "//temporian/implementation/numpy:evaluator",
     ],
 )
 
@@ -187,7 +187,7 @@ py_test(
         "//temporian/core/operators:select",
         "//temporian/implementation/numpy/data:event",
         "//temporian/implementation/numpy/operators:select",
-         "//temporian/implementation/numpy:evaluator",
+        "//temporian/implementation/numpy:evaluator",
     ],
 )
 
@@ -203,7 +203,8 @@ py_test(
         "//temporian/core/data:dtype",
         "//temporian/core/operators/window:simple_moving_average",
         "//temporian/implementation/numpy/operators/window:simple_moving_average",
-         "//temporian/implementation/numpy:evaluator",
+        "//temporian/implementation/numpy:evaluator",
+        "//temporian/implementation/numpy_cc/operators:window",
     ],
 )
 
@@ -219,6 +220,7 @@ py_test(
         "//temporian/core/data:dtype",
         "//temporian/core/operators/window:moving_standard_deviation",
         "//temporian/implementation/numpy/operators/window:moving_standard_deviation",
+        "//temporian/implementation/numpy_cc/operators:window",
     ],
 )
 
@@ -234,6 +236,7 @@ py_test(
         "//temporian/core/data:dtype",
         "//temporian/core/operators/window:moving_sum",
         "//temporian/implementation/numpy/operators/window:moving_sum",
+        "//temporian/implementation/numpy_cc/operators:window",
     ],
 )
 
@@ -249,6 +252,7 @@ py_test(
         "//temporian/core/data:dtype",
         "//temporian/core/operators/window:moving_count",
         "//temporian/implementation/numpy/operators/window:moving_count",
+        "//temporian/implementation/numpy_cc/operators:window",
     ],
 )
 
@@ -261,8 +265,8 @@ py_test(
         "//temporian/core/data:event",
         "//temporian/core/data:feature",
         "//temporian/core/operators:propagate",
+        "//temporian/implementation/numpy:evaluator",
         "//temporian/implementation/numpy/operators:propagate",
-         "//temporian/implementation/numpy:evaluator",
     ],
 )
 
@@ -275,8 +279,8 @@ py_test(
         "//temporian/core/data:event",
         "//temporian/core/data:feature",
         "//temporian/core/operators:sample",
+        "//temporian/implementation/numpy:evaluator",
         "//temporian/implementation/numpy/operators:sample",
-         "//temporian/implementation/numpy:evaluator",
     ],
 )
 
@@ -289,7 +293,7 @@ py_test(
         "//temporian/core/data:event",
         "//temporian/core/data:feature",
         "//temporian/core/operators:prefix",
-        "//temporian/implementation/numpy/operators:prefix",
         "//temporian/implementation/numpy:evaluator",
+        "//temporian/implementation/numpy/operators:prefix",
     ],
 )

--- a/temporian/implementation/numpy/operators/test/moving_count_test.py
+++ b/temporian/implementation/numpy/operators/test/moving_count_test.py
@@ -29,11 +29,35 @@ from temporian.core.data import event as event_lib
 from temporian.core.data import feature as feature_lib
 from temporian.core.data import dtype as dtype_lib
 import math
+from temporian.implementation.numpy_cc.operators import window as window_cc
+from numpy.testing import assert_array_equal
+
+
+def _f64(l):
+    return np.array(l, np.float64)
+
+
+def _f32(l):
+    return np.array(l, np.float32)
+
+
+def _i32(l):
+    return np.array(l, np.int32)
+
+
+nan = math.nan
 
 
 class MovingCountOperatorTest(absltest.TestCase):
-    def setUp(self):
-        pass
+    def test_cc_wo_sampling(self):
+        assert_array_equal(
+            window_cc.moving_count(
+                _f64([1, 2, 3, 5, 20]),
+                _f32([10, nan, 12, 13, 14]),
+                5.0,
+            ),
+            _i32([1, 1, 2, 3, 1]),
+        )
 
     def test_flat(self):
         """A simple time sequence."""
@@ -71,7 +95,7 @@ class MovingCountOperatorTest(absltest.TestCase):
                     [1, 1, 20],
                 ],
                 columns=["a", "b", "timestamp"],
-            )
+            ).astype({"a": np.int32, "b": np.int32})
         )
 
         self.assertEqual(repr(output), repr({"event": expected_output}))
@@ -121,7 +145,7 @@ class MovingCountOperatorTest(absltest.TestCase):
                     ["X2", "Y2", 3, 3.2],
                 ],
                 columns=["x", "y", "a", "timestamp"],
-            ),
+            ).astype({"a": np.int32}),
             index_names=["x", "y"],
         )
 
@@ -145,7 +169,7 @@ class MovingCountOperatorTest(absltest.TestCase):
 
         op = MovingCountOperator(
             event=input_data.schema(),
-            window_length=3,
+            window_length=3.1,
             sampling=event_lib.input_event([]),
         )
         self.assertEqual(
@@ -182,7 +206,7 @@ class MovingCountOperatorTest(absltest.TestCase):
                     [0, 10.0],
                 ],
                 columns=["a", "timestamp"],
-            )
+            ).astype({"a": np.int32})
         )
 
         self.assertEqual(output["event"], expected_output)
@@ -205,7 +229,7 @@ class MovingCountOperatorTest(absltest.TestCase):
 
         op = MovingCountOperator(
             event=input_data.schema(),
-            window_length=1,
+            window_length=1.1,
             sampling=event_lib.input_event([]),
         )
         instance = MovingCountNumpyImplementation(op)
@@ -241,7 +265,7 @@ class MovingCountOperatorTest(absltest.TestCase):
                     [2, 6],
                 ],
                 columns=["a", "timestamp"],
-            )
+            ).astype({"a": np.int32})
         )
 
         self.assertEqual(output["event"], expected_output)

--- a/temporian/implementation/numpy/operators/test/moving_count_test.py
+++ b/temporian/implementation/numpy/operators/test/moving_count_test.py
@@ -70,7 +70,7 @@ class MovingCountOperatorTest(absltest.TestCase):
                     [4, 4, 5],
                     [1, 1, 20],
                 ],
-                columns=["moving_count_a", "moving_count_b", "timestamp"],
+                columns=["a", "b", "timestamp"],
             )
         )
 
@@ -120,7 +120,7 @@ class MovingCountOperatorTest(absltest.TestCase):
                     ["X2", "Y2", 2, 2.2],
                     ["X2", "Y2", 3, 3.2],
                 ],
-                columns=["x", "y", "moving_count_a", "timestamp"],
+                columns=["x", "y", "a", "timestamp"],
             ),
             index_names=["x", "y"],
         )
@@ -181,7 +181,7 @@ class MovingCountOperatorTest(absltest.TestCase):
                     [3, 6.0],
                     [0, 10.0],
                 ],
-                columns=["moving_count_a", "timestamp"],
+                columns=["a", "timestamp"],
             )
         )
 
@@ -240,7 +240,7 @@ class MovingCountOperatorTest(absltest.TestCase):
                     [1, 5],
                     [2, 6],
                 ],
-                columns=["moving_count_a", "timestamp"],
+                columns=["a", "timestamp"],
             )
         )
 

--- a/temporian/implementation/numpy/operators/test/moving_standard_deviation_test.py
+++ b/temporian/implementation/numpy/operators/test/moving_standard_deviation_test.py
@@ -70,7 +70,7 @@ class MovingStandardDeviationOperatorTest(absltest.TestCase):
                     [math.sqrt(1.25), math.sqrt(1.25), 5],
                     [0, 0, 20],
                 ],
-                columns=["msd_a", "msd_b", "timestamp"],
+                columns=["a", "b", "timestamp"],
             )
         )
 
@@ -120,7 +120,7 @@ class MovingStandardDeviationOperatorTest(absltest.TestCase):
                     ["X2", "Y2", 0.5, 2.2],
                     ["X2", "Y2", math.sqrt(2 / 3), 3.2],
                 ],
-                columns=["x", "y", "msd_a", "timestamp"],
+                columns=["x", "y", "a", "timestamp"],
             ),
             index_names=["x", "y"],
         )
@@ -181,7 +181,7 @@ class MovingStandardDeviationOperatorTest(absltest.TestCase):
                     [math.sqrt(2 / 3), 6.0],
                     [math.nan, 10.0],
                 ],
-                columns=["msd_a", "timestamp"],
+                columns=["a", "timestamp"],
             )
         )
 
@@ -240,7 +240,7 @@ class MovingStandardDeviationOperatorTest(absltest.TestCase):
                     [0, 5],
                     [0.5, 6],
                 ],
-                columns=["msd_a", "timestamp"],
+                columns=["a", "timestamp"],
             )
         )
 

--- a/temporian/implementation/numpy/operators/test/moving_standard_deviation_test.py
+++ b/temporian/implementation/numpy/operators/test/moving_standard_deviation_test.py
@@ -26,14 +26,31 @@ from temporian.implementation.numpy.operators.window.moving_standard_deviation i
 from temporian.implementation.numpy.data.event import NumpyEvent
 from temporian.core.data import event as event_lib
 import math
+from temporian.implementation.numpy_cc.operators import window as window_cc
+from numpy.testing import assert_almost_equal
+
+
+def _f64(l):
+    return np.array(l, np.float64)
+
+
+def _f32(l):
+    return np.array(l, np.float32)
+
+
+nan = math.nan
 
 
 class MovingStandardDeviationOperatorTest(absltest.TestCase):
-    def setUp(self):
-        pass
-
-    # TODO: Import tests from pandas backend.
-    # TODO: Simplify tests with "pd_to_event".
+    def test_cc_wo_sampling(self):
+        assert_almost_equal(
+            window_cc.moving_standard_deviation(
+                _f64([1, 2, 3, 5, 20]),
+                _f32([10, nan, 12, 13, 14]),
+                5.0,
+            ),
+            _f32([0.0, 0.0, 1.0, 1.247219, 0.0]),
+        )
 
     def test_flat(self):
         """A simple time sequence."""
@@ -145,7 +162,7 @@ class MovingStandardDeviationOperatorTest(absltest.TestCase):
 
         op = MovingStandardDeviationOperator(
             event=input_data.schema(),
-            window_length=3,
+            window_length=3.1,
             sampling=event_lib.input_event([]),
         )
         self.assertEqual(
@@ -205,7 +222,7 @@ class MovingStandardDeviationOperatorTest(absltest.TestCase):
 
         op = MovingStandardDeviationOperator(
             event=input_data.schema(),
-            window_length=1,
+            window_length=1.1,
             sampling=event_lib.input_event([]),
         )
         instance = MovingStandardDeviationNumpyImplementation(op)

--- a/temporian/implementation/numpy/operators/test/moving_sum_test.py
+++ b/temporian/implementation/numpy/operators/test/moving_sum_test.py
@@ -70,7 +70,7 @@ class MovingSumOperatorTest(absltest.TestCase):
                     [46.0, 86.0, 5],
                     [14.0, 24.0, 20],
                 ],
-                columns=["moving_sum_a", "moving_sum_b", "timestamp"],
+                columns=["a", "b", "timestamp"],
             )
         )
 
@@ -120,7 +120,7 @@ class MovingSumOperatorTest(absltest.TestCase):
                     ["X2", "Y2", 33.0, 2.2],
                     ["X2", "Y2", 51.0, 3.2],
                 ],
-                columns=["x", "y", "moving_sum_a", "timestamp"],
+                columns=["x", "y", "a", "timestamp"],
             ),
             index_names=["x", "y"],
         )
@@ -181,7 +181,7 @@ class MovingSumOperatorTest(absltest.TestCase):
                     [39.0, 6.0],
                     [np.nan, 10.0],
                 ],
-                columns=["moving_sum_a", "timestamp"],
+                columns=["a", "timestamp"],
             )
         )
 
@@ -240,7 +240,7 @@ class MovingSumOperatorTest(absltest.TestCase):
                     [13.0, 5],
                     [27.0, 6],
                 ],
-                columns=["moving_sum_a", "timestamp"],
+                columns=["a", "timestamp"],
             )
         )
 

--- a/temporian/implementation/numpy/operators/test/moving_sum_test.py
+++ b/temporian/implementation/numpy/operators/test/moving_sum_test.py
@@ -29,11 +29,31 @@ from temporian.core.data import event as event_lib
 from temporian.core.data import feature as feature_lib
 from temporian.core.data import dtype as dtype_lib
 import math
+from temporian.implementation.numpy_cc.operators import window as window_cc
+from numpy.testing import assert_array_equal
+
+
+def _f64(l):
+    return np.array(l, np.float64)
+
+
+def _f32(l):
+    return np.array(l, np.float32)
+
+
+nan = math.nan
 
 
 class MovingSumOperatorTest(absltest.TestCase):
-    def setUp(self):
-        pass
+    def test_cc_wo_sampling(self):
+        assert_array_equal(
+            window_cc.moving_sum(
+                _f64([1, 2, 3, 5, 20]),
+                _f32([10, nan, 12, 13, 14]),
+                5.0,
+            ),
+            _f32([10.0, 10.0, 22.0, 35.0, 14.0]),
+        )
 
     def test_flat(self):
         """A simple time sequence."""
@@ -145,7 +165,7 @@ class MovingSumOperatorTest(absltest.TestCase):
 
         op = MovingSumOperator(
             event=input_data.schema(),
-            window_length=3,
+            window_length=3.1,
             sampling=event_lib.input_event([]),
         )
         self.assertEqual(
@@ -173,13 +193,13 @@ class MovingSumOperatorTest(absltest.TestCase):
         expected_output = NumpyEvent.from_dataframe(
             pd.DataFrame(
                 [
-                    [np.nan, -1.0],
+                    [0, -1.0],
                     [10.0, 1.0],
                     [10.0, 1.1],
                     [33.0, 3.0],
                     [33.0, 3.5],
                     [39.0, 6.0],
-                    [np.nan, 10.0],
+                    [0, 10.0],
                 ],
                 columns=["a", "timestamp"],
             )
@@ -205,7 +225,7 @@ class MovingSumOperatorTest(absltest.TestCase):
 
         op = MovingSumOperator(
             event=input_data.schema(),
-            window_length=1,
+            window_length=1.1,
             sampling=event_lib.input_event([]),
         )
         instance = MovingSumNumpyImplementation(op)
@@ -231,12 +251,12 @@ class MovingSumOperatorTest(absltest.TestCase):
         expected_output = NumpyEvent.from_dataframe(
             pd.DataFrame(
                 [
-                    [np.nan, 1],
+                    [0, 1],
                     [11.0, 2],
                     [11.0, 2.5],
                     [11.0, 3],
-                    [np.nan, 3.5],
-                    [np.nan, 4],
+                    [0, 3.5],
+                    [0, 4],
                     [13.0, 5],
                     [27.0, 6],
                 ],

--- a/temporian/implementation/numpy/operators/test/simple_moving_average_test.py
+++ b/temporian/implementation/numpy/operators/test/simple_moving_average_test.py
@@ -72,7 +72,7 @@ class SimpleMovingAverageOperatorTest(absltest.TestCase):
                     [11.5, 21.5, 5],
                     [14.0, 24.0, 20],
                 ],
-                columns=["sma_a", "sma_b", "timestamp"],
+                columns=["a", "b", "timestamp"],
             )
         )
 
@@ -121,7 +121,7 @@ class SimpleMovingAverageOperatorTest(absltest.TestCase):
                     ["X2", "Y2", 16.5, 2.2],
                     ["X2", "Y2", 17.0, 3.2],
                 ],
-                columns=["x", "y", "sma_a", "timestamp"],
+                columns=["x", "y", "a", "timestamp"],
             ),
             index_names=["x", "y"],
         )
@@ -181,7 +181,7 @@ class SimpleMovingAverageOperatorTest(absltest.TestCase):
                     [13.0, 6.0],
                     [math.nan, 10.0],
                 ],
-                columns=["sma_a", "timestamp"],
+                columns=["a", "timestamp"],
             )
         )
 
@@ -239,7 +239,7 @@ class SimpleMovingAverageOperatorTest(absltest.TestCase):
                     [13.0, 5],
                     [13.5, 6],
                 ],
-                columns=["sma_a", "timestamp"],
+                columns=["a", "timestamp"],
             )
         )
 

--- a/temporian/implementation/numpy/operators/test/simple_moving_average_test.py
+++ b/temporian/implementation/numpy/operators/test/simple_moving_average_test.py
@@ -29,14 +29,78 @@ from temporian.core.data import event as event_lib
 from temporian.core.data import feature as feature_lib
 from temporian.core.data import dtype as dtype_lib
 import math
+from temporian.implementation.numpy_cc.operators import window as window_cc
+from numpy.testing import assert_array_equal
+
+
+def _f64(l):
+    return np.array(l, np.float64)
+
+
+def _f32(l):
+    return np.array(l, np.float32)
+
+
+nan = math.nan
+cc_sma = window_cc.simple_moving_average
 
 
 class SimpleMovingAverageOperatorTest(absltest.TestCase):
-    def setUp(self):
-        pass
+    def test_cc_empty(self):
+        a_f64 = _f64([])
+        a_f32 = _f32([])
+        assert_array_equal(cc_sma(a_f64, a_f32, 5.0), a_f32)
+        assert_array_equal(cc_sma(a_f64, a_f64, 5.0), a_f64)
+        assert_array_equal(
+            cc_sma(a_f64, a_f32, a_f64, 5.0),
+            a_f32,
+        )
+        assert_array_equal(
+            cc_sma(a_f64, a_f64, a_f64, 5.0),
+            a_f64,
+        )
 
-    # TODO: Import tests from pandas backend.
-    # TODO: Simplify tests with "pd_to_event".
+    def test_cc_wo_sampling(self):
+        assert_array_equal(
+            cc_sma(
+                _f64([1, 2, 3, 5, 20]),
+                _f32([10, 11, 12, 13, 14]),
+                5.0,
+            ),
+            _f32([10.0, 10.5, 11.0, 11.5, 14.0]),
+        )
+
+    def test_cc_w_sampling(self):
+        assert_array_equal(
+            cc_sma(
+                _f64([1, 2, 3, 5, 6]),
+                _f32([10, 11, 12, 13, 14]),
+                _f64([-1.0, 1.0, 1.1, 3.0, 3.5, 6.0, 10.0]),
+                3.0,
+            ),
+            _f32([nan, 10.0, 10.0, 11.0, 11.0, 13.5, nan]),
+        )
+
+    def test_cc_w_nan_wo_sampling(self):
+        assert_array_equal(
+            cc_sma(
+                _f64([1, 1.5, 2, 5, 20]),
+                _f32([10, nan, nan, 13, 14]),
+                1.0,
+            ),
+            _f32([10.0, 10.0, nan, 13.0, 14.0]),
+        )
+
+    def test_cc_w_nan_w_sampling(self):
+        assert_array_equal(
+            cc_sma(
+                _f64([1, 2, 3, 5, 6]),
+                _f32([nan, 11, nan, 13, 14]),
+                _f64([1.0, 2.0, 2.5, 3.0, 3.5, 4.0, 5.0, 6.0]),
+                1.0,
+            ),
+            _f32([nan, 11.0, 11.0, nan, nan, nan, 13.0, 14]),
+        )
 
     def test_flat(self):
         """A simple time sequence."""
@@ -173,13 +237,13 @@ class SimpleMovingAverageOperatorTest(absltest.TestCase):
         expected_output = NumpyEvent.from_dataframe(
             pd.DataFrame(
                 [
-                    [math.nan, -1.0],
+                    [nan, -1.0],
                     [10.0, 1.0],
                     [10.0, 1.1],
                     [11.0, 3.0],
                     [11.0, 3.5],
-                    [13.0, 6.0],
-                    [math.nan, 10.0],
+                    [13.5, 6.0],
+                    [nan, 10.0],
                 ],
                 columns=["a", "timestamp"],
             )
@@ -193,9 +257,9 @@ class SimpleMovingAverageOperatorTest(absltest.TestCase):
         input_data = NumpyEvent.from_dataframe(
             pd.DataFrame(
                 [
-                    [math.nan, 1],
+                    [nan, 1],
                     [11.0, 2],
-                    [math.nan, 3],
+                    [nan, 3],
                     [13.0, 5],
                     [14.0, 6],
                 ],
@@ -230,14 +294,14 @@ class SimpleMovingAverageOperatorTest(absltest.TestCase):
         expected_output = NumpyEvent.from_dataframe(
             pd.DataFrame(
                 [
-                    [math.nan, 1],
+                    [nan, 1],
                     [11.0, 2],
                     [11.0, 2.5],
-                    [11.0, 3],
-                    [math.nan, 3.5],
-                    [math.nan, 4],
+                    [nan, 3],
+                    [nan, 3.5],
+                    [nan, 4],
                     [13.0, 5],
-                    [13.5, 6],
+                    [14.0, 6],
                 ],
                 columns=["a", "timestamp"],
             )

--- a/temporian/implementation/numpy/operators/window/BUILD
+++ b/temporian/implementation/numpy/operators/window/BUILD
@@ -17,10 +17,10 @@ py_library(
     srcs = ["base.py"],
     srcs_version = "PY3",
     deps = [
-        "//temporian/implementation/numpy/operators:base",
         "//temporian/core/data:duration",
         "//temporian/core/operators/window:base",
         "//temporian/implementation/numpy/data:event",
+        "//temporian/implementation/numpy/operators:base",
     ],
 )
 
@@ -33,6 +33,7 @@ py_library(
         "//temporian/core/operators/window:simple_moving_average",
         "//temporian/implementation/numpy:implementation_lib",
         "//temporian/implementation/numpy/data:event",
+        "//temporian/implementation/numpy_cc/operators:window",
     ],
 )
 

--- a/temporian/implementation/numpy/operators/window/BUILD
+++ b/temporian/implementation/numpy/operators/window/BUILD
@@ -46,6 +46,7 @@ py_library(
         "//temporian/core/operators/window:moving_standard_deviation",
         "//temporian/implementation/numpy:implementation_lib",
         "//temporian/implementation/numpy/data:event",
+        "//temporian/implementation/numpy_cc/operators:window",
     ],
 )
 
@@ -58,6 +59,7 @@ py_library(
         "//temporian/core/operators/window:moving_sum",
         "//temporian/implementation/numpy:implementation_lib",
         "//temporian/implementation/numpy/data:event",
+        "//temporian/implementation/numpy_cc/operators:window",
     ],
 )
 
@@ -70,5 +72,6 @@ py_library(
         "//temporian/core/operators/window:moving_count",
         "//temporian/implementation/numpy:implementation_lib",
         "//temporian/implementation/numpy/data:event",
+        "//temporian/implementation/numpy_cc/operators:window",
     ],
 )

--- a/temporian/implementation/numpy/operators/window/base.py
+++ b/temporian/implementation/numpy/operators/window/base.py
@@ -12,11 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from abc import ABC, abstractmethod
-from typing import Dict, Optional, List
+from abc import abstractmethod
+from typing import Dict, Optional, List, Any
 
 import numpy as np
-from temporian.core.data.duration import Duration
 from temporian.core.operators.window.base import BaseWindowOperator
 from temporian.implementation.numpy.data.event import NumpyEvent
 from temporian.implementation.numpy.data.event import NumpyFeature
@@ -54,6 +53,10 @@ class BaseWindowNumpyImplementation(OperatorImplementation):
 
         return {"event": dst_event}
 
+    @abstractmethod
+    def _implementation(self) -> Any:
+        pass
+
     def _compute(
         self,
         src_timestamps: np.ndarray,
@@ -61,78 +64,14 @@ class BaseWindowNumpyImplementation(OperatorImplementation):
         sampling_timestamps: np.ndarray,
         dst_features: List[NumpyFeature],
     ):
-        mask = self._build_accumulator_mask(
-            src_timestamps,
-            sampling_timestamps,
-            self.operator.window_length(),
-        )
-
-        # For each feature
+        implementation = self._implementation()
         for src_ts in src_features:
-            dst_feature_name = src_ts.name
-            dst_ts_data = self._apply_accumulator_mask(src_ts.data, mask)
-            dst_features.append(NumpyFeature(dst_feature_name, dst_ts_data))
-
-    def _build_accumulator_mask(
-        self,
-        data_timestamps: np.array,
-        sampling_timestamps: np.array,
-        win: Duration,
-    ) -> np.array:
-        """Creates a 2d boolean matrix containing the summing instructions.
-
-        The returned matrix "m[i,j]" is defined as:
-            m[i,j] is true iif. input value "j" is averaged in the output value "i".
-        """
-
-        # This implementation is simple but expensive. It will create multiple
-        # O(n^2) arrays, where n is the number of time samples.
-
-        right_side = (
-            sampling_timestamps[:, np.newaxis] >= data_timestamps[np.newaxis, :]
-        )
-
-        # TODO: Make left side inclusivity/exclusivity a parameter.
-        left_side = sampling_timestamps[:, np.newaxis] <= (
-            data_timestamps[np.newaxis, :] + win
-        )
-
-        return right_side & left_side
-
-    def _apply_accumulator_mask(
-        self, src: np.array, mask: np.array
-    ) -> np.array:
-        """Sums elements according to an accumulator mask."""
-
-        # Broadcast of feature values to requested timestamps.
-        cross_product = src * mask
-
-        # Replace masked values with NaN
-        cross_product[mask == False] = (
-            np.nan
-        )  # pylint: disable=singleton-comparison
-
-        return self._apply_operation(cross_product)
-
-    @abstractmethod
-    def _apply_operation(self, values: np.array) -> np.array:
-        """
-        Applies a window operator to each of the values in each row of the
-        input array.
-
-        The input array should have a shape (n, m), where 'n' is the length of
-        the feature and 'm' is the size of the window. Each row represents a
-        window of data points, with 'nan' values used for padding when the
-        window size is smaller than the number of data points in the time
-        series. The function should compute the operation for each row (window).
-
-        Args:
-            values: A 2D NumPy array with shape (n, m) where each row represents
-                a  window of data points. 'n' is the length of the feature, and
-                'm' is the size of the window. The array can contain 'nan'
-                values as padding.
-
-        Returns:
-            np.array: A 1D NumPy array with shape (n,) containing the operation
-                    for each row (window) in the input array.
-        """
+            args = {
+                "event_timestamps": src_timestamps,
+                "event_values": src_ts.data,
+                "window_length": self.operator.window_length(),
+            }
+            if self.operator.has_sampling():
+                args["sampling_timestamps"] = sampling_timestamps
+            dst_feature = implementation(**args)
+            dst_features.append(NumpyFeature(src_ts.name, dst_feature))

--- a/temporian/implementation/numpy/operators/window/base.py
+++ b/temporian/implementation/numpy/operators/window/base.py
@@ -71,7 +71,7 @@ class BaseWindowNumpyImplementation(OperatorImplementation):
                 "event_values": src_ts.data,
                 "window_length": self.operator.window_length,
             }
-            if self.operator.has_sampling():
+            if self.operator.has_sampling:
                 args["sampling_timestamps"] = sampling_timestamps
             dst_feature = implementation(**args)
             dst_features.append(NumpyFeature(src_ts.name, dst_feature))

--- a/temporian/implementation/numpy/operators/window/moving_count.py
+++ b/temporian/implementation/numpy/operators/window/moving_count.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import numpy as np
 
 from temporian.implementation.numpy import implementation_lib
 from temporian.core.operators.window.moving_count import (
@@ -22,37 +21,14 @@ from temporian.implementation.numpy.operators.window.base import (
     BaseWindowNumpyImplementation,
 )
 
+from temporian.implementation.numpy_cc.operators import window as window_cc
+
 
 class MovingCountNumpyImplementation(BaseWindowNumpyImplementation):
     """Numpy implementation of the moving count operator."""
 
-    def __init__(self, operator: MovingCountOperator) -> None:
-        super().__init__(operator)
-
-    def _apply_operation(self, values: np.array) -> np.array:
-        """
-        Calculates the non-nan count of the values in each row of the input
-        array.
-
-        The input array should have a shape (n, m), where 'n' is the length of
-        the feature and 'm' is the size of the window. Each row represents a
-        window of data points, with 'nan' values used for padding when the
-        window size is  smaller than the number of data points in the time
-        series. The function  computes the count for each row (window) while
-        ignoring the 'nan' values.
-
-        Args:
-            values: A 2D NumPy array with shape (n, m) where each row represents
-                a  window of data points. 'n' is the length of the feature, and
-                'm' is the size of the window. The array can contain 'nan'
-                values as padding.
-
-        Returns:
-            np.array: A 1D NumPy array with shape (n,) containing the non-nan
-                    count for each row (window) in the input array.
-
-        """
-        return np.count_nonzero(~np.isnan(values), axis=1).astype(np.int64)
+    def _implementation(self):
+        return window_cc.moving_count
 
 
 implementation_lib.register_operator_implementation(

--- a/temporian/implementation/numpy/operators/window/moving_standard_deviation.py
+++ b/temporian/implementation/numpy/operators/window/moving_standard_deviation.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import numpy as np
 
 from temporian.implementation.numpy import implementation_lib
 from temporian.core.operators.window.moving_standard_deviation import (
@@ -22,38 +21,14 @@ from temporian.implementation.numpy.operators.window.base import (
     BaseWindowNumpyImplementation,
 )
 
+from temporian.implementation.numpy_cc.operators import window as window_cc
+
 
 class MovingStandardDeviationNumpyImplementation(BaseWindowNumpyImplementation):
     """Numpy implementation of the moving standard deviation operator."""
 
-    def __init__(self, operator: MovingStandardDeviationOperator) -> None:
-        super().__init__(operator)
-
-    def _apply_operation(self, values: np.array) -> np.array:
-        """
-        Calculates the standard deviation of the values in each row of
-        the input array.
-
-        The input array should have a shape (n, m), where 'n' is the length of
-        the feature and 'm' is the size of the window. Each row represents a
-        window of data points, with 'nan' values used for padding when the
-        window size is  smaller than the number of data points in the time
-        series. The function  computes the standard deviation for each row
-        (window) by ignoring the 'nan' values.
-
-
-        Args:
-            values: A 2D NumPy array with shape (n, m) where each row represents
-                a  window of data points. 'n' is the length of the feature, and
-                'm' is the size of the window. The array can contain 'nan'
-                values as padding.
-
-        Returns:
-            np.array: A 1D NumPy array with shape (n,) containing the standard
-                    deviation for each row (window) in the input array.
-
-        """
-        return np.nanstd(values, axis=1)
+    def _implementation(self):
+        return window_cc.moving_standard_deviation
 
 
 implementation_lib.register_operator_implementation(

--- a/temporian/implementation/numpy/operators/window/moving_sum.py
+++ b/temporian/implementation/numpy/operators/window/moving_sum.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import numpy as np
 
 from temporian.implementation.numpy import implementation_lib
 from temporian.core.operators.window.moving_sum import (
@@ -22,42 +21,14 @@ from temporian.implementation.numpy.operators.window.base import (
     BaseWindowNumpyImplementation,
 )
 
+from temporian.implementation.numpy_cc.operators import window as window_cc
+
 
 class MovingSumNumpyImplementation(BaseWindowNumpyImplementation):
     """Numpy implementation of the moving sum operator."""
 
-    def __init__(self, operator: MovingSumOperator) -> None:
-        super().__init__(operator)
-
-    def _apply_operation(self, values: np.array) -> np.array:
-        """
-        Calculates the sum of the values in each row of the input array.
-
-        The input array should have a shape (n, m), where 'n' is the length of
-        the feature and 'm' is the size of the window. Each row represents a
-        window of data points, with 'nan' values used for padding when the
-        window size is  smaller than the number of data points in the time
-        series. The function  computes the sum for each row (window) by ignoring
-        the 'nan' values.
-
-        Args:
-            values: A 2D NumPy array with shape (n, m) where each row represents
-                a  window of data points. 'n' is the length of the feature, and
-                'm' is the size of the window. The array can contain 'nan'
-                values as padding.
-
-        Returns:
-            np.array: A 1D NumPy array with shape (n,) containing the sum for
-                    each row (window) in the input array.
-
-        """
-        # compute the sum for each row ignoring the np.nan values
-        result = np.nansum(values, axis=1)
-        # check which rows are all np.nan
-        all_nan_rows = np.isnan(values).all(axis=1)
-        # set the result for those rows to np.nan
-        result[all_nan_rows] = np.nan
-        return result
+    def _implementation(self):
+        return window_cc.moving_sum
 
 
 implementation_lib.register_operator_implementation(

--- a/temporian/implementation/numpy/operators/window/simple_moving_average.py
+++ b/temporian/implementation/numpy/operators/window/simple_moving_average.py
@@ -12,12 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import List
 
-import numpy as np
-
-from temporian.implementation.numpy.data.event import NumpyEvent
-from temporian.implementation.numpy.data.event import NumpyFeature
 from temporian.implementation.numpy import implementation_lib
 from temporian.core.operators.window.simple_moving_average import (
     SimpleMovingAverageOperator,
@@ -26,42 +21,13 @@ from temporian.implementation.numpy.operators.window.base import (
     BaseWindowNumpyImplementation,
 )
 from temporian.implementation.numpy_cc.operators import window as window_cc
-from temporian.core.data import dtype
-
-FN_MAP = {
-    dtype.FLOAT32: window_cc.simple_moving_average_float32,
-    dtype.FLOAT64: window_cc.simple_moving_average_float64,
-}
 
 
 class SimpleMovingAverageNumpyImplementation(BaseWindowNumpyImplementation):
     """Numpy implementation of the simple moving average operator."""
 
-    def __init__(self, operator: SimpleMovingAverageOperator) -> None:
-        super().__init__(operator)
-
-    def _compute(
-        self,
-        src_timestamps: np.ndarray,
-        src_features: List[NumpyFeature],
-        sampling_timestamps: np.ndarray,
-        dst_features: List[NumpyFeature],
-    ):
-        for src_ts in src_features:
-            fn = window_cc.simple_moving_average_float64
-            args = {
-                "event_timestamps": src_timestamps,
-                "event_values": src_ts.data,
-                "window_length": self.operator.window_length(),
-            }
-            if self.operator.has_sampling():
-                args["sampling_timestamps"] = sampling_timestamps
-            dst_feature = fn(**args)
-            print("@@@@@@@@ dst_feature:", dst_feature, flush=True)
-            dst_features.append(NumpyFeature(src_ts.name, dst_feature))
-
-    def _apply_operation(self, values: np.array) -> np.array:
-        raise NotImplementedError()
+    def _implementation(self):
+        return window_cc.simple_moving_average
 
 
 implementation_lib.register_operator_implementation(

--- a/temporian/implementation/numpy_cc/operators/BUILD
+++ b/temporian/implementation/numpy_cc/operators/BUILD
@@ -14,3 +14,13 @@ py_library(
     name = "sample",
     data = [":sample.so"],
 )
+
+pybind_extension(
+    name = "window",
+    srcs = ["window.cc"],
+)
+
+py_library(
+    name = "window",
+    data = [":window.so"],
+)

--- a/temporian/implementation/numpy_cc/operators/BUILD
+++ b/temporian/implementation/numpy_cc/operators/BUILD
@@ -5,6 +5,8 @@ package(
 
 load("@pybind11_bazel//:build_defs.bzl", "pybind_extension")
 
+# TODO: Merge all the extensions into a single .so file.
+
 pybind_extension(
     name = "sample",
     srcs = ["sample.cc"],

--- a/temporian/implementation/numpy_cc/operators/window.cc
+++ b/temporian/implementation/numpy_cc/operators/window.cc
@@ -1,0 +1,154 @@
+#include <cstdint>
+#include <iostream>
+#include <map>
+#include <pybind11/numpy.h>
+#include <pybind11/pybind11.h>
+#include <string>
+#include <vector>
+
+namespace {
+namespace py = pybind11;
+
+typedef py::array_t<double> ArrayD;
+typedef py::array_t<float> ArrayF;
+
+template <typename T>
+py::array_t<T> simple_moving_average(const ArrayD &event_timestamps,
+                                     const py::array_t<T> &event_values,
+                                     const double window_length) {
+
+  // Input size
+  const size_t n_event = event_timestamps.shape(0);
+
+  // Allocate output array
+  auto output = py::array_t<T>(n_event);
+
+  auto v_output = output.template mutable_unchecked<1>();
+  auto v_timestamps = event_timestamps.unchecked<1>();
+  auto v_values = event_values.template unchecked<1>();
+
+  double sum_values = 0;
+  int num_values = 0;
+  size_t next_begin_idx = 0;
+
+  for (size_t sampling_idx = 0; sampling_idx < n_event; sampling_idx++) {
+
+    // Add to accumulator
+    {
+      const auto value = v_values[sampling_idx];
+      if (!std::isnan(value)) {
+        num_values++;
+        sum_values += value;
+      }
+    }
+
+    const auto left_limit = v_timestamps[sampling_idx] - window_length;
+    while (next_begin_idx < n_event &&
+           v_timestamps[next_begin_idx] <= left_limit) {
+      if (next_begin_idx >= 0) {
+        // Remove from accumulator.
+        const auto value = v_values[next_begin_idx];
+        if (!std::isnan(value)) {
+          num_values--;
+          sum_values -= value;
+        }
+      }
+      next_begin_idx++;
+    }
+
+    const T output = (num_values > 0) ? (sum_values / num_values)
+                                      : std::numeric_limits<T>::quiet_NaN();
+    v_output[sampling_idx] = output;
+  }
+
+  return output;
+}
+
+// DO NOT SUBMIT: Can we merge the two?
+template <typename T>
+py::array_t<T> simple_moving_average(const ArrayD &event_timestamps,
+                                     const py::array_t<T> &event_values,
+                                     const ArrayD &sampling_timestamps,
+                                     const double window_length) {
+  // Input size
+  const size_t n_event = event_timestamps.shape(0);
+  const size_t n_sampling = sampling_timestamps.shape(0);
+
+  // Allocate output array
+  auto output = py::array_t<T>(n_sampling);
+
+  auto v_output = output.template mutable_unchecked<1>();
+  auto v_timestamps = event_timestamps.unchecked<1>();
+  auto v_values = event_values.template unchecked<1>();
+  auto v_sampling = sampling_timestamps.unchecked<1>();
+
+  double sum_values = 0;
+  int num_values = 0;
+
+  size_t next_begin_idx = 0;
+  size_t end_idx = 0;
+
+  for (size_t sampling_idx = 0; sampling_idx < n_sampling; sampling_idx++) {
+    const auto right_limit = v_sampling[sampling_idx];
+    const auto left_limit = v_sampling[sampling_idx] - window_length;
+
+    while (end_idx < n_event && v_timestamps[end_idx] <= right_limit) {
+      // Add from accumulator.
+      const auto value = v_values[end_idx];
+      if (!std::isnan(value)) {
+        num_values++;
+        sum_values += value;
+      }
+      end_idx++;
+    }
+
+    while (next_begin_idx < n_event &&
+           v_timestamps[next_begin_idx] <= left_limit) {
+      if (next_begin_idx >= 0) {
+        // Remove from accumulator.
+        const auto value = v_values[next_begin_idx];
+        if (!std::isnan(value)) {
+          num_values--;
+          sum_values -= value;
+        }
+      }
+      next_begin_idx++;
+    }
+
+    v_output[sampling_idx] = 0;
+  }
+
+  return output;
+}
+
+} // namespace
+
+PYBIND11_MODULE(window, m) {
+  m.def(
+      "simple_moving_average_float32",
+      py::overload_cast<const ArrayD &, const ArrayF &, const ArrayD &, double>(
+          &simple_moving_average<float>),
+      "", py::arg("event_timestamps").noconvert(),
+      py::arg("event_values").noconvert(),
+      py::arg("sampling_timestamps").noconvert(), py::arg("window_length"));
+
+  m.def("simple_moving_average_float32",
+        py::overload_cast<const ArrayD &, const ArrayF &, double>(
+            &simple_moving_average<float>),
+        "", py::arg("event_timestamps").noconvert(),
+        py::arg("event_values").noconvert(), py::arg("window_length"));
+
+  m.def(
+      "simple_moving_average_float64",
+      py::overload_cast<const ArrayD &, const ArrayD &, const ArrayD &, double>(
+          &simple_moving_average<double>),
+      "", py::arg("event_timestamps").noconvert(),
+      py::arg("event_values").noconvert(),
+      py::arg("sampling_timestamps").noconvert(), py::arg("window_length"));
+
+  m.def("simple_moving_average_float64",
+        py::overload_cast<const ArrayD &, const ArrayD &, double>(
+            &simple_moving_average<double>),
+        "", py::arg("event_timestamps").noconvert(),
+        py::arg("event_values").noconvert(), py::arg("window_length"));
+}

--- a/temporian/implementation/numpy_cc/operators/window.cc
+++ b/temporian/implementation/numpy_cc/operators/window.cc
@@ -4,6 +4,7 @@
 #include <pybind11/numpy.h>
 #include <pybind11/pybind11.h>
 #include <string>
+#include <type_traits>
 #include <vector>
 
 namespace {
@@ -12,80 +13,68 @@ namespace py = pybind11;
 typedef py::array_t<double> ArrayD;
 typedef py::array_t<float> ArrayF;
 
-template <typename T>
-py::array_t<T> simple_moving_average(const ArrayD &event_timestamps,
-                                     const py::array_t<T> &event_values,
-                                     const double window_length) {
+// Apply TAccumulator over the data sequentially and return the aggregated
+// results.
+template <typename INPUT, typename OUTPUT, typename TAccumulator>
+py::array_t<OUTPUT> accumulate(const ArrayD &event_timestamps,
+                               const py::array_t<INPUT> &event_values,
+                               const double window_length) {
 
   // Input size
   const size_t n_event = event_timestamps.shape(0);
 
   // Allocate output array
-  auto output = py::array_t<T>(n_event);
+  auto output = py::array_t<OUTPUT>(n_event);
 
   auto v_output = output.template mutable_unchecked<1>();
   auto v_timestamps = event_timestamps.unchecked<1>();
   auto v_values = event_values.template unchecked<1>();
 
-  double sum_values = 0;
-  int num_values = 0;
-  size_t next_begin_idx = 0;
+  TAccumulator accumulator;
+
+  // Index of the first value in the RW.
+  size_t begin_idx = 0;
 
   for (size_t sampling_idx = 0; sampling_idx < n_event; sampling_idx++) {
 
-    // Add to accumulator
-    {
-      const auto value = v_values[sampling_idx];
-      if (!std::isnan(value)) {
-        num_values++;
-        sum_values += value;
-      }
-    }
+    accumulator.Add(v_values[sampling_idx]);
 
+    // Note: We accumulate values in (t-window_length, t] with t=
+    // v_timestamps[sampling_idx].
     const auto left_limit = v_timestamps[sampling_idx] - window_length;
-    while (next_begin_idx < n_event &&
-           v_timestamps[next_begin_idx] <= left_limit) {
-      if (next_begin_idx >= 0) {
-        // Remove from accumulator.
-        const auto value = v_values[next_begin_idx];
-        if (!std::isnan(value)) {
-          num_values--;
-          sum_values -= value;
-        }
-      }
-      next_begin_idx++;
+    while (begin_idx < n_event && v_timestamps[begin_idx] <= left_limit) {
+      accumulator.Remove(v_values[begin_idx]);
+      begin_idx++;
     }
 
-    const T output = (num_values > 0) ? (sum_values / num_values)
-                                      : std::numeric_limits<T>::quiet_NaN();
-    v_output[sampling_idx] = output;
+    v_output[sampling_idx] = accumulator.Result();
   }
 
   return output;
 }
 
-// DO NOT SUBMIT: Can we merge the two?
-template <typename T>
-py::array_t<T> simple_moving_average(const ArrayD &event_timestamps,
-                                     const py::array_t<T> &event_values,
-                                     const ArrayD &sampling_timestamps,
-                                     const double window_length) {
+// Apply TAccumulator over the data sequentially and return the aggregated
+// results.
+template <typename INPUT, typename OUTPUT, typename TAccumulator>
+py::array_t<OUTPUT> accumulate(const ArrayD &event_timestamps,
+                               const py::array_t<INPUT> &event_values,
+                               const ArrayD &sampling_timestamps,
+                               const double window_length) {
   // Input size
   const size_t n_event = event_timestamps.shape(0);
   const size_t n_sampling = sampling_timestamps.shape(0);
 
   // Allocate output array
-  auto output = py::array_t<T>(n_sampling);
+  auto output = py::array_t<OUTPUT>(n_sampling);
 
   auto v_output = output.template mutable_unchecked<1>();
   auto v_timestamps = event_timestamps.unchecked<1>();
   auto v_values = event_values.template unchecked<1>();
   auto v_sampling = sampling_timestamps.unchecked<1>();
 
-  double sum_values = 0;
-  int num_values = 0;
+  TAccumulator accumulator;
 
-  size_t next_begin_idx = 0;
+  size_t begin_idx = 0;
   size_t end_idx = 0;
 
   for (size_t sampling_idx = 0; sampling_idx < n_sampling; sampling_idx++) {
@@ -93,62 +82,227 @@ py::array_t<T> simple_moving_average(const ArrayD &event_timestamps,
     const auto left_limit = v_sampling[sampling_idx] - window_length;
 
     while (end_idx < n_event && v_timestamps[end_idx] <= right_limit) {
-      // Add from accumulator.
-      const auto value = v_values[end_idx];
-      if (!std::isnan(value)) {
-        num_values++;
-        sum_values += value;
-      }
+      accumulator.Add(v_values[end_idx]);
       end_idx++;
     }
 
-    while (next_begin_idx < n_event &&
-           v_timestamps[next_begin_idx] <= left_limit) {
-      if (next_begin_idx >= 0) {
-        // Remove from accumulator.
-        const auto value = v_values[next_begin_idx];
-        if (!std::isnan(value)) {
-          num_values--;
-          sum_values -= value;
-        }
-      }
-      next_begin_idx++;
+    while (begin_idx < n_event && v_timestamps[begin_idx] <= left_limit) {
+      accumulator.Remove(v_values[begin_idx]);
+      begin_idx++;
     }
 
-    v_output[sampling_idx] = 0;
+    v_output[sampling_idx] = accumulator.Result();
   }
 
   return output;
 }
 
+// Note: We only use inheritence to compile check the code.
+template <typename INPUT, typename OUTPUT> struct Accumulator {
+  virtual void Add(INPUT value) = 0;
+  virtual void Remove(INPUT value) = 0;
+  virtual OUTPUT Result() = 0;
+};
+
+template <typename INPUT, typename OUTPUT>
+struct SimpleMovingAverageAccumulator : Accumulator<INPUT, OUTPUT> {
+
+  void Add(INPUT value) override {
+    if (std::isnan(value)) {
+      return;
+    }
+    sum_values += value;
+    num_values++;
+  }
+
+  void Remove(INPUT value) override {
+    if (std::isnan(value)) {
+      return;
+    }
+    sum_values -= value;
+    num_values--;
+  }
+
+  OUTPUT Result() override {
+    return (num_values > 0) ? (sum_values / num_values)
+                            : std::numeric_limits<OUTPUT>::quiet_NaN();
+  }
+
+  // TODO(gbm): Increase precision of accumulator.
+
+  // Sum of the values in the rolling window (RW).
+  double sum_values = 0;
+  // Number of values in the RW.
+  int num_values = 0;
+};
+
+template <typename INPUT, typename OUTPUT>
+struct MovingStandardDeviationAccumulator : Accumulator<INPUT, OUTPUT> {
+
+  void Add(INPUT value) override {
+    if (std::isnan(value)) {
+      return;
+    }
+    sum_values += value;
+    sum_square_values += value * value;
+    num_values++;
+  }
+
+  void Remove(INPUT value) override {
+    if (std::isnan(value)) {
+      return;
+    }
+    sum_values -= value;
+    sum_square_values -= value * value;
+    num_values--;
+  }
+
+  OUTPUT Result() override {
+    if (num_values == 0) {
+      return std::numeric_limits<OUTPUT>::quiet_NaN();
+    }
+    const auto mean = sum_values / num_values;
+    return sqrt(sum_square_values / num_values - mean * mean);
+  }
+
+  // Sum of the values in the rolling window (RW).
+  double sum_values = 0;
+  double sum_square_values = 0;
+  // Number of values in the RW.
+  int num_values = 0;
+};
+
+template <typename INPUT, typename OUTPUT>
+struct MovingCountAccumulator : Accumulator<INPUT, OUTPUT> {
+
+  void Add(INPUT value) override {
+
+    static_assert(std::is_same<OUTPUT, int32_t>::value,
+                  "OUTPUT must be int32_t");
+
+    // TODO: Skip for non floating point types.
+    if (std::isnan(value)) {
+      return;
+    }
+    num_values++;
+  }
+
+  void Remove(INPUT value) override {
+    // TODO: Skip for non floating point types.
+    if (std::isnan(value)) {
+      return;
+    }
+    num_values--;
+  }
+
+  OUTPUT Result() override { return num_values; }
+
+  // Number of values in the RW.
+  int32_t num_values = 0;
+};
+
+template <typename INPUT, typename OUTPUT>
+struct MovingSumAccumulator : Accumulator<INPUT, OUTPUT> {
+
+  void Add(INPUT value) override {
+    // TODO: Skip for non floating point types.
+    if (std::isnan(value)) {
+      return;
+    }
+    sum_values += value;
+  }
+
+  void Remove(INPUT value) override {
+    // TODO: Skip for non floating point types.
+    if (std::isnan(value)) {
+      return;
+    }
+    sum_values -= value;
+  }
+
+  OUTPUT Result() override { return sum_values; }
+
+  // Sum of the values in the rolling window (RW).
+  double sum_values = 0;
+};
+
+// Instantiate the "accumulate" function with an accumulator for both float32
+// and float64 precision.
+//
+// Args:
+//   NAME: Name of the python and c++ function.
+//   INPUT: Input value type.
+//   OUTPUT: Output value type.
+//   ACCUMULATOR: Accumulator class.
+#define REGISTER_CC_FUNC(NAME, INPUT, OUTPUT, ACCUMULATOR)                     \
+                                                                               \
+  py::array_t<OUTPUT> NAME(const ArrayD &event_timestamps,                     \
+                           const py::array_t<INPUT> &event_values,             \
+                           const double window_length) {                       \
+    return accumulate<INPUT, OUTPUT, ACCUMULATOR<INPUT, OUTPUT>>(              \
+        event_timestamps, event_values, window_length);                        \
+  }                                                                            \
+                                                                               \
+  py::array_t<OUTPUT> NAME(                                                    \
+      const ArrayD &event_timestamps, const py::array_t<INPUT> &event_values,  \
+      const ArrayD &sampling_timestamps, const double window_length) {         \
+    return accumulate<INPUT, OUTPUT, ACCUMULATOR<INPUT, OUTPUT>>(              \
+        event_timestamps, event_values, sampling_timestamps, window_length);   \
+  }
+
+REGISTER_CC_FUNC(simple_moving_average, float, float,
+                 SimpleMovingAverageAccumulator)
+REGISTER_CC_FUNC(simple_moving_average, double, double,
+                 SimpleMovingAverageAccumulator)
+
+REGISTER_CC_FUNC(moving_standard_deviation, float, float,
+                 MovingStandardDeviationAccumulator)
+REGISTER_CC_FUNC(moving_standard_deviation, double, double,
+                 MovingStandardDeviationAccumulator)
+
+REGISTER_CC_FUNC(moving_sum, float, float, MovingSumAccumulator)
+REGISTER_CC_FUNC(moving_sum, double, double, MovingSumAccumulator)
+
+REGISTER_CC_FUNC(moving_count, float, int32_t, MovingCountAccumulator)
+REGISTER_CC_FUNC(moving_count, double, int32_t, MovingCountAccumulator)
+REGISTER_CC_FUNC(moving_count, int32_t, int32_t, MovingCountAccumulator)
+REGISTER_CC_FUNC(moving_count, int64_t, int32_t, MovingCountAccumulator)
+
 } // namespace
 
+// Register c++ functions to pybind with and without sampling.
+//
+// Args:
+//   NAME: Name of the python and c++ function.
+//   INPUT: Input value type.
+//   OUTPUT: Output value type.
+//
+#define ADD_PY_DEF(NAME, INPUT, OUTPUT)                                        \
+  m.def(#NAME,                                                                 \
+        py::overload_cast<const ArrayD &, const py::array_t<INPUT> &,          \
+                          const ArrayD &, double>(&NAME),                      \
+        "", py::arg("event_timestamps").noconvert(),                           \
+        py::arg("event_values").noconvert(),                                   \
+        py::arg("sampling_timestamps").noconvert(), py::arg("window_length")); \
+                                                                               \
+  m.def(#NAME,                                                                 \
+        py::overload_cast<const ArrayD &, const py::array_t<INPUT> &, double>( \
+            &NAME),                                                            \
+        "", py::arg("event_timestamps").noconvert(),                           \
+        py::arg("event_values").noconvert(), py::arg("window_length"));
+
 PYBIND11_MODULE(window, m) {
-  m.def(
-      "simple_moving_average_float32",
-      py::overload_cast<const ArrayD &, const ArrayF &, const ArrayD &, double>(
-          &simple_moving_average<float>),
-      "", py::arg("event_timestamps").noconvert(),
-      py::arg("event_values").noconvert(),
-      py::arg("sampling_timestamps").noconvert(), py::arg("window_length"));
+  ADD_PY_DEF(simple_moving_average, float, float)
+  ADD_PY_DEF(simple_moving_average, double, double)
 
-  m.def("simple_moving_average_float32",
-        py::overload_cast<const ArrayD &, const ArrayF &, double>(
-            &simple_moving_average<float>),
-        "", py::arg("event_timestamps").noconvert(),
-        py::arg("event_values").noconvert(), py::arg("window_length"));
+  ADD_PY_DEF(moving_standard_deviation, float, float)
+  ADD_PY_DEF(moving_standard_deviation, double, double)
 
-  m.def(
-      "simple_moving_average_float64",
-      py::overload_cast<const ArrayD &, const ArrayD &, const ArrayD &, double>(
-          &simple_moving_average<double>),
-      "", py::arg("event_timestamps").noconvert(),
-      py::arg("event_values").noconvert(),
-      py::arg("sampling_timestamps").noconvert(), py::arg("window_length"));
+  ADD_PY_DEF(moving_sum, float, float)
+  ADD_PY_DEF(moving_sum, double, double)
 
-  m.def("simple_moving_average_float64",
-        py::overload_cast<const ArrayD &, const ArrayD &, double>(
-            &simple_moving_average<double>),
-        "", py::arg("event_timestamps").noconvert(),
-        py::arg("event_values").noconvert(), py::arg("window_length"));
+  ADD_PY_DEF(moving_count, float, int32_t)
+  ADD_PY_DEF(moving_count, double, int32_t)
+  ADD_PY_DEF(moving_count, int32_t, int32_t)
+  ADD_PY_DEF(moving_count, int64_t, int32_t)
 }

--- a/temporian/test/api_test.py
+++ b/temporian/test/api_test.py
@@ -42,7 +42,7 @@ class TFPTest(absltest.TestCase):
         i2 = i2_data.schema()
         h1 = t.simple_moving_average(event=i1, window_length=7)
         h2 = t.sample(event=h1, sampling=i2)
-        result = t.glue(h2["sma_f2"], i2)
+        result = t.glue(t.prefix("sma_", h2["f2"]), i2)
 
         result_data = t.evaluate(
             query=result,


### PR DESCRIPTION
Bonus:
- Using the benchmark script, we see a x2000 speed-up.
- There is not allocated work memory anymore (only the output).

Benchmark:

Before
```
Running lag benchmark with N=300000...
Build schedule
Run 1 operators
    1 / 1: SIMPLE_MOVING_AVERAGE [7.26928 s]
Execution in 7.26963 s
```

After
```
Running lag benchmark with N=300000...
Build schedule
Run 1 operators
    1 / 1: SIMPLE_MOVING_AVERAGE [0.00371 s]
Execution in 0.00405 s
```

