### PR TITLE
Fix window accumulation

### DIFF
--- a/temporian/implementation/numpy/operators/test/moving_count_test.py
+++ b/temporian/implementation/numpy/operators/test/moving_count_test.py
@@ -26,7 +26,6 @@ from temporian.implementation.numpy.operators.window.moving_count import (
 )
 from temporian.implementation.numpy.data.event_set import EventSet
 from temporian.core.data import node as node_lib
-from numpy.testing import assert_array_equal
 
 
 def _f64(l):
@@ -48,11 +47,11 @@ class MovingCountOperatorTest(absltest.TestCase):
     def test_cc_wo_sampling(self):
         assert_array_equal(
             operators_cc.moving_count(
-                _f64([1, 2, 3, 5, 20]),
-                _f32([10, nan, 12, 13, 14]),
+                _f64([1, 2, 3, 5, 5, 5, 20]),
+                _f32([10, nan, 12, 13, 14, 15, 16]),
                 5.0,
             ),
-            _i32([1, 1, 2, 3, 1]),
+            _i32([1, 1, 2, 5, 5, 5, 1]),
         )
 
     def test_flat(self):
@@ -61,11 +60,13 @@ class MovingCountOperatorTest(absltest.TestCase):
         evset = EventSet.from_dataframe(
             pd.DataFrame(
                 [
+                    [9.0, 19.0, 1],
                     [10.0, 20.0, 1],
-                    [00.0, 21.0, 2],
+                    [11.0, 21.0, 2],
                     [12.0, 00.0, 3],
                     [13.0, 23.0, 5],
                     [14.0, 24.0, 20],
+                    [15.0, 25.0, 20],
                 ],
                 columns=["a", "b", "timestamp"],
             )
@@ -84,11 +85,13 @@ class MovingCountOperatorTest(absltest.TestCase):
         expected_output = EventSet.from_dataframe(
             pd.DataFrame(
                 [
-                    [1, 1, 1],
-                    [2, 2, 2],
-                    [3, 3, 3],
-                    [4, 4, 5],
-                    [1, 1, 20],
+                    [2, 2, 1],
+                    [2, 2, 1],
+                    [3, 3, 2],
+                    [4, 4, 3],
+                    [5, 5, 5],
+                    [2, 2, 20],
+                    [2, 2, 20],
                 ],
                 columns=["a", "b", "timestamp"],
             ).astype({"a": np.int32, "b": np.int32})
@@ -237,6 +240,7 @@ class MovingCountOperatorTest(absltest.TestCase):
                     [2],
                     [2.5],
                     [3],
+                    [3],
                     [3.5],
                     [4],
                     [5],
@@ -254,6 +258,7 @@ class MovingCountOperatorTest(absltest.TestCase):
                     [0, 1],
                     [1, 2],
                     [1, 2.5],
+                    [1, 3],
                     [1, 3],
                     [0, 3.5],
                     [0, 4],

--- a/temporian/implementation/numpy/operators/test/moving_max_test.py
+++ b/temporian/implementation/numpy/operators/test/moving_max_test.py
@@ -12,11 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from absl.testing import absltest
 import math
 
+from absl.testing import absltest
 import pandas as pd
 import numpy as np
+from numpy.testing import assert_array_equal
 
 from temporian.core.operators.window.moving_max import (
     MovingMaxOperator,
@@ -25,9 +26,7 @@ from temporian.implementation.numpy.operators.window.moving_max import (
     MovingMaxNumpyImplementation,
     operators_cc,
 )
-from temporian.implementation.numpy.data.event_set import IndexData
 from temporian.implementation.numpy.data.event_set import EventSet
-from numpy.testing import assert_array_equal
 
 
 def _f64(l):
@@ -49,11 +48,11 @@ class MovingMaxOperatorTest(absltest.TestCase):
     def test_cc_wo_sampling(self):
         assert_array_equal(
             operators_cc.moving_max(
-                _f64([0, 1, 2, 3, 5, 20]),
-                _f32([nan, 10, nan, 12, 13, 14]),
+                _f64([0, 1, 2, 3, 5, 5, 20]),
+                _f32([nan, 10, nan, 12, 13, 14, 15]),
                 3.5,
             ),
-            _f32([nan, 10, 10, 12, 13, 14]),
+            _f32([nan, 10, 10, 12, 14, 14, 15]),
         )
 
     def test_cc_w_sampling(self):

--- a/temporian/implementation/numpy/operators/test/moving_min_test.py
+++ b/temporian/implementation/numpy/operators/test/moving_min_test.py
@@ -12,20 +12,19 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from absl.testing import absltest
 import math
 
+from absl.testing import absltest
 import pandas as pd
 import numpy as np
+from numpy.testing import assert_array_equal
 
 from temporian.core.operators.window.moving_min import MovingMinOperator
 from temporian.implementation.numpy.operators.window.moving_min import (
     MovingMinNumpyImplementation,
     operators_cc,
 )
-from temporian.implementation.numpy.data.event_set import IndexData
 from temporian.implementation.numpy.data.event_set import EventSet
-from numpy.testing import assert_array_equal
 
 
 def _f64(l):
@@ -47,11 +46,11 @@ class MovingMinOperatorTest(absltest.TestCase):
     def test_cc_wo_sampling(self):
         assert_array_equal(
             operators_cc.moving_min(
-                _f64([0, 1, 2, 3, 5, 20]),
-                _f32([nan, 10, nan, 12, 13, 14]),
+                _f64([0, 1, 2, 3, 5, 6, 6, 20]),
+                _f32([nan, 10, nan, 12, 13, 14, 2, 15]),
                 3.5,
             ),
-            _f32([nan, 10, 10, 10, 12, 14]),
+            _f32([nan, 10, 10, 10, 12, 2, 2, 15]),
         )
 
     def test_cc_w_sampling(self):

--- a/temporian/implementation/numpy/operators/test/moving_standard_deviation_test.py
+++ b/temporian/implementation/numpy/operators/test/moving_standard_deviation_test.py
@@ -28,8 +28,6 @@ from temporian.implementation.numpy.operators.window.moving_standard_deviation i
 )
 from temporian.implementation.numpy.data.event_set import EventSet
 from temporian.core.data import node as node_lib
-import math
-from numpy.testing import assert_almost_equal
 
 
 def _f64(l):

--- a/temporian/implementation/numpy/operators/test/moving_sum_test.py
+++ b/temporian/implementation/numpy/operators/test/moving_sum_test.py
@@ -19,7 +19,6 @@ import numpy as np
 from numpy.testing import assert_array_equal
 import pandas as pd
 
-from absl.testing import absltest
 from temporian.core.operators.window.moving_sum import (
     MovingSumOperator,
 )
@@ -29,10 +28,6 @@ from temporian.implementation.numpy.operators.window.moving_sum import (
 )
 from temporian.implementation.numpy.data.event_set import EventSet
 from temporian.core.data import node as node_lib
-from temporian.core.data import feature as feature_lib
-from temporian.core.data import dtype as dtype_lib
-import math
-from numpy.testing import assert_array_equal
 
 
 def _f64(l):
@@ -50,11 +45,11 @@ class MovingSumOperatorTest(absltest.TestCase):
     def test_cc_wo_sampling(self):
         assert_array_equal(
             operators_cc.moving_sum(
-                _f64([1, 2, 3, 5, 20]),
-                _f32([10, nan, 12, 13, 14]),
+                _f64([1, 2, 3, 5, 20, 20]),
+                _f32([10, nan, 12, 13, 14, 2]),
                 5.0,
             ),
-            _f32([10.0, 10.0, 22.0, 35.0, 14.0]),
+            _f32([10.0, 10.0, 22.0, 35.0, 16.0, 16.0]),
         )
 
     def test_flat(self):

--- a/temporian/implementation/numpy/operators/test/simple_moving_average_test.py
+++ b/temporian/implementation/numpy/operators/test/simple_moving_average_test.py
@@ -12,9 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from absl.testing import absltest
 import math
 
+from absl.testing import absltest
 import numpy as np
 from numpy.testing import assert_array_equal
 import pandas as pd
@@ -28,10 +28,6 @@ from temporian.implementation.numpy.operators.window.simple_moving_average impor
 )
 from temporian.implementation.numpy.data.event_set import EventSet
 from temporian.core.data import node as node_lib
-from temporian.core.data import feature as feature_lib
-from temporian.core.data import dtype as dtype_lib
-import math
-from numpy.testing import assert_array_equal
 
 
 def _f64(l):
@@ -64,22 +60,22 @@ class SimpleMovingAverageOperatorTest(absltest.TestCase):
     def test_cc_wo_sampling(self):
         assert_array_equal(
             cc_sma(
-                _f64([1, 2, 3, 5, 20]),
-                _f32([10, 11, 12, 13, 14]),
+                _f64([1, 2, 3, 5, 5, 20]),
+                _f32([10, 11, 12, 13, 14, 15]),
                 5.0,
             ),
-            _f32([10.0, 10.5, 11.0, 11.5, 14.0]),
+            _f32([10.0, 10.5, 11.0, 12.0, 12.0, 15.0]),
         )
 
     def test_cc_w_sampling(self):
         assert_array_equal(
             cc_sma(
-                _f64([1, 2, 3, 5, 6]),
-                _f32([10, 11, 12, 13, 14]),
+                _f64([1, 2, 3, 3, 5, 6]),
+                _f32([10, 11, 12, 13, 14, 15]),
                 _f64([-1.0, 1.0, 1.1, 3.0, 3.5, 6.0, 10.0]),
                 3.0,
             ),
-            _f32([nan, 10.0, 10.0, 11.0, 11.0, 13.5, nan]),
+            _f32([nan, 10.0, 10.0, 11.5, 11.5, 14.5, nan]),
         )
 
     def test_cc_w_nan_wo_sampling(self):

--- a/temporian/implementation/numpy_cc/operators/window.cc
+++ b/temporian/implementation/numpy_cc/operators/window.cc
@@ -34,27 +34,30 @@ py::array_t<OUTPUT> accumulate(const ArrayD &evset_timestamps,
 
   TAccumulator accumulator;
 
-  // Index of the first value in the RW.
+  // Index of the first value in the window.
   size_t begin_idx = 0;
+  // Index of the first value outside the window.
+  size_t end_idx = 0;
 
-  for (size_t sampling_idx = 0; sampling_idx < n_event; sampling_idx++) {
+  while (end_idx < n_event) {
     // Note: We accumulate values in (t-window_length, t] with t=
-    // v_timestamps[sampling_idx], and there may be several contiguous equal
+    // v_timestamps[end_idx], and there may be several contiguous equal
     // values in v_timestamps.
 
     // Add all values with same timestamp as the current one.
-    accumulator.Add(v_values[sampling_idx]);
-    size_t same_ts_idx = sampling_idx;
+    accumulator.Add(v_values[end_idx]);
+    const auto current_ts = v_timestamps[end_idx];
+    size_t first_diff_ts_idx = end_idx + 1;
     while (
-      same_ts_idx + 1 < n_event &&
-      v_timestamps[same_ts_idx] == v_timestamps[same_ts_idx + 1]
+      first_diff_ts_idx < n_event &&
+      v_timestamps[first_diff_ts_idx] == current_ts
     ) {
-      same_ts_idx++;
-      accumulator.Add(v_values[same_ts_idx]);
+      accumulator.Add(v_values[first_diff_ts_idx]);
+      first_diff_ts_idx++;
     }
 
     // Remove all values that no longer belong to the window.
-    const auto left_limit = v_timestamps[sampling_idx] - window_length;
+    const auto left_limit = v_timestamps[end_idx] - window_length;
     while (begin_idx < n_event && v_timestamps[begin_idx] <= left_limit) {
       accumulator.Remove(v_values[begin_idx]);
       begin_idx++;
@@ -62,12 +65,12 @@ py::array_t<OUTPUT> accumulate(const ArrayD &evset_timestamps,
 
     // Set current value of window to all values with the same timestamp.
     const auto result = accumulator.Result();
-    for (size_t i = sampling_idx; i <= same_ts_idx; i++) {
+    for (size_t i = end_idx; i < first_diff_ts_idx; i++) {
       v_output[i] = result;
     }
 
     // Move pointer to the index of the last value with the same timestamp.
-    sampling_idx = same_ts_idx;
+    end_idx = first_diff_ts_idx;
   }
 
   return output;


### PR DESCRIPTION
Fix for tiny bug we discovered today. The `accumulate` function in `window.cc` didn't account for the possibility of there being equal timestamps in `evset_timestamps`, which caused two values in the same timestamp to end up with a different result in all window ops.