### PR TITLE
Bugfix in event_set: don't allow set() in feature_values

### DIFF
--- a/temporian/implementation/numpy/data/event_set.py
+++ b/temporian/implementation/numpy/data/event_set.py
@@ -131,9 +131,8 @@ def normalize_features(
         if feature_values.dtype == "object":
             feature_values = feature_values.fillna("")
         feature_values = feature_values.to_numpy(copy=True)
-
-    if not isinstance(feature_values, np.ndarray):
-        # The data is not a np.array
+    elif isinstance(feature_values, (tuple, list)):
+        # Convert list/tuple to array
 
         # Looks for an indication of a string or non-string array.
         is_string = False
@@ -150,6 +149,11 @@ def normalize_features(
             feature_values = np.array(feature_values, dtype=np.bytes_)
         else:
             feature_values = np.array(feature_values)
+    elif not isinstance(feature_values, np.ndarray):
+        raise ValueError(
+            "Feature values should be provided in a tuple, list, numpy array or"
+            f" pandas Series. Got type {type(feature_values)} instead."
+        )
 
     if feature_values.dtype.type == np.string_:
         feature_values = feature_values.astype(np.bytes_)

--- a/temporian/implementation/numpy/data/io.py
+++ b/temporian/implementation/numpy/data/io.py
@@ -111,16 +111,16 @@ def event_set(
     if features is None:
         features = {}
 
+    features = {
+        name: normalize_features(value, name)
+        for name, value in features.items()
+    }
+
     # Check timestamps and all features are of same length
     if not all(len(f) == len(timestamps) for f in features.values()):
         raise ValueError(
             "Timestamps and all features must have the same length."
         )
-
-    features = {
-        name: normalize_features(value, name)
-        for name, value in features.items()
-    }
 
     # Convert timestamps to expected type.
     timestamps, auto_is_unix_timestamp = normalize_timestamps(timestamps)

--- a/temporian/implementation/numpy/data/test/io_test.py
+++ b/temporian/implementation/numpy/data/test/io_test.py
@@ -148,6 +148,18 @@ class IOTest(absltest.TestCase):
         # Shouldn't raise
         event_set(timestamps=[1])
 
+    def test_feature_wrong_type(self):
+        with self.assertRaisesRegex(
+            ValueError, "Feature values should be provided in a tuple, list"
+        ):
+            event_set(
+                timestamps=[1, 2],
+                features={
+                    # np.array({1, 2}) would produce a single-item value
+                    "y": {1, 2},
+                },
+            )
+
 
 if __name__ == "__main__":
     absltest.main()


### PR DESCRIPTION
Due to an error, I noticed that this code worked but produced a malformed EventSet:

```python
event_set(
    timestamps=[1, 2],
    features={
        # np.array({1, 2}) would produce a single-item value
        "y": {1, 2},
    },
)
```

Similar issues might happen with other iterable types. So I made explicit in `event_set()` the allowed types for features (tuple, list, np.array or pd.Series)