### PR TITLE
Avoid assign value to Node and EventSet

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -18,7 +18,7 @@
     "editor.defaultFormatter": "ms-python.black-formatter"
   },
   "editor.tabSize": 4,
-  "editor.formatOnSave": false,
+  "editor.formatOnSave": true,
   "python.linting.flake8Enabled": false,
   "python.linting.pylintEnabled": true,
   "python.linting.enabled": true,

--- a/temporian/core/data/node.py
+++ b/temporian/core/data/node.py
@@ -163,6 +163,12 @@ class Node(object):
 
         return select(self, feature_names)
 
+    def __setitem__(self, feature_names: Any, value: Any) -> None:
+        """Fails, features cannot be assigned"""
+
+        raise TypeError("Cannot assign features to an existing node. "
+                        "New nodes should be created instead.")
+
     def __repr__(self) -> str:
         """Human readable representation of a node."""
 

--- a/temporian/core/data/node.py
+++ b/temporian/core/data/node.py
@@ -166,8 +166,10 @@ class Node(object):
     def __setitem__(self, feature_names: Any, value: Any) -> None:
         """Fails, features cannot be assigned"""
 
-        raise TypeError("Cannot assign features to an existing node. "
-                        "New nodes should be created instead.")
+        raise TypeError(
+            "Cannot assign features to an existing node. "
+            "New nodes should be created instead."
+        )
 
     def __repr__(self) -> str:
         """Human readable representation of a node."""

--- a/temporian/core/operators/select.py
+++ b/temporian/core/operators/select.py
@@ -38,7 +38,7 @@ class SelectOperator(Operator):
 
         for feature_name in feature_names:
             if feature_name not in input_feature_names:
-                raise ValueError(
+                raise IndexError(
                     f"Selected features {feature_name!r} is not part of the"
                     f" available features {input_feature_names!r}."
                 )
@@ -105,7 +105,7 @@ def select(
     elif isinstance(feature_names, str):
         feature_names = [feature_names]
     else:
-        raise ValueError(
+        raise TypeError(
             "Unexpected type for feature_names. Expect str or list of"
             f" str. Got '{feature_names}' instead."
         )

--- a/temporian/core/test/magic_methods_test.py
+++ b/temporian/core/test/magic_methods_test.py
@@ -121,7 +121,6 @@ class MagicMethodsTest(absltest.TestCase):
             assert node in node_list
             assert node in node_map
 
-
     #########################################
     ### Get/set item with square brackets ###
     #########################################
@@ -153,7 +152,6 @@ class MagicMethodsTest(absltest.TestCase):
         assert len(node_out.schema.features) == 0
         node_out.check_same_sampling(self.node_float_1)
 
-
     def test_getitem_errors(self):
         with self.assertRaises(IndexError):
             self.node_float_1["f3"]
@@ -165,7 +163,6 @@ class MagicMethodsTest(absltest.TestCase):
             self.node_float_1[["f1", 0]]
         with self.assertRaises(TypeError):
             self.node_float_1[None]
-
 
     def test_setitem_fails(self):
         # Try to modify existent feature

--- a/temporian/core/test/magic_methods_test.py
+++ b/temporian/core/test/magic_methods_test.py
@@ -121,6 +121,77 @@ class MagicMethodsTest(absltest.TestCase):
             assert node in node_list
             assert node in node_map
 
+
+    #########################################
+    ### Get/set item with square brackets ###
+    #########################################
+    def test_getitem_single(self):
+        node_out = self.node_float_1["f2"]
+        assert len(node_out.schema.features) == 1
+        assert node_out.schema.features[0].name == "f2"
+        assert node_out.schema.features[0].dtype == DType.FLOAT64
+        # Raises ValueError if fails
+        node_out.check_same_sampling(self.node_float_1)
+
+    def test_getitem_multiple(self):
+        node_out = self.node_float_1[["f2"]]
+        assert len(node_out.schema.features) == 1
+        assert node_out.schema.features[0].name == "f2"
+        assert node_out.schema.features[0].dtype == DType.FLOAT64
+        node_out.check_same_sampling(self.node_float_1)
+
+        node_out = self.node_float_1[["f2", "f1"]]
+        assert len(node_out.schema.features) == 2
+        assert node_out.schema.features[0].name == "f2"
+        assert node_out.schema.features[0].dtype == DType.FLOAT64
+        assert node_out.schema.features[1].name == "f1"
+        assert node_out.schema.features[1].dtype == DType.FLOAT32
+        node_out.check_same_sampling(self.node_float_1)
+
+        # Node with empty features
+        node_out = self.node_float_1[[]]
+        assert len(node_out.schema.features) == 0
+        node_out.check_same_sampling(self.node_float_1)
+
+
+    def test_getitem_errors(self):
+        with self.assertRaises(IndexError):
+            self.node_float_1["f3"]
+        with self.assertRaises(IndexError):
+            self.node_float_1[["f1", "f3"]]
+        with self.assertRaises(TypeError):
+            self.node_float_1[0]
+        with self.assertRaises(TypeError):
+            self.node_float_1[["f1", 0]]
+        with self.assertRaises(TypeError):
+            self.node_float_1[None]
+
+
+    def test_setitem_fails(self):
+        # Try to modify existent feature
+        with self.assertRaisesRegex(TypeError, "Cannot assign"):
+            self.node_float_1["f1"] = self.node_float_2["f3"]
+        with self.assertRaisesRegex(TypeError, "Cannot assign"):
+            self.node_float_1["f1"] = None
+
+        # Try to assign inexistent feature
+        with self.assertRaisesRegex(TypeError, "Cannot assign"):
+            self.node_float_1["f5"] = self.node_float_2["f3"]
+        with self.assertRaisesRegex(TypeError, "Cannot assign"):
+            self.node_float_1["f5"] = None
+
+        # Try to assign multiple features
+        with self.assertRaisesRegex(TypeError, "Cannot assign"):
+            self.node_float_1[["f1", "f2"]] = self.node_float_2[["f3", "f4"]]
+        with self.assertRaisesRegex(TypeError, "Cannot assign"):
+            self.node_float_1[["f1", "f2"]] = None
+
+        # Weird cases
+        with self.assertRaisesRegex(TypeError, "Cannot assign"):
+            self.node_float_1[[]] = None
+        with self.assertRaisesRegex(TypeError, "Cannot assign"):
+            self.node_float_1[None] = None
+
     ###################################
     ### Relational binary operators ###
     ###################################

--- a/temporian/implementation/numpy/data/event_set.py
+++ b/temporian/implementation/numpy/data/event_set.py
@@ -464,9 +464,19 @@ class EventSet:
         )
 
     def __getitem__(self, index: Tuple) -> IndexData:
+        if not isinstance(index, tuple):
+            raise TypeError(
+                "EventSet items can only be accessed by index tuples. "
+                "Use evset.node() to select features and operate on it."
+            )
         return self.data[index]
 
     def __setitem__(self, index: Tuple, value: IndexData) -> None:
+        if not isinstance(index, tuple) or not isinstance(value, IndexData):
+            raise TypeError(
+                "EventSets are not intended to be modified externally. "
+                "Use evset.node() to operate on it."
+            )
         self.data[index] = value
 
     def __eq__(self, other) -> bool:

--- a/temporian/implementation/numpy/data/test/event_set_test.py
+++ b/temporian/implementation/numpy/data/test/event_set_test.py
@@ -1,6 +1,7 @@
+import numpy as np
 from absl.testing import absltest
 
-from temporian.implementation.numpy.data.io import event_set
+from temporian.implementation.numpy.data.io import event_set, IndexData
 
 # TODO: Rename file to "event_set_test" and rename the following class to EventSetTest.
 
@@ -17,6 +18,34 @@ class EventTest(absltest.TestCase):
             },
             index_features=["x", "y"],
         )
+
+    def test_getitem(self):
+        index_data = self._evset[(2, "world")]
+        self.assertTrue(isinstance(index_data, IndexData))
+        self.assertTrue(
+            (np.array(index_data.features) == [[7, 8], [9, 10]]).all()
+        )
+        self.assertTrue((abs(index_data.timestamps - [0.4, 0.5]) < 1e-6).all())
+
+    def test_getitem_error(self):
+        with self.assertRaisesRegex(
+            TypeError, "can only be accessed by index tuples"
+        ):
+            self._evset["feature"]
+        with self.assertRaisesRegex(
+            TypeError, "can only be accessed by index tuples"
+        ):
+            self._evset[0]
+
+    def test_setitem_error(self):
+        with self.assertRaisesRegex(
+            TypeError, "not intended to be modified externally"
+        ):
+            self._evset["feature"] = None
+        with self.assertRaisesRegex(
+            TypeError, "not intended to be modified externally"
+        ):
+            self._evset[(2, "world")] = None
 
     def test_data_access(self):
         self.assertEqual(


### PR DESCRIPTION
Don't allow `node["feature"] = whatever` as discussed yesterday.

Took the chance and added a typecheck to the EventSet methods.
I'm sure that many newcomers will try to do `eventset["feature"]`, so it's a small price to pay imo.