### PR TITLE
Fix bug in glue op

### DIFF
--- a/temporian/core/operators/glue.py
+++ b/temporian/core/operators/glue.py
@@ -201,7 +201,7 @@ def glue(
     Returns:
         EventSet with concatenated features.
     """
-    if len(inputs) == 1:
+    if len(inputs) == 1 and isinstance(inputs[0], EventSetNode):
         return inputs[0]
 
     # Note: The node should be called "input_{idx}" with idx in [0, MAX_NUM_ARGUMENTS).

--- a/temporian/implementation/numpy/operators/base.py
+++ b/temporian/implementation/numpy/operators/base.py
@@ -60,40 +60,38 @@ def _check_value_to_schema(
 
         if value.schema != node.schema:
             raise RuntimeError(
-                "Unexpected EventSet set schema.\n"
-                f"actual schema =\n{value.schema}\n"
-                f"expected schema =\n{node.schema}"
+                "Unexpected EventSet schema.\n"
+                f"Actual schema:\n{value.schema}\n"
+                f"Expected schema:\n{node.schema}"
             )
 
-        index_key = value.get_arbitrary_index_key()
-        if index_key is not None:
-            index_data = value.data[index_key]
-
+        index_data = value.get_arbitrary_index_data()
+        if index_data is not None:
             if len(index_data.features) != len(value.schema.features):
                 raise RuntimeError(
                     "Invalid internal number of input features for argument"
-                    f" {label!r}.\nexpected ="
-                    f" {len(value.schema.features)}\neffective ="
-                    f" {len(index_data.features)}.\n\nSchema:\n{value.schema}"
+                    f" {label!r}.\nExpected {len(value.schema.features)}, but"
+                    f" got {len(index_data.features)}.\nSchema:\n{value.schema}"
                 )
 
             for feature_value, feature_schema in zip(
                 index_data.features, value.schema.features
             ):
-                expecterd_tdtype = numpy_array_to_tp_dtype(
+                expected_dtype = numpy_array_to_tp_dtype(
                     feature_schema.name, feature_value
                 )
-                if feature_schema.dtype != expecterd_tdtype:
+                if feature_schema.dtype != expected_dtype:
                     raise RuntimeError(
-                        f"Non matching {label} feature dtype. "
-                        f"expected={expecterd_tdtype} vs "
-                        f"effective={feature_schema.dtype}"
+                        f"Feature dtypes in {label} don't match the expected"
+                        f" ones. Expected dtype {expected_dtype} for feature"
+                        f" {feature_schema.name}, but got"
+                        f" {feature_schema.dtype} instead."
                     )
 
                 if len(index_data.timestamps) != len(feature_value):
                     raise RuntimeError(
-                        "Number of timstamps does not match number of feature"
-                        " values"
+                        "Number of timestamps does not match the number of"
+                        f" values in feature {feature_schema.name}."
                     )
 
 

--- a/temporian/implementation/numpy/operators/glue.py
+++ b/temporian/implementation/numpy/operators/glue.py
@@ -37,9 +37,7 @@ class GlueNumpyImplementation(OperatorImplementation):
         output_schema = self.output_schema("output")
 
         # convert input evest dict to list of evsets
-        evsets: List[EventSet] = list(
-            list(zip(*sorted(list(inputs.items()))))[1]
-        )
+        evsets: List[EventSet] = list(list(zip(*list(inputs.items())))[1])
         if len(evsets) < 2:
             raise ValueError(
                 f"Glue operator cannot be called on a {len(evsets)} EventSets."

--- a/temporian/implementation/numpy/operators/test/glue_test.py
+++ b/temporian/implementation/numpy/operators/test/glue_test.py
@@ -13,8 +13,9 @@
 # limitations under the License.
 
 from absl.testing import absltest
+import numpy as np
 
-from temporian.core.operators.glue import GlueOperator
+from temporian.core.operators.glue import GlueOperator, glue
 from temporian.core.data.node import input_node
 from temporian.core.data.dtype import DType
 from temporian.implementation.numpy.operators.glue import (
@@ -117,6 +118,51 @@ class GlueNumpyImplementationTest(absltest.TestCase):
                 features=[("a", DType.FLOAT64)], same_sampling_as=n1
             )
             _ = GlueOperator(input_0=n1, input_1=n2)
+
+    def test_order_unchanged(self):
+        """Tests that input evsets' order is kept.
+
+        Regression test for failing case where glue misordered its inputs when
+        more than 10, because of sorted() being called over a list where
+        "input_10"  was interpreted as less than "input_2".
+        """
+        evset_0 = event_set(
+            timestamps=[1],
+            features={
+                "f0": np.asarray([1], dtype=np.int64),
+            },
+        )
+        evset_1 = evset_0.rename("f1")
+        evset_2 = evset_0.rename("f2")
+        evset_3 = evset_0.rename("f3")
+        evset_4 = evset_0.rename("f4")
+        evset_5 = evset_0.rename("f5")
+        evset_6 = evset_0.rename("f6")
+        evset_7 = evset_0.rename("f7")
+        evset_8 = evset_0.rename("f8")
+        evset_9 = evset_0.rename("f9")
+
+        evset_10 = event_set(
+            timestamps=[1],
+            features={
+                "f10": np.asarray([1], dtype=np.int32),
+            },
+            same_sampling_as=evset_0,
+        )
+
+        glue(
+            evset_0,
+            evset_1,
+            evset_2,
+            evset_3,
+            evset_4,
+            evset_5,
+            evset_6,
+            evset_7,
+            evset_8,
+            evset_9,
+            evset_10,
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
`sorted()` in the glue implementation gave the wrong order when inputs >= 11, since "input_10" as a string is less than "input_2". remove the sorted since I don't think it's needed, else we'll need to change it for a custom sorted that takes this into account.