### PR TITLE
Optimize `from_df()`

### DIFF
--- a/benchmark/benchmark_time.py
+++ b/benchmark/benchmark_time.py
@@ -65,6 +65,7 @@ def _build_toy_dataset(
             }
         ),
         index_names=["index_1", "index_2"],
+        is_sorted=True,
     )
 
 
@@ -220,7 +221,9 @@ def benchmark_from_dataframe(runner):
 
                     runner.benchmark(
                         benchmark_name,
-                        lambda: NumpyEvent.from_dataframe(df, index_names),
+                        lambda: NumpyEvent.from_dataframe(
+                            df, index_names, is_sorted=True
+                        ),
                     )
 
 

--- a/temporian/implementation/numpy/data/event.py
+++ b/temporian/implementation/numpy/data/event.py
@@ -240,15 +240,22 @@ class NumpyEvent:
             Returns:
                 pd.Series: Converted timestamp column to Unix Epoch float.
             """
+            # check if timestamp column contains missing values and raise error
+            if timestamp_column.isna().any():
+                raise ValueError(
+                    f"Cannot convert timestamp column {timestamp_column.name} "
+                    "to Unix Epoch Float because it contains missing values."
+                )
+
             # if timestamp_column is already float64, ignore it
             if timestamp_column.dtype == "float64":
                 return timestamp_column
 
-            # if timestamp_column is int or float != float64, convert to float64
+            # if timestamp_column is int or float != float64 convert to float64
             if timestamp_column.dtype.kind in ("i", "f"):
                 return timestamp_column.astype("float64")
 
-            # string and objects will be converted to datetime and then to float
+            # string and objects will be converted to datetime, then to float
             timestamp_column = pd.to_datetime(timestamp_column, errors="raise")
             timestamp_column = timestamp_column.view("int64") / 1e9
             return timestamp_column
@@ -275,11 +282,8 @@ class NumpyEvent:
                 f"Timestamp column {timestamp_column} cannot be on index_names"
             )
 
-        # check if created sampling's values will be unix timestamps. #TODO:
-        # the user should also be able to specifiy wether it's a unix timestamp
-        is_unix_timestamp = pd.api.types.is_datetime64_any_dtype(
-            df[timestamp_column]
-        )
+        # check if created sampling's values will be unix timestamps
+        is_unix_timestamp = df[timestamp_column].dtype.kind not in ("i", "f")
 
         # convert timestamp column to Unix Epoch Float
         df[timestamp_column] = convert_timestamp_column_to_unix_epoch_float(

--- a/temporian/implementation/numpy/data/event.py
+++ b/temporian/implementation/numpy/data/event.py
@@ -258,9 +258,17 @@ class NumpyEvent:
         )
         # convert timestamp column to float
         # TODO: This is taking a lot of time. Don't use apply.
-        df[timestamp_column] = df[timestamp_column].apply(
-            convert_date_to_duration
-        )
+
+        # if timestamp column is of kind int convert to float
+        if df[timestamp_column].dtype.kind == "i":
+            df[timestamp_column] = df[timestamp_column].astype("float64")
+
+        elif df[timestamp_column].dtype.type not in DTYPE_MAPPING.keys():
+            df[timestamp_column] = pd.to_datetime(
+                df[timestamp_column], errors="raise"
+            )
+            # convert from nanoseconds to seconds and float
+            df[timestamp_column] = df[timestamp_column].astype("int64") / 1e9
 
         # sort by timestamp if it's not sorted
         # TODO: we may consider using kind="mergesort" if we know that most of

--- a/temporian/implementation/numpy/data/event.py
+++ b/temporian/implementation/numpy/data/event.py
@@ -281,14 +281,14 @@ class NumpyEvent:
             # if dtype is object, check if it only contains string values
             if df[column].dtype.type is np.object_:
                 df[column] = df[column].fillna("")
-                # TODO: Don't use apply.
-                is_string = df[column].apply(lambda x: isinstance(x, str))
-                if not is_string.all():
+                # Check if there are any non-string elements in the column
+                non_string_mask = df[column].map(type) != str
+                if non_string_mask.any():
                     raise ValueError(
                         f'Cannot convert column "{column}". Column of type'
-                        ' "Object" can only values. However, the following'
-                        " non-string values were found: "
-                        f" {df[column][~is_string]}"
+                        ' "Object" can only have string values. However, the'
+                        " following non-string values were found: "
+                        f" {df[column][non_string_mask]}"
                     )
                 # convert object column to np.string_
                 df[column] = df[column].astype("string")

--- a/temporian/implementation/numpy/data/sampling.py
+++ b/temporian/implementation/numpy/data/sampling.py
@@ -13,6 +13,7 @@ PYTHON_DTYPE_MAPPING = {
     str: DType.STRING,
     # TODO: fix this, int doesn't have to be INT64 necessarily
     int: DType.INT64,
+    np.int64: DType.INT64,
 }
 
 

--- a/temporian/implementation/numpy/data/test/df_to_event_test.py
+++ b/temporian/implementation/numpy/data/test/df_to_event_test.py
@@ -405,6 +405,22 @@ class DataFrameToEventTest(absltest.TestCase):
                 df, index_names=["product_id"], timestamp_column="timestamp"
             )
 
+    def test_timestamp_column_with_non_supported_object(self) -> None:
+        df = pd.DataFrame(
+            [
+                [666964, 1.0, 740.0],
+                [666964, 2.0, 508.0],
+                [574016, 3.0, 573.0],
+                [574016, object(), 573.0],
+            ],
+            columns=["product_id", "timestamp", "costs"],
+        )
+
+        with self.assertRaises(TypeError):
+            NumpyEvent.from_dataframe(
+                df, index_names=["product_id"], timestamp_column="timestamp"
+            )
+
     def test_no_index(self) -> None:
         df = pd.DataFrame(
             [


### PR DESCRIPTION
Depends on #93 

- [x] Vectorized date conversion. -> 13x impact for 0 Indexes, negligible for multi-index.
- [x] Very slight improvement by changing apply to map for checking mixed types in object columns. -> Barely noticeable 
- [x]  Remove `get_group(group)`. Call `group[column_name]` directly. -> 2x impact with multiple indexes, doesn't apply to no index.

>__Warning__: Had to add np.int64 to PYTHON_DTYPE_MAPPING in order to pass the test after implementing the third point. Don't really understand the reason for this change yet.  Check [this commit](https://github.com/google/temporian/pull/96/commits/8857a8f9b9947b4a326f4b5e5184aa22a8f6b463).

Previous time:
```
================================================================
Name                              Wall time (s)    CPU time (s)
================================================================
from_dataframe:s:10000_numidx:0_numidxval:20_idx:int       0.00198       0.00542
from_dataframe:s:10000_numidx:0_numidxval:20_idx:str       0.00193       0.00193
from_dataframe:s:10000_numidx:1_numidxval:20_idx:int       0.00529       0.00528
from_dataframe:s:10000_numidx:1_numidxval:20_idx:str       0.00897       0.00897
from_dataframe:s:10000_numidx:3_numidxval:20_idx:int       0.69247       0.69235
from_dataframe:s:10000_numidx:3_numidxval:20_idx:str       1.14818       1.13795
from_dataframe:s:10000_numidx:5_numidxval:20_idx:int       1.28118       1.27048
from_dataframe:s:10000_numidx:5_numidxval:20_idx:str       2.31480       2.30958
```

New time:

```
================================================================
Name                              Wall time (s)    CPU time (s)
================================================================
from_dataframe:s:10000_numidx:0_numidxval:20_idx:int       0.00015       0.00015
from_dataframe:s:10000_numidx:0_numidxval:20_idx:str       0.00014       0.00014
from_dataframe:s:10000_numidx:1_numidxval:20_idx:int       0.00192       0.00192
from_dataframe:s:10000_numidx:1_numidxval:20_idx:str       0.00545       0.00545
from_dataframe:s:10000_numidx:3_numidxval:20_idx:int       0.36431       0.36395
from_dataframe:s:10000_numidx:3_numidxval:20_idx:str       0.55161       0.55124
from_dataframe:s:10000_numidx:5_numidxval:20_idx:int       0.63044       0.63038
from_dataframe:s:10000_numidx:5_numidxval:20_idx:str       1.14939       1.14907
```

Speed up:

```
================================================================
Name                              Wall time Speed up  CPU time Speed up
================================================================
from_dataframe:s:10000_numidx:0_numidxval:20_idx:int       13.2x           36.1x
from_dataframe:s:10000_numidx:0_numidxval:20_idx:str       13.8x           13.8x
from_dataframe:s:10000_numidx:1_numidxval:20_idx:int        2.8x            2.8x
from_dataframe:s:10000_numidx:1_numidxval:20_idx:str        1.6x            1.6x
from_dataframe:s:10000_numidx:3_numidxval:20_idx:int        1.9x            1.9x
from_dataframe:s:10000_numidx:3_numidxval:20_idx:str        2.1x            2.1x
from_dataframe:s:10000_numidx:5_numidxval:20_idx:int        2.0x            2.0x
from_dataframe:s:10000_numidx:5_numidxval:20_idx:str        2.0x            2.0x
```

We can see from the table that the most important aspect to optimize is the logic when there are multiple indexes. Grouping probably takes the most time.

>__Warning__: Couldnt run the profiler to profile from_dataframe.