### PR TITLE
fix missing entries in user guide's table of contents

### DIFF
--- a/docs/src/user_guide.ipynb
+++ b/docs/src/user_guide.ipynb
@@ -1643,7 +1643,6 @@
     "lines_to_next_cell": 0
    },
    "source": [
-    "\n",
     "Note that features of type `int64` and `float64` are not mixed above, because otherwise the operation would fail without an explicit type cast."
    ]
   },
@@ -1657,8 +1656,7 @@
    },
    "source": [
     "```python\n",
-    "# Attempt to mix dtypes.\n",
-    ">>> node[\"f1\"] + node[\"f2\"]\n",
+    ">>> node[\"f1\"] + node[\"f2\"]  # Attempt to mix dtypes.\n",
     "Traceback (most recent call last):\n",
     "    ...\n",
     "ValueError: corresponding features should have the same dtype. ...\n",
@@ -1674,7 +1672,6 @@
     "lines_to_next_cell": 0
    },
    "source": [
-    "\n",
     "Refer to the [Casting](#casting) section for more on this.\n",
     "\n",
     "All the operators have an equivalent functional form. The example above using `+`, could be rewritten with `tp.add()`."
@@ -1707,7 +1704,6 @@
     "lines_to_next_cell": 0
    },
    "source": [
-    "\n",
     "Other usual comparison and logic operators also work (except `==`, see below)."
    ]
   },
@@ -1739,7 +1735,6 @@
     "lines_to_next_cell": 0
    },
    "source": [
-    "\n",
     "**Warning:** The Python equality operator (`==`) does not compute element-wise equality between features. Use the `tp.equal()` operator instead."
    ]
   },
@@ -1819,7 +1814,6 @@
     "lines_to_next_cell": 0
    },
    "source": [
-    "\n",
     "All these operators act feature-wise, i.e. they perform index-feature-wise operations (for each feature in each index key). This implies that the input `EventSets` must have the same number of features."
    ]
   },
@@ -1887,7 +1881,6 @@
     "lines_to_next_cell": 0
    },
    "source": [
-    "\n",
     "If you want to apply arithmetic operators on `EventSets` with different samplings, take a look at\n",
     "[Sampling](#sampling) section.\n",
     "\n",
@@ -1943,7 +1936,6 @@
     "lines_to_next_cell": 0
    },
    "source": [
-    "\n",
     "## Sampling\n",
     "\n",
     "Arithmetic operators, such as `tp.add()`, require their input arguments to have the same timestamps and [Index](#indexes-horizontal-and-vertical-operators). The unique combination of timestamps and indexes is called a _sampling_.\n",
@@ -2700,7 +2692,6 @@
     "lines_to_next_cell": 0
    },
    "source": [
-    "\n",
     "<!--\n",
     "`EventSet` data can be accessed using the `index()` and `feature()` functions. Temporian internally relies on NumPy, which means that the data access functions always return NumPy arrays.\n",
     "\n",
@@ -2741,17 +2732,14 @@
     "\n",
     "`EventSets` can be read from and saved to csv files via the `tp.from_csv()` and `tp.to_csv()` functions.\n",
     "\n",
-    "# Read EventSet from a .csv file.\n",
-    "\n",
     "```python\n",
-    "evset = tp.from_csv(\n",
+    "evset = tp.from_csv(  # Read EventSet from a .csv file.\n",
     "    path=\"path/to/file.csv\",\n",
     "    timestamps=\"timestamp\",\n",
     "    indexes=[\"product_id\"],\n",
     ")\n",
     "\n",
-    "# Save EventSet to a .csv file.\n",
-    "tp.to_csv(evset, path=\"path/to/file.csv\")\n",
+    "tp.to_csv(evset, path=\"path/to/file.csv\")  # Save EventSet to a .csv file.\n",
     "```\n",
     "\n",
     "Converting `EventSet` data to and from pandas DataFrames is also easily done via `tp.to_pandas()` and `tp.from_pandas()`."


### PR DESCRIPTION
Using python comments inside a markdown cell messes with the table of contents, since it (buggily) interprets it as an H1 heading (which makes all the headers after this one hidden, since mkdocs expects a single H1 at the top of the file). 

Solution is to either not use those comments (and pass that text to above/below the code cell if possible, or to use same-line comments, i.e. instead of this:
```
# This is a comment that messes up the ToC
<code>
```

do this
```
<code>  # This is a comment that doesn't mess up the ToC
```

note that this only applies to ``` code blocks inside markdown cells, comments inside code cells are fine.