### PR TITLE
Rename and unify evaluation i/o types

### DIFF
--- a/docs/src/reference/temporian/internals/EventSetOperationsMixin.md
+++ b/docs/src/reference/temporian/internals/EventSetOperationsMixin.md
@@ -1,0 +1,1 @@
+::: temporian.core.mixins.EventSetOperationsMixin

--- a/docs/src/reference/temporian/internals/typing/EventSetCollection.md
+++ b/docs/src/reference/temporian/internals/typing/EventSetCollection.md
@@ -1,0 +1,1 @@
+::: temporian.implementation.numpy.data.event_set.EventSetCollection

--- a/docs/src/reference/temporian/internals/typing/EventSetNodeCollection.md
+++ b/docs/src/reference/temporian/internals/typing/EventSetNodeCollection.md
@@ -1,0 +1,1 @@
+::: temporian.core.data.node.EventSetNodeCollection

--- a/docs/src/reference/temporian/internals/typing/NodeToEventSetMapping.md
+++ b/docs/src/reference/temporian/internals/typing/NodeToEventSetMapping.md
@@ -1,0 +1,1 @@
+::: temporian.implementation.numpy.data.event_set.NodeToEventSetMapping

--- a/temporian/core/compilation.py
+++ b/temporian/core/compilation.py
@@ -14,17 +14,16 @@
 
 from functools import wraps
 from copy import copy
-from typing import Any, Dict, Optional, Tuple, Callable, TypeVar
-from temporian.core.data.node import EventSetNode
+from typing import Any, Dict, Optional, Tuple, Callable
+from temporian.core.data.node import EventSetNode, EventSetNodeCollection
 from temporian.implementation.numpy.data.event_set import EventSet
 
-T = TypeVar("T", bound=Callable)
 
-
-# TODO: unify the fn's output type with run's EvaluationQuery, and add it to the
-# public API so it shows in the docs.
-# TODO: make compile change the fn's annotations to EventSetOrNode
-def compile(fn: Optional[Callable] = None, *, verbose: int = 0) -> Any:
+def compile(
+    fn: Optional[Callable[..., EventSetNodeCollection]] = None,
+    *,
+    verbose: int = 0
+) -> Any:
     """Compiles a Temporian function.
 
     A Temporian function is a function that takes
@@ -74,7 +73,7 @@ def compile(fn: Optional[Callable] = None, *, verbose: int = 0) -> Any:
         The compiled function.
     """
 
-    def _compile(fn: T) -> T:
+    def _compile(fn):
         @wraps(fn)
         def wrapper(*args, **kwargs):
             is_eager = None

--- a/temporian/core/data/node.py
+++ b/temporian/core/data/node.py
@@ -16,7 +16,7 @@
 
 from __future__ import annotations
 from dataclasses import dataclass
-from typing import List, Optional, Tuple, TYPE_CHECKING, Union
+from typing import Dict, List, Optional, Set, Tuple, TYPE_CHECKING, Union
 
 from temporian.core.data.dtype import DType, IndexDType
 from temporian.core.data.schema import Schema, FeatureSchema, IndexSchema
@@ -24,20 +24,24 @@ from temporian.core.mixins import EventSetOperationsMixin
 from temporian.utils import string
 
 if TYPE_CHECKING:
-    from temporian.core.evaluation import EvaluationInput, EvaluationResult
     from temporian.core.operators.base import Operator
+    from temporian.implementation.numpy.data.event_set import EventSetCollection
+    from temporian.implementation.numpy.data.event_set import (
+        NodeToEventSetMapping,
+    )
 
 
 class EventSetNode(EventSetOperationsMixin):
-    """A EventSetNode is a reference to the input/output of ops in a compute graph.
+    """An EventSetNode is a reference to the input/output of ops in a compute
+    graph.
 
-    Use [`tp.input_node()`][temporian.input_node] to create an EventSetNode manually, or
-    use [`event_set.node()`][temporian.EventSet.node] to create an EventSetNode
-    compatible with a given [`EventSet`][temporian.EventSet].
+    Use [`tp.input_node()`][temporian.input_node] to create an EventSetNode
+    manually, or use [`event_set.node()`][temporian.EventSet.node] to create an
+    EventSetNode compatible with a given [`EventSet`][temporian.EventSet].
 
     A EventSetNode does not contain any data. Use
     [`node.run()`][temporian.EventSetNode.run] to get the
-    [`EventSet`][temporian.EventSet] resulting from an [`EventSetNodes`][temporian.EventSetNode].
+    [`EventSet`][temporian.EventSet] resulting from an EventSetNode.
     """
 
     def __init__(
@@ -143,10 +147,10 @@ class EventSetNode(EventSetOperationsMixin):
 
     def run(
         self,
-        input: EvaluationInput,
+        input: NodeToEventSetMapping,
         verbose: int = 0,
         check_execution: bool = True,
-    ) -> EvaluationResult:
+    ) -> EventSetCollection:
         """Evaluates the EventSetNode on the specified input.
 
         See [`tp.run()`][temporian.run] for details.
@@ -172,6 +176,15 @@ class EventSetNode(EventSetOperationsMixin):
             f"creator: {self._creator}\n"
             f"id:{id(self)}\n"
         )
+
+
+EventSetNodeCollection = Union[
+    EventSetNode, List[EventSetNode], Set[EventSetNode], Dict[str, EventSetNode]
+]
+"""A collection of [`EventSetNodes`][temporian.EventSetNode].
+
+This can be a single EventSetNode, a list or set of EventSetNodes, or a
+dictionary mapping names to EventSetNodes."""
 
 
 def input_node(

--- a/temporian/core/serialization.py
+++ b/temporian/core/serialization.py
@@ -56,7 +56,7 @@ DTYPE_MAPPING = {
 INV_DTYPE_MAPPING = {v: k for k, v in DTYPE_MAPPING.items()}
 
 
-# TODO: allow saved fn to return a single Node too
+# TODO: allow saved fn to return a list or node too (EventSetNodeCollection)
 def save(
     fn: Callable[..., Dict[str, EventSetNode]],
     path: str,

--- a/temporian/core/serialization.py
+++ b/temporian/core/serialization.py
@@ -36,7 +36,6 @@ from temporian.core.data.node import (
     EventSetNode,
     Sampling,
     Feature,
-    create_node_with_new_reference,
     input_node,
 )
 from temporian.core.data.schema import Schema

--- a/temporian/implementation/numpy/data/event_set.py
+++ b/temporian/implementation/numpy/data/event_set.py
@@ -16,7 +16,7 @@ from __future__ import annotations
 
 import logging
 from dataclasses import dataclass
-from typing import Any, Dict, List, Optional, Tuple, TYPE_CHECKING, Union
+from typing import Any, Dict, List, Optional, Set, Tuple, TYPE_CHECKING, Union
 import datetime
 import sys
 
@@ -575,3 +575,23 @@ class EventSet(EventSetOperationsMixin):
         created EventSets have a `None` creator.
         """
         return self.node()._creator
+
+
+EventSetCollection = Union[EventSet, List[EventSet], Dict[str, EventSet]]
+"""A collection of [`EventSets`][temporian.EventSet].
+
+This can be a single EventSet, a list of EventSets, or a dictionary mapping
+names to EventSets."""
+
+NodeToEventSetMapping = Union[
+    Dict[EventSetNode, EventSet], EventSet, List[EventSet]
+]
+"""A mapping of [`EventSetNodes`][temporian.EventSetNode] to
+[`EventSets`][temporian.EventSet].
+
+If a dictionary, the mapping is defined by it.
+
+If a single EventSet or a list of EventSets, each EventSet is mapped to their
+own node using [`EventSet.node()`][temporian.EventSet.node], i.e., `[event_set]`
+is equivalent to `{event_set.node() : event_set}`.
+"""


### PR DESCRIPTION
`run`'s i/o types weren't showed in docs, and were used in other modules. renamed them to more explanatory names, moved them to node/event set module, added docstrings to them, added them to docs.

also made the internal symbols show in docs not show full path in the nav bar.