### PR TITLE
Remove Lag Operator auto naming

### DIFF
--- a/temporian/core/operators/lag.py
+++ b/temporian/core/operators/lag.py
@@ -45,13 +45,10 @@ class LagOperator(Operator):
             index_levels=event.sampling.index.levels, creator=self
         )
 
-        prefix = "lag" if duration > 0 else "leak"
-        duration_str = duration_abbreviation(duration)
-
         # outputs
         output_features = [  # pylint: disable=g-complex-comprehension
             Feature(
-                name=f"{prefix}[{duration_str}]_{f.name}",
+                name=f.name,
                 dtype=f.dtype,
                 sampling=output_sampling,
                 creator=self,

--- a/temporian/implementation/numpy/operators/lag.py
+++ b/temporian/implementation/numpy/operators/lag.py
@@ -19,16 +19,13 @@ class LagNumpyImplementation(OperatorImplementation):
         sampling_data = {}
         output_data = {}
 
-        prefix = "lag" if duration > 0 else "leak"
-        duration_str = duration_abbreviation(duration)
-
         for index, timestamps in event.sampling.data.items():
             sampling_data[index] = timestamps + duration
             output_data[index] = []
             for feature in event.data[index]:
                 new_feature = NumpyFeature(
                     data=feature.data,
-                    name=f"{prefix}[{duration_str}]_{feature.name}",
+                    name=feature.name,
                 )
                 output_data[index].append(new_feature)
 

--- a/temporian/implementation/numpy/operators/test/lag_test.py
+++ b/temporian/implementation/numpy/operators/test/lag_test.py
@@ -60,7 +60,7 @@ class LagNumpyImplementationTest(absltest.TestCase):
                     [0, 12, 15.0],
                     [0, 22, 16.0],
                 ],
-                columns=["store_id", "timestamp", "lag[2s]_sales"],
+                columns=["store_id", "timestamp", "sales"],
             ),
             index_names=["store_id"],
         )
@@ -112,7 +112,7 @@ class LagNumpyImplementationTest(absltest.TestCase):
                 columns=[
                     "store_id",
                     "timestamp",
-                    "lag[1s]_sales",
+                    "sales",
                 ],
             ),
             index_names=["store_id"],
@@ -132,7 +132,7 @@ class LagNumpyImplementationTest(absltest.TestCase):
                 columns=[
                     "store_id",
                     "timestamp",
-                    "lag[2s]_sales",
+                    "sales",
                 ],
             ),
             index_names=["store_id"],
@@ -202,7 +202,7 @@ class LagNumpyImplementationTest(absltest.TestCase):
                     [0, 8, 15.0],
                     [0, 18, 16.0],
                 ],
-                columns=["store_id", "timestamp", "leak[2s]_sales"],
+                columns=["store_id", "timestamp", "sales"],
             ),
             index_names=["store_id"],
         )
@@ -254,7 +254,7 @@ class LagNumpyImplementationTest(absltest.TestCase):
                 columns=[
                     "store_id",
                     "timestamp",
-                    "leak[1s]_sales",
+                    "sales",
                 ],
             ),
             index_names=["store_id"],
@@ -274,7 +274,7 @@ class LagNumpyImplementationTest(absltest.TestCase):
                 columns=[
                     "store_id",
                     "timestamp",
-                    "leak[2s]_sales",
+                    "sales",
                 ],
             ),
             index_names=["store_id"],

--- a/temporian/test/prototype_test_numpy.py
+++ b/temporian/test/prototype_test_numpy.py
@@ -103,7 +103,7 @@ class PrototypeTest(absltest.TestCase):
         # create and glue sum feature
         # TODO: Restore when arithmetic operator is fixed.
         # b = tp.glue(a, self.event_1 + self.event_2)
-        c = tp.lag(self.event_1, duration=1)
+        c = tp.prefix("lag[1s]_", tp.lag(self.event_1, duration=1))
         d = tp.glue(a, tp.sample(c, a))
         sub_sales = 0 - self.event_1["sales"]
         e = tp.glue(d, sub_sales)


### PR DESCRIPTION
- [x] Removed lag auto naming.

>__Note__: Window operators already had no auto naming.