### PR TITLE
Combine operator.

### DIFF
--- a/docs/public_api_test.py
+++ b/docs/public_api_test.py
@@ -53,6 +53,7 @@ PUBLIC_API_SYMBOLS = {
     "runtime_check_raise_exception",
     # OPERATORS
     "glue",
+    "combine",
     # BINARY OPERATORS
     "add",
     "subtract",

--- a/docs/src/reference/index.md
+++ b/docs/src/reference/index.md
@@ -47,7 +47,8 @@ Check the index on the left for a more detailed description of any symbol.
 | [`EventSet.end()`][temporian.EventSet.end]                             | Generates a single timestamp at the end of the input.                                                        |
 | [`EventSet.enumerate()`][temporian.EventSet.enumerate]                 | Creates an ordinal feature enumerating the events according to their timestamp.                              |
 | [`EventSet.filter()`][temporian.EventSet.filter]                       | Filters out events in an [`EventSet`][temporian.EventSet] for which a condition is false.                    |
-| [`tp.glue()`][temporian.glue]                                          | Concatenates [`EventSets`][temporian.EventSet] with the same sampling.                                       |
+| [`tp.glue()`][temporian.glue]                                          | Concatenates features from [`EventSets`][temporian.EventSet] with the same sampling.                         |
+| [`tp.combine()`][temporian.combine]                                    | Combines events from [`EventSets`][temporian.EventSet] with different samplings.                             |
 | [`EventSet.join()`][temporian.EventSet.join]                           | Join [`EventSets`][temporian.EventSet] with different samplings but the same index together.                 |
 | [`EventSet.lag()`][temporian.EventSet.lag]                             | Adds a delay to an [`EventSet`][temporian.EventSet]'s timestamps.                                            |
 | [`EventSet.leak()`][temporian.EventSet.leak]                           | Subtracts a duration from an [`EventSet`][temporian.EventSet]'s timestamps.                                  |

--- a/temporian/__init__.py
+++ b/temporian/__init__.py
@@ -91,6 +91,7 @@ from temporian.utils.rtcheck import runtime_check_raise_exception
 # --- OPERATORS ---
 
 from temporian.core.operators.glue import glue
+from temporian.core.operators.combine import combine
 
 # Binary operators
 from temporian.core.operators.binary.arithmetic import add

--- a/temporian/core/data/duration.py
+++ b/temporian/core/data/duration.py
@@ -14,6 +14,8 @@
 
 from typing import Union
 
+import numpy as np
+
 # NOTE: this module is shown in the docs and so will any symbol in this file
 # with a docstring and a non-private name.
 
@@ -29,6 +31,15 @@ this module, calendar operators, plotting functions, and more) and assume that
 durations are expressed in seconds (see
 [Time units](https://temporian.readthedocs.io/en/latest/user_guide/#time-units)),
 so it is recommended to use seconds as timestamps where possible.
+"""
+
+eps = np.finfo(float).eps
+"""Round-off error for timestamp durations (machine epsilon for floating point).
+
+This number can be used as the smallest window length to unify events with the
+same timestamp. If the difference between two timestamps is below this threshold,
+they can be considered instantaneous, since the difference could be due to
+numeric errors.
 """
 
 

--- a/temporian/core/data/schema.py
+++ b/temporian/core/data/schema.py
@@ -119,6 +119,18 @@ class Schema:
                 f" {other.indexes}"
             )
 
+    def check_compatible_features(self, other: Schema, check_order: bool):
+        if set(self.features) != set(other.features):
+            raise ValueError(
+                "Some features are different between inputs: "
+                f"{set(self.features) ^ set(other.features)}."
+            )
+        if check_order and (self.features != other.features):
+            raise ValueError(
+                "Features should be in the same order, but got:"
+                f"{self.feature_names} and {other.feature_names}."
+            )
+
 
 def _normalize_feature(x):
     if isinstance(x, FeatureSchema):

--- a/temporian/core/data/schema.py
+++ b/temporian/core/data/schema.py
@@ -22,7 +22,7 @@ from dataclasses import dataclass
 from temporian.core.data.dtype import DType, IndexDType
 
 
-@dataclass
+@dataclass(frozen=True)
 class FeatureSchema:
     name: str
     dtype: DType
@@ -31,7 +31,7 @@ class FeatureSchema:
         return f"({self.name!r}, {self.dtype})"
 
 
-@dataclass
+@dataclass(frozen=True)
 class IndexSchema:
     name: str
     dtype: IndexDType

--- a/temporian/core/operators/BUILD
+++ b/temporian/core/operators/BUILD
@@ -330,3 +330,17 @@ py_library(
         "//temporian/proto:core_py_proto",
     ],
 )
+
+py_library(
+    name = "combine",
+    srcs = ["combine.py"],
+    srcs_version = "PY3",
+    deps = [
+        ":base",
+        "//temporian/core:operator_lib",
+        "//temporian/core/data:node",
+        "//temporian/core/data:schema",
+        "//temporian/proto:core_py_proto",
+    ],
+)
+    

--- a/temporian/core/operators/combine.py
+++ b/temporian/core/operators/combine.py
@@ -116,7 +116,7 @@ def combine(
         ...                  features={"A": [0, 10, 30], "B": [0, -10, -30]}
         ...                 )
         >>> b = tp.event_set(timestamps=[1, 4],
-        ...                  features={"B": [-10, -40], "A": [10, 40]}
+        ...                  features={"A": [10, 40], "B": [-10, -40]}
         ...                 )
         >>> c = tp.combine(a, b)
         >>> c
@@ -131,7 +131,8 @@ def combine(
 
         >>> # Unify events with the same timestamp (add their values).
         >>> unique_t = c.unique_timestamps()
-        >>> d = c.moving_sum(window_length=0, sampling=unique_t)
+        >>> d = c.moving_sum(window_length=1, sampling=unique_t)
+        >>> d
         indexes: []
         features: [('A', int64), ('B', int64)]
         events:

--- a/temporian/core/operators/combine.py
+++ b/temporian/core/operators/combine.py
@@ -54,6 +54,7 @@ class Combine(Operator):
             first_input.schema.check_compatible_features(
                 input.schema, check_order=False
             )
+            first_input.schema.check_compatible_index(input.schema)
 
             # Output is unix if all inputs are
             all_unix_timestamp &= input.schema.is_unix_timestamp
@@ -149,4 +150,6 @@ def combine(
     if len(inputs) == 1:
         return inputs[0]
 
-    return Combine(inputs).outputs["output"]  # type: ignore
+    # NOTE: input name must match op. definition name
+    inputs_dict = {f"input_{idx}": input for idx, input in enumerate(inputs)}
+    return Combine(**inputs_dict).outputs["output"]  # type: ignore

--- a/temporian/core/operators/combine.py
+++ b/temporian/core/operators/combine.py
@@ -17,42 +17,68 @@
 
 from temporian.core import operator_lib
 from temporian.core.compilation import compile
-from temporian.core.data.node import EventSetNode, create_node_new_features_new_sampling
+from temporian.core.data.node import (
+    EventSetNode,
+    create_node_new_features_new_sampling,
+)
 from temporian.core.operators.base import Operator
+from temporian.core.typing import EventSetOrNode
 from temporian.proto import core_pb2 as pb
+from temporian.utils.rtcheck import rtcheck
+
+MAX_NUM_ARGUMENTS = 30
 
 
 class Combine(Operator):
-    def __init__(self, input: EventSetNode, param: float):
+    def __init__(self, **inputs: EventSetNode):
         super().__init__()
 
-        self.add_input("input", input)
-        self.add_attribute("param", param)
+        # Note: Support for dictionaries of nodes is required for
+        # serialization.
 
+        if len(inputs) < 2:
+            raise ValueError("At least two arguments should be provided")
+
+        if len(inputs) >= MAX_NUM_ARGUMENTS:
+            raise ValueError(
+                f"Too many (>{MAX_NUM_ARGUMENTS}) arguments provided"
+            )
+
+        # inputs
+        first_input = None
+        all_unix_timestamp = True
+        for key, input in inputs.items():
+            # Check that all features are in all nodes
+            if first_input is None:
+                first_input = input
+            first_input.schema.check_compatible_features(
+                input.schema, check_order=False
+            )
+
+            # Output is unix if all inputs are
+            all_unix_timestamp &= input.schema.is_unix_timestamp
+            self.add_input(key, input)
+
+        assert first_input is not None  # for static checker
         self.add_output(
             "output",
             create_node_new_features_new_sampling(
-                features=[],
-                indexes=input.schema.indexes,
-                is_unix_timestamp=input.schema.is_unix_timestamp,
+                features=first_input.schema.features,
+                indexes=first_input.indexes,
+                is_unix_timestamp=all_unix_timestamp,
                 creator=self,
             ),
         )
-
         self.check()
 
     @classmethod
     def build_op_definition(cls) -> pb.OperatorDef:
         return pb.OperatorDef(
             key="COMBINE",
-            attributes=[
-                pb.OperatorDef.Attribute(
-                    key="param",
-                    type=pb.OperatorDef.Attribute.Type.FLOAT_64,
-                    is_optional=False,
-                ),
+            inputs=[
+                pb.OperatorDef.Input(key=f"input_{idx}", is_optional=idx >= 2)
+                for idx in range(MAX_NUM_ARGUMENTS)
             ],
-            inputs=[pb.OperatorDef.Input(key="input")],
             outputs=[pb.OperatorDef.Output(key="output")],
         )
 
@@ -60,20 +86,67 @@ class Combine(Operator):
 operator_lib.register_operator(Combine)
 
 
+@rtcheck
 @compile
-def combine(input: EventSetNode, param: float) -> EventSetNode:
-    """<Text>
+def combine(
+    *inputs: EventSetOrNode,
+) -> EventSetOrNode:
+    """Combines all events from multiple EventSets with the same features and index.
+
+    Input events must have the same feature names and dtypes, and the order of the first
+    input's features is used for the output feature list.
+
+    Since the input timestamps may overlap at some points, the result may contain
+    multiple events for the same timestamp. Duplicated events are not unified or
+    aggregated in any way.
+    Check the second part of the example below to see how to unify
+    events with the same timestamp, in this case adding their values.
+
+    If all inputs contain unix timestamps (i.e., datetimes), the output will also
+    be unix timestamps.
 
     Args:
-        input: <Text>
-        param: <Text>
+        *inputs: EventSets to combine their events.
 
-    Example:
-        <Text>
+    Example combining duplicated timestamps:
+
+        ```python
+        >>> a = tp.event_set(timestamps=[0, 1, 3],
+        ...                  features={"A": [0, 10, 30], "B": [0, -10, -30]}
+        ...                 )
+        >>> b = tp.event_set(timestamps=[1, 4],
+        ...                  features={"B": [-10, -40], "A": [10, 40]}
+        ...                 )
+        >>> c = tp.combine(a, b)
+        >>> c
+        indexes: []
+        features: [('A', int64), ('B', int64)]
+        events:
+            (5 events):
+                timestamps: [0. 1. 1. 3. 4.]
+                'A': [ 0 10 10 30 40]
+                'B': [ 0 -10 -10 -30 -40]
+        ...
+
+        >>> # Unify events with the same timestamp (add their values).
+        >>> unique_t = c.unique_timestamps()
+        >>> d = c.moving_sum(window_length=0, sampling=unique_t)
+        indexes: []
+        features: [('A', int64), ('B', int64)]
+        events:
+            (4 events):
+                timestamps: [0. 1. 3. 4.]
+                'A': [ 0 20 30 40]
+                'B': [ 0 -20 -30 -40]
+        ...
+
+        ```
+
 
     Returns:
-        <Text>
+        An EventSet with events from all inputs combined.
     """
+    if len(inputs) == 1:
+        return inputs[0]
 
-    return Combine(input=input, param=param).outputs["output"]
-
+    return Combine(inputs).outputs["output"]  # type: ignore

--- a/temporian/core/operators/combine.py
+++ b/temporian/core/operators/combine.py
@@ -1,0 +1,79 @@
+# Copyright 2021 Google LLC.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+"""Combine operator class and public API function definitions."""
+
+from temporian.core import operator_lib
+from temporian.core.compilation import compile
+from temporian.core.data.node import EventSetNode, create_node_new_features_new_sampling
+from temporian.core.operators.base import Operator
+from temporian.proto import core_pb2 as pb
+
+
+class Combine(Operator):
+    def __init__(self, input: EventSetNode, param: float):
+        super().__init__()
+
+        self.add_input("input", input)
+        self.add_attribute("param", param)
+
+        self.add_output(
+            "output",
+            create_node_new_features_new_sampling(
+                features=[],
+                indexes=input.schema.indexes,
+                is_unix_timestamp=input.schema.is_unix_timestamp,
+                creator=self,
+            ),
+        )
+
+        self.check()
+
+    @classmethod
+    def build_op_definition(cls) -> pb.OperatorDef:
+        return pb.OperatorDef(
+            key="COMBINE",
+            attributes=[
+                pb.OperatorDef.Attribute(
+                    key="param",
+                    type=pb.OperatorDef.Attribute.Type.FLOAT_64,
+                    is_optional=False,
+                ),
+            ],
+            inputs=[pb.OperatorDef.Input(key="input")],
+            outputs=[pb.OperatorDef.Output(key="output")],
+        )
+
+
+operator_lib.register_operator(Combine)
+
+
+@compile
+def combine(input: EventSetNode, param: float) -> EventSetNode:
+    """<Text>
+
+    Args:
+        input: <Text>
+        param: <Text>
+
+    Example:
+        <Text>
+
+    Returns:
+        <Text>
+    """
+
+    return Combine(input=input, param=param).outputs["output"]
+

--- a/temporian/core/operators/glue.py
+++ b/temporian/core/operators/glue.py
@@ -112,7 +112,7 @@ operator_lib.register_operator(GlueOperator)
 def glue(
     *inputs: EventSetOrNode,
 ) -> EventSetOrNode:
-    """Concatenates [`EventSets`][temporian.EventSet] with the same sampling.
+    """Concatenates features from EventSets with the same sampling.
 
     Feature names cannot be duplicated across EventSets.
 
@@ -195,10 +195,10 @@ def glue(
         ```
 
     Args:
-        *inputs: EventSets to concatenate.
+        *inputs: EventSets to concatenate their features.
 
     Returns:
-        Concatenated EventSets.
+        EventSet with concatenated features.
     """
     if len(inputs) == 1:
         return inputs[0]

--- a/temporian/core/test/registered_operators_test.py
+++ b/temporian/core/test/registered_operators_test.py
@@ -41,6 +41,7 @@ class RegisteredOperatorsTest(absltest.TestCase):
             "CALENDAR_SECOND",
             "CALENDAR_YEAR",
             "CAST",
+            "COMBINE",
             "DIVISION",
             "DIVISION_SCALAR",
             "DROP_INDEX",

--- a/temporian/implementation/numpy/operators/BUILD
+++ b/temporian/implementation/numpy/operators/BUILD
@@ -14,6 +14,7 @@ py_library(
         ":add_index",
         ":begin",
         ":cast",
+        ":combine",
         ":drop_index",
         ":end",
         ":enumerate",
@@ -351,5 +352,3 @@ py_library(
         "//temporian/implementation/numpy/data:event_set",
     ],
 )
-
-    

--- a/temporian/implementation/numpy/operators/BUILD
+++ b/temporian/implementation/numpy/operators/BUILD
@@ -336,3 +336,20 @@ py_library(
         "//temporian/implementation/numpy/data:event_set",
     ],
 )
+
+py_library(
+    name = "combine",
+    srcs = ["combine.py"],
+    srcs_version = "PY3",
+    deps = [
+        # already_there/numpy
+        ":base",
+        "//temporian/core/data:duration_utils",
+        "//temporian/core/operators:combine",
+        "//temporian/implementation/numpy:implementation_lib",
+        "//temporian/implementation/numpy:utils",
+        "//temporian/implementation/numpy/data:event_set",
+    ],
+)
+
+    

--- a/temporian/implementation/numpy/operators/__init__.py
+++ b/temporian/implementation/numpy/operators/__init__.py
@@ -18,6 +18,7 @@
 # pylint: disable=line-too-long
 # fmt: off
 from temporian.implementation.numpy.operators import cast
+from temporian.implementation.numpy.operators import combine
 from temporian.implementation.numpy.operators import drop_index
 from temporian.implementation.numpy.operators import filter
 from temporian.implementation.numpy.operators import glue

--- a/temporian/implementation/numpy/operators/combine.py
+++ b/temporian/implementation/numpy/operators/combine.py
@@ -75,6 +75,7 @@ class CombineNumpyImplementation(OperatorImplementation):
                     timestamps=timestamps,
                     schema=output_schema,
                 ),
+                normalize=False,
             )
 
         return {"output": output_evset}

--- a/temporian/implementation/numpy/operators/combine.py
+++ b/temporian/implementation/numpy/operators/combine.py
@@ -1,0 +1,59 @@
+# Copyright 2021 Google LLC.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+"""Implementation for the Combine operator."""
+
+
+from typing import Dict
+import numpy as np
+
+from temporian.implementation.numpy.data.event_set import IndexData, EventSet
+from temporian.core.operators.combine import Combine
+from temporian.implementation.numpy import implementation_lib
+from temporian.implementation.numpy.operators.base import OperatorImplementation
+
+class CombineNumpyImplementation(OperatorImplementation):
+
+    def __init__(self, operator: Combine) -> None:
+        assert isinstance(operator, Combine)
+        super().__init__(operator)
+
+    def __call__(
+        self, input: EventSet) -> Dict[str, EventSet]:
+        assert isinstance(self.operator, Combine)
+
+        output_schema = self.output_schema("output")
+
+        # Create output EventSet
+        output_evset = EventSet(data={}, schema=output_schema)
+
+        # Fill output EventSet's data
+        for index_key, index_data in input.data.items():
+            output_evset.set_index_value(
+                index_key,
+                IndexData(
+                    [],
+                    np.array([1], dtype=np.float64),
+                    schema=output_schema,
+                    normalize=False,
+                )
+            )
+
+        return {"output": output_evset}
+
+
+implementation_lib.register_operator_implementation(
+    Combine, CombineNumpyImplementation
+)

--- a/temporian/implementation/numpy/operators/test/BUILD
+++ b/temporian/implementation/numpy/operators/test/BUILD
@@ -720,3 +720,20 @@ py_test(
         "//temporian/implementation/numpy/operators:enumerate",
     ],
 )
+
+py_test(
+    name = "combine_test",
+    srcs = ["combine_test.py"],
+    srcs_version = "PY3",
+    deps = [
+        # already_there/absl/testing:absltest
+        ":test_util",
+        "//temporian/core/data:dtype",
+        "//temporian/core/data:node",
+        "//temporian/core/data:schema",
+        "//temporian/implementation/numpy/data:io",
+        "//temporian/core/operators:combine",
+        "//temporian/implementation/numpy/operators:combine",
+    ],
+)
+    

--- a/temporian/implementation/numpy/operators/test/combine_test.py
+++ b/temporian/implementation/numpy/operators/test/combine_test.py
@@ -26,39 +26,150 @@ from temporian.implementation.numpy.operators.test.test_util import (
     testOperatorAndImp,
 )
 
+
 class CombineOperatorTest(absltest.TestCase):
     def setUp(self):
         pass
 
-    def test_base(self):
-        evset = event_set(
-            timestamps=[1,2,3,4],
+    def test_combine_two_noindex(self):
+        evset_1 = event_set(
+            timestamps=[0, 1, 2, 2.5, 3, 4],
             features={
-                    "a": [1.0, 2.0, 3.0, 4.0],
-                    "b": [5, 6, 7, 8],
-                    "c": ["A", "A", "B", "B"],
+                "a": [0.0, -10.0, -20.0, -25.0, -30.0, -40.0],
+                "b": [0, 10, 20, 25, 30, 40],
             },
-            indexes=["c"],
         )
-        node = evset.node()
+        evset_2 = event_set(
+            timestamps=[-2, -1, 0, 3, 8],
+            features={
+                "b": [-20, -10, 0, 30, 80],
+                "a": [20.0, 10.0, 0.0, -30.0, -80.0],
+            },
+        )
+        node_1 = evset_1.node()
+        node_2 = evset_2.node()
 
         expected_output = event_set(
-            timestamps=[1, 1],
+            timestamps=[-2, -1, 0, 0, 1, 2, 2.5, 3, 3, 4, 8],
             features={
-                    "c": ["A", "B"],
+                "a": [20.0, 10, 0, 0, -10, -20, -25, -30, -30, -40, -80],
+                "b": [-20, -10, 0, 0, 10, 20, 25, 30, 30, 40, 80],
             },
-            indexes=["c"],
         )
 
         # Run op
-        op = Combine(input=node, param=1.0)
+        op = Combine(input_0=node_1, input_1=node_2)
         instance = CombineNumpyImplementation(op)
         testOperatorAndImp(self, op, instance)
-        output = instance.call(input=evset)["output"]
-
+        output = instance.call(input_0=evset_1, input_1=evset_2)["output"]
         assertEqualEventSet(self, output, expected_output)
+
+    def test_combine_multiple_indexed(self):
+        nodes_dict = {}
+        evsets_dict = {}
+        base_timestamps = np.array([0, 1, 2, -10, 0, 10])
+        base_fa = np.array([55, 23, 44, 0, 31, 66])
+        base_fb = ["a", "b", "c", "d", "e", "f"]
+        indexes = ["A", "A", "A", "B", "B", "B"]
+        n = 5
+        for i in range(n):
+            evset = event_set(
+                timestamps=base_timestamps + 0.01 * i,
+                features={
+                    "a": base_fa + i,
+                    "b": base_fb,
+                    "idx": indexes,
+                },
+                indexes=["idx"],
+            )
+            evsets_dict[f"input_{i}"] = evset
+            nodes_dict[f"input_{i}"] = evset.node()
+        expected_output = event_set(
+            timestamps=[
+                b + 0.01 * i for i in range(n) for b in base_timestamps
+            ],
+            features={
+                "a": [b + i for i in range(n) for b in base_fa],
+                "b": [b for _ in range(n) for b in base_fb],
+                "idx": [idx for _ in range(n) for idx in indexes],
+            },
+            indexes=["idx"],
+        )
+
+        # Run op
+        op = Combine(**nodes_dict)
+        instance = CombineNumpyImplementation(op)
+        testOperatorAndImp(self, op, instance)
+        output = instance.call(**evsets_dict)["output"]
+        assertEqualEventSet(self, output, expected_output)
+
+    def test_combine_different_feature_names(self):
+        # Test error msg when two events have different feature names
+        evset_1 = event_set(
+            timestamps=[1.0],
+            features={
+                "a": [0],
+                "b": [0.0],
+            },
+        )
+        evset_2 = event_set(
+            timestamps=[1.0],
+            features={
+                "a": [0],
+                "c": [0.0],
+            },
+        )
+        node_1 = evset_1.node()
+        node_2 = evset_2.node()
+
+        # Run op
+        with self.assertRaisesRegex(ValueError, "features are different"):
+            Combine(input_0=node_1, input_1=node_2)
+
+    def test_combine_different_dtypes(self):
+        # Same feature names, but second evset has a float feature
+        evset_1 = event_set(
+            timestamps=[1.0],
+            features={
+                "a": [0],
+                "b": [0],
+            },
+        )
+        evset_2 = event_set(
+            timestamps=[1.0],
+            features={
+                "a": [0],
+                "b": [0.0],
+            },
+        )
+        node_1 = evset_1.node()
+        node_2 = evset_2.node()
+
+        # Run op
+        with self.assertRaisesRegex(ValueError, "features are different"):
+            Combine(input_0=node_1, input_1=node_2)
+
+    def test_combine_noncompatible_indexes(self):
+        # Different index names
+        evset_1 = event_set(
+            timestamps=[1.0, 1.0],
+            features={"a": [0, 1], "idx1": ["A", "C"]},
+            indexes=["idx1"],
+        )
+        evset_2 = event_set(
+            timestamps=[1.0, 1.0],
+            features={"a": [0, 1], "idx2": ["A", "C"]},
+            indexes=["idx2"],
+        )
+        node_1 = evset_1.node()
+        node_2 = evset_2.node()
+
+        # Run op
+        with self.assertRaisesRegex(
+            ValueError, "Arguments don't have the same index"
+        ):
+            Combine(input_0=node_1, input_1=node_2)
 
 
 if __name__ == "__main__":
     absltest.main()
-

--- a/temporian/implementation/numpy/operators/test/combine_test.py
+++ b/temporian/implementation/numpy/operators/test/combine_test.py
@@ -1,0 +1,64 @@
+# Copyright 2021 Google LLC.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+from absl.testing import absltest
+
+import numpy as np
+from temporian.core.operators.combine import Combine
+from temporian.implementation.numpy.data.io import event_set
+from temporian.implementation.numpy.operators.combine import (
+    CombineNumpyImplementation,
+)
+from temporian.implementation.numpy.operators.test.test_util import (
+    assertEqualEventSet,
+    testOperatorAndImp,
+)
+
+class CombineOperatorTest(absltest.TestCase):
+    def setUp(self):
+        pass
+
+    def test_base(self):
+        evset = event_set(
+            timestamps=[1,2,3,4],
+            features={
+                    "a": [1.0, 2.0, 3.0, 4.0],
+                    "b": [5, 6, 7, 8],
+                    "c": ["A", "A", "B", "B"],
+            },
+            indexes=["c"],
+        )
+        node = evset.node()
+
+        expected_output = event_set(
+            timestamps=[1, 1],
+            features={
+                    "c": ["A", "B"],
+            },
+            indexes=["c"],
+        )
+
+        # Run op
+        op = Combine(input=node, param=1.0)
+        instance = CombineNumpyImplementation(op)
+        testOperatorAndImp(self, op, instance)
+        output = instance.call(input=evset)["output"]
+
+        assertEqualEventSet(self, output, expected_output)
+
+
+if __name__ == "__main__":
+    absltest.main()
+

--- a/temporian/implementation/numpy/test/registered_operators_test.py
+++ b/temporian/implementation/numpy/test/registered_operators_test.py
@@ -39,6 +39,7 @@ class RegisteredOperatorsTest(absltest.TestCase):
             "CALENDAR_SECOND",
             "CALENDAR_YEAR",
             "CAST",
+            "COMBINE",
             "DIVISION",
             "DIVISION_SCALAR",
             "DROP_INDEX",

--- a/tools/create_operator.py
+++ b/tools/create_operator.py
@@ -82,7 +82,9 @@ from temporian.core import operator_lib
 from temporian.core.compilation import compile
 from temporian.core.data.node import EventSetNode, create_node_new_features_new_sampling
 from temporian.core.operators.base import Operator
+from temporian.core.typing import EventSetOrNode
 from temporian.proto import core_pb2 as pb
+from temporian.utils.rtcheck import rtcheck
 
 
 class {capitalized_op}(Operator):
@@ -123,8 +125,9 @@ class {capitalized_op}(Operator):
 operator_lib.register_operator({capitalized_op})
 
 
+@rtcheck
 @compile
-def {lower_op}(input: EventSetNode, param: float) -> EventSetNode:
+def {lower_op}(input: EventSetOrNode, param: float) -> EventSetOrNode:
     """<Text>
 
     Args:
@@ -132,13 +135,26 @@ def {lower_op}(input: EventSetNode, param: float) -> EventSetNode:
         param: <Text>
 
     Example:
-        <Text>
+
+        ```python
+        >>> a = tp.event_set(timestamps=[0, 1, 2], features={{"A": [0, 10, 20]}})
+        >>> b = tp.{lower_op}(a)
+        >>> b
+        indexes: []
+        features: [('A', int64)]
+        events:
+            (3 events):
+                timestamps: [0. 1. 2.]
+                'A': [ 0 10 20]
+        ...
+
+        ```
 
     Returns:
         <Text>
     """
 
-    return {capitalized_op}(input=input, param=param).outputs["output"]
+    return {capitalized_op}(input=input, param=param).outputs["output"]  # type: ignore
 
 '''
         )
@@ -212,10 +228,9 @@ class {capitalized_op}NumpyImplementation(OperatorImplementation):
             output_evset.set_index_value(
                 index_key,
                 IndexData(
-                    [],
-                    np.array([1], dtype=np.float64),
+                    features=[],
+                    timestamps=np.array([1], dtype=np.float64),
                     schema=output_schema,
-                    normalize=False,
                 )
             )
 


### PR DESCRIPTION
To fix/discuss @achoum:
To unify timestamps in the docstring example, I wanted to use the smallest window length. Since it's not possible to use a `duration=0` (normalize_duration checks `duration>0`), I defined `duration.eps`. But when I tried to use it in the moving_sum duration, it doesn't work. Apparently C++ interprets this as a 0 in some value range, since there are some empty values in the output.
To reproduce the problem, set `window_length=tp.duration.eps` in the docstring example and check
`bazel test  //temporian/test:docstring_test --test_output=streamed`.