### PR TITLE
Variable window length

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -39,7 +39,7 @@ jobs:
         run: poetry install --no-interaction
 
       - name: Run tests
-        run: poetry run bazel test //temporian/...:all //docs/...:all //tools/...:all --test_output=errors
+        run: poetry run bazel test //temporian/...:all //docs/...:all //tools/...:all --test_output=errors --compliation_mode=dbg
         # Note: Since mid-August 23, using "//...:all" incorrectly try to
         # compile the directory "build" created during the installation of one
         # of the dependency during "poetry install".

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -39,7 +39,7 @@ jobs:
         run: poetry install --no-interaction
 
       - name: Run tests
-        run: poetry run bazel test //temporian/...:all //docs/...:all //tools/...:all --test_output=errors --compliation_mode=dbg
+        run: poetry run bazel test //temporian/...:all //docs/...:all //tools/...:all --test_output=errors --compilation_mode=dbg
         # Note: Since mid-August 23, using "//...:all" incorrectly try to
         # compile the directory "build" created during the installation of one
         # of the dependency during "poetry install".

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -30,6 +30,8 @@
   "prettier.tabWidth": 2,
   "editor.detectIndentation": true,
   "files.associations": {
+    "*.excalidraw": "json",
+    "*.excalidrawlib": "json",
     "system_error": "cpp",
     "type_traits": "cpp",
     "xtr1common": "cpp",
@@ -92,7 +94,8 @@
     "random": "cpp",
     "string_view": "cpp",
     "numbers": "cpp",
-    "any": "cpp"
+    "any": "cpp",
+    "bitset": "cpp"
   },
   "python.analysis.typeCheckingMode": "basic",
   "jupyter.notebookFileRoot": "${fileDirname}",

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -76,6 +76,8 @@ bazel test //...:all
 
 You can use the Bazel test flag `--test_output=streamed` to see the test logs in realtime.
 
+If developing and testing C++ code, the `--compilation_mode=dbg` flag enables additional assertions that are otherwise disabled.
+
 Note that these tests also include docstring examples, using the builtin `doctest` module.
 See the [Adding code examples](#adding-code-examples) section for more information.
 

--- a/docs/src/reference/temporian/internals/typing/WindowLength.md
+++ b/docs/src/reference/temporian/internals/typing/WindowLength.md
@@ -1,0 +1,1 @@
+::: temporian.core.typing.WindowLength

--- a/temporian/core/event_set_ops.py
+++ b/temporian/core/event_set_ops.py
@@ -2205,7 +2205,7 @@ class EventSetOperations:
 
         Raises:
             KeyError: If any of the specified `indexes` are not found in the
-            input.
+                input.
         """
         from temporian.core.operators.add_index import set_index
 

--- a/temporian/core/event_set_ops.py
+++ b/temporian/core/event_set_ops.py
@@ -1392,7 +1392,10 @@ class EventSetOperations:
         window (t - window_length, t].
 
         If `sampling` is provided samples the moving window's value at each
-        timestamp in `sampling`, else samples it at each timestamp in the input.
+        timestamp in `sampling`, else samples it at each timestamp in
+        `window_length` if it is an `EventSet`, else in the input. If both
+        `sampling` and `window_length` are provided as `EventSets`, their
+        sampling must be the same.
 
         Example without sampling:
             ```python
@@ -1473,7 +1476,10 @@ class EventSetOperations:
         (t - window_length, t].
 
         If `sampling` is provided samples the moving window's value at each
-        timestamp in `sampling`, else samples it at each timestamp in the input.
+        timestamp in `sampling`, else samples it at each timestamp in
+        `window_length` if it is an `EventSet`, else in the input. If both
+        `sampling` and `window_length` are provided as `EventSets`, their
+        sampling must be the same.
 
         If the window does not contain any values (e.g., all the values are
         missing, or the window does not contain any sampling), outputs missing
@@ -1524,7 +1530,10 @@ class EventSetOperations:
         (t - window_length, t].
 
         If `sampling` is provided samples the moving window's value at each
-        timestamp in `sampling`, else samples it at each timestamp in the input.
+        timestamp in `sampling`, else samples it at each timestamp in
+        `window_length` if it is an `EventSet`, else in the input. If both
+        `sampling` and `window_length` are provided as `EventSets`, their
+        sampling must be the same.
 
         If the window does not contain any values (e.g., all the values are
         missing, or the window does not contain any sampling), outputs missing
@@ -1547,8 +1556,8 @@ class EventSetOperations:
 
             ```
 
-        See [`EventSet.moving_count()`][temporian.EventSet.moving_count] for examples
-        of moving window operations with external sampling and indices.
+        See [`EventSet.moving_count()`][temporian.EventSet.moving_count] for
+        examples of moving window operations with external sampling and indices.
 
         Args:
             window_length: Sliding window's length.
@@ -1575,7 +1584,10 @@ class EventSetOperations:
         (t - window_length, t].
 
         If `sampling` is provided samples the moving window's value at each
-        timestamp in `sampling`, else samples it at each timestamp in the input.
+        timestamp in `sampling`, else samples it at each timestamp in
+        `window_length` if it is an `EventSet`, else in the input. If both
+        `sampling` and `window_length` are provided as `EventSets`, their
+        sampling must be the same.
 
         Missing values (such as NaNs) are ignored.
 
@@ -1600,8 +1612,8 @@ class EventSetOperations:
 
             ```
 
-        See [`EventSet.moving_count()`][temporian.EventSet.moving_count] for examples of moving window
-        operations with external sampling and indices.
+        See [`EventSet.moving_count()`][temporian.EventSet.moving_count] for
+        examples of moving window operations with external sampling and indices.
 
         Args:
             window_length: Sliding window's length.
@@ -1632,7 +1644,10 @@ class EventSetOperations:
         time t the sum of the feature in the window (t - window_length, t].
 
         If `sampling` is provided samples the moving window's value at each
-        timestamp in `sampling`, else samples it at each timestamp in the input.
+        timestamp in `sampling`, else samples it at each timestamp in
+        `window_length` if it is an `EventSet`, else in the input. If both
+        `sampling` and `window_length` are provided as `EventSets`, their
+        sampling must be the same.
 
         Missing values (such as NaNs) are ignored.
 
@@ -1657,8 +1672,8 @@ class EventSetOperations:
 
             ```
 
-        See [`EventSet.moving_count()`][temporian.EventSet.moving_count] for examples of moving window
-        operations with external sampling and indices.
+        See [`EventSet.moving_count()`][temporian.EventSet.moving_count] for
+        examples of moving window operations with external sampling and indices.
 
         Args:
             window_length: Sliding window's length.
@@ -2182,12 +2197,15 @@ class EventSetOperations:
         (t - window_length, t].
 
         If `sampling` is provided samples the moving window's value at each
-        timestamp in `sampling`, else samples it at each timestamp in the input.
+        timestamp in `sampling`, else samples it at each timestamp in
+        `window_length` if it is an `EventSet`, else in the input. If both
+        `sampling` and `window_length` are provided as `EventSets`, their
+        sampling must be the same.
 
         Missing values (such as NaNs) are ignored.
 
         If the window does not contain any values (e.g., all the values are
-        missing, or the window does not contain any sampling), outputs missing
+        missing, or the window does not contain any timestamp), outputs missing
         values.
 
         Example:

--- a/temporian/core/event_set_ops.py
+++ b/temporian/core/event_set_ops.py
@@ -2197,14 +2197,15 @@ class EventSetOperations:
 
         Args:
             indexes: List of index / feature names (strings) used as
-                the new indexes. These names should be either indexes or features in
-                the input.
+                the new indexes. These names should be either indexes or
+                features in the input.
 
         Returns:
             EventSet with the updated indexes.
 
         Raises:
-            KeyError: If any of the specified `indexes` are not found in the input.
+            KeyError: If any of the specified `indexes` are not found in the
+            input.
         """
         from temporian.core.operators.add_index import set_index
 
@@ -2252,8 +2253,8 @@ class EventSetOperations:
 
             ```
 
-        See [`EventSet.moving_count()`][temporian.EventSet.moving_count] for examples of moving window
-        operations with external sampling and indices.
+        See [`EventSet.moving_count()`][temporian.EventSet.moving_count] for
+        examples of moving window operations with external sampling and indices.
 
         Args:
             window_length: Sliding window's length.

--- a/temporian/core/event_set_ops.py
+++ b/temporian/core/event_set_ops.py
@@ -14,7 +14,6 @@
 
 # pylint: disable=import-outside-toplevel
 
-
 from __future__ import annotations
 from typing import Any, Dict, List, Optional, Union, TYPE_CHECKING
 
@@ -22,7 +21,12 @@ from temporian.core.data.duration import Duration
 
 
 if TYPE_CHECKING:
-    from temporian.core.typing import EventSetOrNode, TypeOrDType, IndexKeyList
+    from temporian.core.typing import (
+        EventSetOrNode,
+        TypeOrDType,
+        IndexKeyList,
+        WindowLength,
+    )
 
 T_SCALAR = (int, float)
 
@@ -1379,7 +1383,7 @@ class EventSetOperations:
 
     def moving_count(
         self: EventSetOrNode,
-        window_length: Duration,
+        window_length: WindowLength,
         sampling: Optional[EventSetOrNode] = None,
     ) -> EventSetOrNode:
         """Gets the number of events in a sliding window.
@@ -1387,9 +1391,8 @@ class EventSetOperations:
         Create a tp.int32 feature containing the number of events in the time
         window (t - window_length, t].
 
-        If the `sampling` argument is not provided, outputs a timestamp for
-        each timestamp in `input`. If the `sampling` argument is provided,
-        outputs a timestamp for each timestamp in `sampling`.
+        If `sampling` is provided samples the moving window's value at each
+        timestamp in `sampling`, else samples it at each timestamp in the input.
 
         Example without sampling:
             ```python
@@ -1459,7 +1462,7 @@ class EventSetOperations:
 
     def moving_max(
         self: EventSetOrNode,
-        window_length: Duration,
+        window_length: WindowLength,
         sampling: Optional[EventSetOrNode] = None,
     ) -> EventSetOrNode:
         """Computes the maximum in a sliding window over an
@@ -1472,8 +1475,9 @@ class EventSetOperations:
         If `sampling` is provided samples the moving window's value at each
         timestamp in `sampling`, else samples it at each timestamp in the input.
 
-        If the window does not contain any values (e.g., all the values are missing,
-        or the window does not contain any sampling), outputs missing values.
+        If the window does not contain any values (e.g., all the values are
+        missing, or the window does not contain any sampling), outputs missing
+        values.
 
         Example:
             ```python
@@ -1509,7 +1513,7 @@ class EventSetOperations:
 
     def moving_min(
         self: EventSetOrNode,
-        window_length: Duration,
+        window_length: WindowLength,
         sampling: Optional[EventSetOrNode] = None,
     ) -> EventSetOrNode:
         """Computes the minimum of values in a sliding window over an
@@ -1522,8 +1526,9 @@ class EventSetOperations:
         If `sampling` is provided samples the moving window's value at each
         timestamp in `sampling`, else samples it at each timestamp in the input.
 
-        If the window does not contain any values (e.g., all the values are missing,
-        or the window does not contain any sampling), outputs missing values.
+        If the window does not contain any values (e.g., all the values are
+        missing, or the window does not contain any sampling), outputs missing
+        values.
 
         Example:
             ```python
@@ -1559,14 +1564,14 @@ class EventSetOperations:
 
     def moving_standard_deviation(
         self: EventSetOrNode,
-        window_length: Duration,
+        window_length: WindowLength,
         sampling: Optional[EventSetOrNode] = None,
     ) -> EventSetOrNode:
         """Computes the standard deviation of values in a sliding window over an
         [`EventSet`][temporian.EventSet].
 
-        For each t in sampling, and for each feature independently, returns at time
-        t the standard deviation for the feature in the window
+        For each t in sampling, and for each feature independently, returns at
+        time t the standard deviation for the feature in the window
         (t - window_length, t].
 
         If `sampling` is provided samples the moving window's value at each
@@ -1574,8 +1579,9 @@ class EventSetOperations:
 
         Missing values (such as NaNs) are ignored.
 
-        If the window does not contain any values (e.g., all the values are missing,
-        or the window does not contain any sampling), outputs missing values.
+        If the window does not contain any values (e.g., all the values are
+        missing, or the window does not contain any sampling), outputs missing
+        values.
 
         Example:
             ```python
@@ -1616,22 +1622,23 @@ class EventSetOperations:
 
     def moving_sum(
         self: EventSetOrNode,
-        window_length: Duration,
+        window_length: WindowLength,
         sampling: Optional[EventSetOrNode] = None,
     ) -> EventSetOrNode:
         """Computes the sum of values in a sliding window over an
         [`EventSet`][temporian.EventSet].
 
-        For each t in sampling, and for each feature independently, returns at time
-        t the sum of the feature in the window (t - window_length, t].
+        For each t in sampling, and for each feature independently, returns at
+        time t the sum of the feature in the window (t - window_length, t].
 
         If `sampling` is provided samples the moving window's value at each
         timestamp in `sampling`, else samples it at each timestamp in the input.
 
         Missing values (such as NaNs) are ignored.
 
-        If the window does not contain any values (e.g., all the values are missing,
-        or the window does not contain any sampling), outputs missing values.
+        If the window does not contain any values (e.g., all the values are
+        missing, or the window does not contain any sampling), outputs missing
+        values.
 
         Example:
             ```python
@@ -2164,22 +2171,24 @@ class EventSetOperations:
 
     def simple_moving_average(
         self: EventSetOrNode,
-        window_length: Duration,
+        window_length: WindowLength,
         sampling: Optional[EventSetOrNode] = None,
     ) -> EventSetOrNode:
         """Computes the average of values in a sliding window over an
         [`EventSet`][temporian.EventSet].
 
-        For each t in sampling, and for each feature independently, returns at time
-        t the average value of the feature in the window (t - window_length, t].
+        For each t in sampling, and for each feature independently, returns at
+        time t the average value of the feature in the window
+        (t - window_length, t].
 
         If `sampling` is provided samples the moving window's value at each
         timestamp in `sampling`, else samples it at each timestamp in the input.
 
         Missing values (such as NaNs) are ignored.
 
-        If the window does not contain any values (e.g., all the values are missing,
-        or the window does not contain any sampling), outputs missing values.
+        If the window does not contain any values (e.g., all the values are
+        missing, or the window does not contain any sampling), outputs missing
+        values.
 
         Example:
             ```python

--- a/temporian/core/event_set_ops.py
+++ b/temporian/core/event_set_ops.py
@@ -1391,11 +1391,12 @@ class EventSetOperations:
         Create a tp.int32 feature containing the number of events in the time
         window (t - window_length, t].
 
-        If `sampling` is provided samples the moving window's value at each
-        timestamp in `sampling`, else samples it at each timestamp in
-        `window_length` if it is an `EventSet`, else in the input. If both
-        `sampling` and `window_length` are provided as `EventSets`, their
-        sampling must be the same.
+        `sampling` can't be  specified if a variable `window_length` is
+        specified (i.e. if `window_length` is an EventSet).
+
+        If `sampling` is specified or `window_length` is an EventSet, the moving
+        window is sampled at each timestamp in them, else it is sampled on the
+        input's.
 
         Example without sampling:
             ```python
@@ -1420,6 +1421,27 @@ class EventSetOperations:
                 (9 events):
                     timestamps: [-1. 0. 1. 2. 3. 4. 5. 6. 7.]
                     'count': [0 1 2 2 1 0 1 1 0]
+            ...
+
+            ```
+
+        Example with variable window length:
+            ```python
+            >>> a = tp.event_set(timestamps=[0, 1, 2, 5])
+            >>> b = tp.event_set(
+            ...     timestamps=[0, 3, 3, 3, 9],
+            ...     features={
+            ...         "w": [1, 0.5, 3.5, 2.5, 5],
+            ...     },
+            ... )
+            >>> c = a.moving_count(window_length=b)
+            >>> c
+            indexes: []
+            features: [('count', int32)]
+            events:
+                (5 events):
+                    timestamps: [0. 3. 3. 3. 9.]
+                    'count': [1 0 3 2 1]
             ...
 
             ```
@@ -1475,11 +1497,12 @@ class EventSetOperations:
         returns at time t the max of non-nan values for the feature in the window
         (t - window_length, t].
 
-        If `sampling` is provided samples the moving window's value at each
-        timestamp in `sampling`, else samples it at each timestamp in
-        `window_length` if it is an `EventSet`, else in the input. If both
-        `sampling` and `window_length` are provided as `EventSets`, their
-        sampling must be the same.
+        `sampling` can't be  specified if a variable `window_length` is
+        specified (i.e. if `window_length` is an EventSet).
+
+        If `sampling` is specified or `window_length` is an EventSet, the moving
+        window is sampled at each timestamp in them, else it is sampled on the
+        input's.
 
         If the window does not contain any values (e.g., all the values are
         missing, or the window does not contain any sampling), outputs missing
@@ -1529,11 +1552,12 @@ class EventSetOperations:
         returns at time t the minimum of non-nan values for the feature in the window
         (t - window_length, t].
 
-        If `sampling` is provided samples the moving window's value at each
-        timestamp in `sampling`, else samples it at each timestamp in
-        `window_length` if it is an `EventSet`, else in the input. If both
-        `sampling` and `window_length` are provided as `EventSets`, their
-        sampling must be the same.
+        `sampling` can't be  specified if a variable `window_length` is
+        specified (i.e. if `window_length` is an EventSet).
+
+        If `sampling` is specified or `window_length` is an EventSet, the moving
+        window is sampled at each timestamp in them, else it is sampled on the
+        input's.
 
         If the window does not contain any values (e.g., all the values are
         missing, or the window does not contain any sampling), outputs missing
@@ -1583,11 +1607,12 @@ class EventSetOperations:
         time t the standard deviation for the feature in the window
         (t - window_length, t].
 
-        If `sampling` is provided samples the moving window's value at each
-        timestamp in `sampling`, else samples it at each timestamp in
-        `window_length` if it is an `EventSet`, else in the input. If both
-        `sampling` and `window_length` are provided as `EventSets`, their
-        sampling must be the same.
+        `sampling` can't be  specified if a variable `window_length` is
+        specified (i.e. if `window_length` is an EventSet).
+
+        If `sampling` is specified or `window_length` is an EventSet, the moving
+        window is sampled at each timestamp in them, else it is sampled on the
+        input's.
 
         Missing values (such as NaNs) are ignored.
 
@@ -1641,13 +1666,14 @@ class EventSetOperations:
         [`EventSet`][temporian.EventSet].
 
         For each t in sampling, and for each feature independently, returns at
-        time t the sum of the feature in the window (t - window_length, t].
+        time t the sum of the feature in the window (
 
-        If `sampling` is provided samples the moving window's value at each
-        timestamp in `sampling`, else samples it at each timestamp in
-        `window_length` if it is an `EventSet`, else in the input. If both
-        `sampling` and `window_length` are provided as `EventSets`, their
-        sampling must be the same.
+            in them. `sampling` can't be specified if `window_length` is  an EventSet.ta variable  - window_length
+            specified, (i.e. if `window_length` is an EventSet).
+
+        If `sampling` is specified or `window_length` is an EventSet, the moving
+        window is sampled at each timesta, else it is sampled on the
+        input's.p
 
         Missing values (such as NaNs) are ignored.
 
@@ -2196,11 +2222,12 @@ class EventSetOperations:
         time t the average value of the feature in the window
         (t - window_length, t].
 
-        If `sampling` is provided samples the moving window's value at each
-        timestamp in `sampling`, else samples it at each timestamp in
-        `window_length` if it is an `EventSet`, else in the input. If both
-        `sampling` and `window_length` are provided as `EventSets`, their
-        sampling must be the same.
+        `sampling` can't be  specified if a variable `window_length` is
+        specified (i.e. if `window_length` is an EventSet).
+
+        If `sampling` is specified or `window_length` is an EventSet, the moving
+        window is sampled at each timestamp in them, else it is sampled on the
+        input's.
 
         Missing values (such as NaNs) are ignored.
 

--- a/temporian/core/operators/window/BUILD
+++ b/temporian/core/operators/window/BUILD
@@ -25,6 +25,7 @@ py_library(
     srcs = ["base.py"],
     srcs_version = "PY3",
     deps = [
+        "//temporian/core:typing",
         "//temporian/core/data:dtype",
         "//temporian/core/data:duration_utils",
         "//temporian/core/data:node",

--- a/temporian/core/operators/window/base.py
+++ b/temporian/core/operators/window/base.py
@@ -63,14 +63,11 @@ class BaseWindowOperator(Operator, ABC):
             effective_sampling_node.schema.check_compatible_index(
                 window_length.schema
             )
-            self.add_input("variable_window_length", window_length)
-            self._variable_window_length = window_length
-            self._window_length = None
+            self.add_input("window_length", window_length)
         else:
             window_length = normalize_duration(window_length)
             self.add_attribute("window_length", window_length)
             self._window_length = window_length
-            self._variable_window_length = None
 
         self.add_input("input", input)
 
@@ -99,10 +96,6 @@ class BaseWindowOperator(Operator, ABC):
         return self._window_length
 
     @property
-    def variable_window_length(self) -> Optional[EventSetNode]:
-        return self._variable_window_length
-
-    @property
     def has_sampling(self) -> bool:
         return self._has_sampling
 
@@ -120,9 +113,7 @@ class BaseWindowOperator(Operator, ABC):
             inputs=[
                 pb.OperatorDef.Input(key="input"),
                 pb.OperatorDef.Input(key="sampling", is_optional=True),
-                pb.OperatorDef.Input(
-                    key="variable_window_length", is_optional=True
-                ),
+                pb.OperatorDef.Input(key="window_length", is_optional=True),
             ],
             outputs=[pb.OperatorDef.Output(key="output")],
         )

--- a/temporian/core/operators/window/base.py
+++ b/temporian/core/operators/window/base.py
@@ -57,7 +57,7 @@ class BaseWindowOperator(Operator, ABC):
         if isinstance(window_length, EventSetNode):
             if len(window_length.schema.features) != 1:
                 raise ValueError(
-                    "The window_length EventSet must have a single feature."
+                    "`window_length` must have exactly one feature."
                 )
             # TODO: check the feature is float64 (and try to cast if not?)
             effective_sampling_node.schema.check_compatible_index(

--- a/temporian/core/operators/window/base.py
+++ b/temporian/core/operators/window/base.py
@@ -55,11 +55,13 @@ class BaseWindowOperator(Operator, ABC):
             effective_sampling_node = input
 
         if isinstance(window_length, EventSetNode):
-            if len(window_length.schema.features) != 1:
+            if (
+                len(window_length.schema.features) != 1
+                or window_length.schema.features[0].dtype != DType.FLOAT64
+            ):
                 raise ValueError(
-                    "`window_length` must have exactly one feature."
+                    "`window_length` must have exactly one float64 feature."
                 )
-            # TODO: check the feature is float64 (and try to cast if not?)
             effective_sampling_node.schema.check_compatible_index(
                 window_length.schema
             )

--- a/temporian/core/operators/window/base.py
+++ b/temporian/core/operators/window/base.py
@@ -95,6 +95,8 @@ class BaseWindowOperator(Operator, ABC):
 
     @property
     def window_length(self) -> Optional[NormalizedDuration]:
+        """Return None if window_length is variable (i.e. an EventSet was passed
+        as `window_length` to the operator)."""
         return self._window_length
 
     @property

--- a/temporian/core/operators/window/base.py
+++ b/temporian/core/operators/window/base.py
@@ -55,6 +55,11 @@ class BaseWindowOperator(Operator, ABC):
             effective_sampling_node = input
 
         if isinstance(window_length, EventSetNode):
+            if len(window_length.schema.features) != 1:
+                raise ValueError(
+                    "The window_length EventSet must have a single feature."
+                )
+            # TODO: check the feature is float64 (and try to cast if not?)
             effective_sampling_node.schema.check_compatible_index(
                 window_length.schema
             )

--- a/temporian/core/operators/window/base.py
+++ b/temporian/core/operators/window/base.py
@@ -49,9 +49,14 @@ class BaseWindowOperator(Operator, ABC):
         self._has_sampling = has_sampling
 
         if has_sampling:
-            input.schema.check_compatible_index(sampling.schema)
             if has_variable_winlen:
-                sampling.check_same_sampling(window_length)
+                raise ValueError(
+                    "`sampling` cannot be specified if a variable"
+                    " `window_length` is specified with an EventSet. If"
+                    " specifying `window_length` with an EventSet, that"
+                    " EventSet's sampling will be used."
+                )
+            input.schema.check_compatible_index(sampling.schema)
             self.add_input("sampling", sampling)
 
         if has_variable_winlen:
@@ -71,11 +76,11 @@ class BaseWindowOperator(Operator, ABC):
         self.add_input("input", input)
 
         # Note: effective_sampling_node can be either the received sampling,
-        # window_length, or input
+        # window_length, or the input
         effective_sampling_node = (
-            sampling
-            if has_sampling
-            else (window_length if has_variable_winlen else input)
+            window_length
+            if has_variable_winlen
+            else (sampling if has_sampling else input)
         )
         assert isinstance(effective_sampling_node, EventSetNode)
 

--- a/temporian/core/operators/window/moving_count.py
+++ b/temporian/core/operators/window/moving_count.py
@@ -19,11 +19,10 @@ from typing import Optional
 from temporian.core import operator_lib
 from temporian.core.compilation import compile
 from temporian.core.data.dtype import DType
-from temporian.core.data.duration_utils import Duration, normalize_duration
 from temporian.core.data.node import EventSetNode
 from temporian.core.data.schema import FeatureSchema
 from temporian.core.operators.window.base import BaseWindowOperator
-from temporian.core.typing import EventSetOrNode
+from temporian.core.typing import EventSetOrNode, WindowLength
 
 
 class MovingCountOperator(BaseWindowOperator):
@@ -44,7 +43,7 @@ operator_lib.register_operator(MovingCountOperator)
 @compile
 def moving_count(
     input: EventSetOrNode,
-    window_length: Duration,
+    window_length: WindowLength,
     sampling: Optional[EventSetOrNode] = None,
 ) -> EventSetOrNode:
     assert isinstance(input, EventSetNode)
@@ -53,6 +52,6 @@ def moving_count(
 
     return MovingCountOperator(
         input=input,
-        window_length=normalize_duration(window_length),
+        window_length=window_length,
         sampling=sampling,
     ).outputs["output"]

--- a/temporian/core/operators/window/moving_max.py
+++ b/temporian/core/operators/window/moving_max.py
@@ -19,11 +19,10 @@ from typing import Optional
 from temporian.core import operator_lib
 from temporian.core.compilation import compile
 from temporian.core.data.dtype import DType
-from temporian.core.data.duration_utils import Duration, normalize_duration
 from temporian.core.data.node import EventSetNode
 from temporian.core.data.schema import FeatureSchema
 from temporian.core.operators.window.base import BaseWindowOperator
-from temporian.core.typing import EventSetOrNode
+from temporian.core.typing import EventSetOrNode, WindowLength
 
 
 class MovingMaxOperator(BaseWindowOperator):
@@ -41,7 +40,7 @@ operator_lib.register_operator(MovingMaxOperator)
 @compile
 def moving_max(
     input: EventSetOrNode,
-    window_length: Duration,
+    window_length: WindowLength,
     sampling: Optional[EventSetOrNode] = None,
 ) -> EventSetOrNode:
     assert isinstance(input, EventSetNode)
@@ -50,6 +49,6 @@ def moving_max(
 
     return MovingMaxOperator(
         input=input,
-        window_length=normalize_duration(window_length),
+        window_length=window_length,
         sampling=sampling,
     ).outputs["output"]

--- a/temporian/core/operators/window/moving_min.py
+++ b/temporian/core/operators/window/moving_min.py
@@ -19,11 +19,10 @@ from typing import Optional
 from temporian.core import operator_lib
 from temporian.core.compilation import compile
 from temporian.core.data.dtype import DType
-from temporian.core.data.duration_utils import Duration, normalize_duration
 from temporian.core.data.node import EventSetNode
 from temporian.core.data.schema import FeatureSchema
 from temporian.core.operators.window.base import BaseWindowOperator
-from temporian.core.typing import EventSetOrNode
+from temporian.core.typing import EventSetOrNode, WindowLength
 
 
 class MovingMinOperator(BaseWindowOperator):
@@ -41,7 +40,7 @@ operator_lib.register_operator(MovingMinOperator)
 @compile
 def moving_min(
     input: EventSetOrNode,
-    window_length: Duration,
+    window_length: WindowLength,
     sampling: Optional[EventSetOrNode] = None,
 ) -> EventSetOrNode:
     assert isinstance(input, EventSetNode)
@@ -50,6 +49,6 @@ def moving_min(
 
     return MovingMinOperator(
         input=input,
-        window_length=normalize_duration(window_length),
+        window_length=window_length,
         sampling=sampling,
     ).outputs["output"]

--- a/temporian/core/operators/window/moving_standard_deviation.py
+++ b/temporian/core/operators/window/moving_standard_deviation.py
@@ -18,11 +18,10 @@ from typing import Optional
 from temporian.core import operator_lib
 from temporian.core.compilation import compile
 from temporian.core.data.dtype import DType
-from temporian.core.data.duration_utils import Duration, normalize_duration
 from temporian.core.data.node import EventSetNode
 from temporian.core.data.schema import FeatureSchema
 from temporian.core.operators.window.base import BaseWindowOperator
-from temporian.core.typing import EventSetOrNode
+from temporian.core.typing import EventSetOrNode, WindowLength
 
 
 class MovingStandardDeviationOperator(BaseWindowOperator):
@@ -42,7 +41,7 @@ operator_lib.register_operator(MovingStandardDeviationOperator)
 @compile
 def moving_standard_deviation(
     input: EventSetOrNode,
-    window_length: Duration,
+    window_length: WindowLength,
     sampling: Optional[EventSetOrNode] = None,
 ) -> EventSetOrNode:
     assert isinstance(input, EventSetNode)
@@ -51,6 +50,6 @@ def moving_standard_deviation(
 
     return MovingStandardDeviationOperator(
         input=input,
-        window_length=normalize_duration(window_length),
+        window_length=window_length,
         sampling=sampling,
     ).outputs["output"]

--- a/temporian/core/operators/window/moving_sum.py
+++ b/temporian/core/operators/window/moving_sum.py
@@ -20,12 +20,11 @@ import numpy as np
 
 from temporian.core import operator_lib
 from temporian.core.compilation import compile
-from temporian.core.data.duration_utils import Duration, normalize_duration
 from temporian.core.data.dtype import DType
 from temporian.core.data.node import EventSetNode
 from temporian.core.data.schema import FeatureSchema
 from temporian.core.operators.window.base import BaseWindowOperator
-from temporian.core.typing import EventSetOrNode
+from temporian.core.typing import EventSetOrNode, WindowLength
 
 
 class MovingSumOperator(BaseWindowOperator):
@@ -43,7 +42,7 @@ operator_lib.register_operator(MovingSumOperator)
 @compile
 def moving_sum(
     input: EventSetOrNode,
-    window_length: Duration,
+    window_length: WindowLength,
     sampling: Optional[EventSetOrNode] = None,
 ) -> EventSetOrNode:
     assert isinstance(input, EventSetNode)
@@ -52,7 +51,7 @@ def moving_sum(
 
     return MovingSumOperator(
         input=input,
-        window_length=normalize_duration(window_length),
+        window_length=window_length,
         sampling=sampling,
     ).outputs["output"]
 
@@ -65,5 +64,5 @@ def cumsum(
 
     return MovingSumOperator(
         input=input,
-        window_length=normalize_duration(np.inf),
+        window_length=np.inf,
     ).outputs["output"]

--- a/temporian/core/operators/window/simple_moving_average.py
+++ b/temporian/core/operators/window/simple_moving_average.py
@@ -19,12 +19,11 @@ from typing import Optional
 from temporian.core import operator_lib
 from temporian.core.compilation import compile
 from temporian.core.data.dtype import DType
-from temporian.core.data.duration_utils import Duration, normalize_duration
 from temporian.core.data.node import EventSetNode
 from temporian.core.data.schema import FeatureSchema
 from temporian.core.operators.window.base import BaseWindowOperator
 from temporian.utils.typecheck import typecheck
-from temporian.core.typing import EventSetOrNode
+from temporian.core.typing import EventSetOrNode, WindowLength
 
 
 class SimpleMovingAverageOperator(BaseWindowOperator):
@@ -49,7 +48,7 @@ operator_lib.register_operator(SimpleMovingAverageOperator)
 @compile
 def simple_moving_average(
     input: EventSetOrNode,
-    window_length: Duration,
+    window_length: WindowLength,
     sampling: Optional[EventSetOrNode] = None,
 ) -> EventSetOrNode:
     assert isinstance(input, EventSetNode)
@@ -58,6 +57,6 @@ def simple_moving_average(
 
     return SimpleMovingAverageOperator(
         input=input,
-        window_length=normalize_duration(window_length),
+        window_length=window_length,
         sampling=sampling,
     ).outputs["output"]

--- a/temporian/core/typing.py
+++ b/temporian/core/typing.py
@@ -98,15 +98,17 @@ single IndexKey.
 WindowLength = Union[Duration, EventSetOrNode]
 """Window length of a moving window operator.
 
-If a [Duration][temporian.duration.Duration], the window length is fixed, and
-will be the same for each timestamp in the effective sampling (the effective
-sampling being the `sampling` if it was provided, or the input otherwise).
+A window length can be either constant or variable.
 
-If an [EventSet][temporian.EventSet], the window length will vary for each
-timestamp in the effective sampling. In this case, the `window_length` EventSet
-must have a single float64 feature and the same sampling as the effective
-sampling. The window length for each timestamp in the effective sampling will be
-the feature value at that timestamp in `window_length`.
+A constant window length is specified with a
+[Duration][temporian.duration.Duration]. For example, `window_length=5.0` or
+`window_length=tp.duration.days(4)`.
+
+A variable window length is specified with an [EventSet][temporian.EventSet]
+containing a single float64 feature. This EventSet can have the same sampling as
+the input EventSet or a different one, in which case the output will have the
+same sampling as the `window_length` EventSet. In both cases the feature value
+on each timestamp will dictate the length of the window in that timestamp.
 
 If an `EventSet`, it should contain strictly positive values. If receiving 0,
 negative values, or missing values, the operator will treat the window as empty.

--- a/temporian/core/typing.py
+++ b/temporian/core/typing.py
@@ -98,16 +98,15 @@ single IndexKey.
 WindowLength = Union[Duration, EventSetOrNode]
 """Window length of a moving window operator.
 
-If a [Duration][temporian.duration.Duration], the window length is constant.
+If a [Duration][temporian.duration.Duration], the window length is fixed, and
+will be the same for each timestamp in the effective sampling (the effective
+sampling being the `sampling` if it was provided, or the input otherwise).
 
 If an [EventSet][temporian.EventSet], the window length will vary for each
-timestamp in the effective sampling (i.e., `sampling` if it was provided or the
-input otherwise).
-
-In this case, the `window_length` `EventSet` must have a single positive float64
-feature, and the same sampling as the effective sampling, and the window length
-for each timestamp in the effective sampling will be the feature value at that
-timestamp in `window_length`.
+timestamp in the effective sampling. In this case, the `window_length` EventSet
+must have a single positive float64 feature and the same sampling as the
+effective sampling. The window length for each timestamp in the effective
+sampling will be the feature value at that timestamp in `window_length`.
 """
 
 

--- a/temporian/core/typing.py
+++ b/temporian/core/typing.py
@@ -104,9 +104,12 @@ sampling being the `sampling` if it was provided, or the input otherwise).
 
 If an [EventSet][temporian.EventSet], the window length will vary for each
 timestamp in the effective sampling. In this case, the `window_length` EventSet
-must have a single positive float64 feature and the same sampling as the
-effective sampling. The window length for each timestamp in the effective
-sampling will be the feature value at that timestamp in `window_length`.
+must have a single float64 feature and the same sampling as the effective
+sampling. The window length for each timestamp in the effective sampling will be
+the feature value at that timestamp in `window_length`.
+
+If an `EventSet`, it should contain strictly positive values. If receiving 0 or
+negative values, the operator will treat the window as empty.
 """
 
 

--- a/temporian/core/typing.py
+++ b/temporian/core/typing.py
@@ -104,10 +104,10 @@ If an [EventSet][temporian.EventSet], the window length will vary for each
 timestamp in the effective sampling (i.e., `sampling` if it was provided or the
 input otherwise).
 
-In this case, the `window_length` `EventSet` must have a single feature and the
-same sampling as the effective sampling, and the window length for each
-timestamp in the effective sampling will be the feature value at that timestamp
-in `window_length`.
+In this case, the `window_length` `EventSet` must have a single positive float64
+feature, and the same sampling as the effective sampling, and the window length
+for each timestamp in the effective sampling will be the feature value at that
+timestamp in `window_length`.
 """
 
 

--- a/temporian/core/typing.py
+++ b/temporian/core/typing.py
@@ -14,6 +14,7 @@
 
 from typing import Dict, List, Set, Tuple, Type, TypeVar, Union
 from temporian.core.data.dtype import DType
+from temporian.core.data.duration import Duration
 
 from temporian.core.data.node import EventSetNode
 from temporian.core.event_set_ops import EventSetOperations
@@ -93,6 +94,22 @@ Auxiliary type to allow receiving a single IndexKey or a list of IndexKeys.
 If receiving a single IndexKey, it is equivalent to receiving a list with a
 single IndexKey.
 """
+
+WindowLength = Union[Duration, EventSetOrNode]
+"""Window length of a moving window operator.
+
+If a [Duration][temporian.duration.Duration], the window length is constant.
+
+If an [EventSet][temporian.EventSet], the window length will vary for each
+timestamp in the effective sampling (i.e., `sampling` if it was provided or the
+input otherwise).
+
+In this case, the `window_length` `EventSet` must have a single feature and the
+same sampling as the effective sampling, and the window length for each
+timestamp in the effective sampling will be the feature value at that timestamp
+in `window_length`.
+"""
+
 
 # Internal
 

--- a/temporian/core/typing.py
+++ b/temporian/core/typing.py
@@ -108,8 +108,8 @@ must have a single float64 feature and the same sampling as the effective
 sampling. The window length for each timestamp in the effective sampling will be
 the feature value at that timestamp in `window_length`.
 
-If an `EventSet`, it should contain strictly positive values. If receiving 0 or
-negative values, the operator will treat the window as empty.
+If an `EventSet`, it should contain strictly positive values. If receiving 0,
+negative values, or missing values, the operator will treat the window as empty.
 """
 
 

--- a/temporian/implementation/numpy/operators/test/moving_count_test.py
+++ b/temporian/implementation/numpy/operators/test/moving_count_test.py
@@ -53,22 +53,13 @@ class MovingCountOperatorTest(absltest.TestCase):
             _i32([1, 2, 3, 4, 1]),
         )
 
-    def test_cc_window_0(self):
-        assert_array_equal(
-            operators_cc.moving_count(
-                _f64([1, 2, 3, 5, 20]),
-                0,
-            ),
-            _i32([0, 0, 0, 0, 0]),
-        )
-
     def test_cc_wo_sampling_w_variable_winlength(self):
         assert_array_equal(
             operators_cc.moving_count(
                 _f64([1, 2, 3, 5, 20]),
-                _f64([0, np.inf, 1.001, 5, 0]),
+                _f64([0, np.inf, 1.001, 5, 0.00001]),
             ),
-            _i32([1, 2, 2, 4, 0]),
+            _i32([1, 2, 2, 4, 1]),
         )
 
     def test_cc_w_sampling_w_variable_winlength(self):
@@ -76,7 +67,7 @@ class MovingCountOperatorTest(absltest.TestCase):
             operators_cc.moving_count(
                 _f64([1, 2, 3, 5, 20]),
                 _f64([0, 1.5, 3.5, 3.5, 3.5, 20]),
-                _f64([0, 1, 1, 3, 0.5, 19.5]),
+                _f64([1, 1, 1, 3, 0.5, 19.5]),
             ),
             _i32([0, 1, 1, 3, 0, 5]),
         )

--- a/temporian/implementation/numpy/operators/test/moving_count_test.py
+++ b/temporian/implementation/numpy/operators/test/moving_count_test.py
@@ -53,16 +53,16 @@ class MovingCountOperatorTest(absltest.TestCase):
             _i32([1, 2, 3, 4, 1]),
         )
 
-    def test_cc_wo_sampling_w_variable_winlength(self):
+    def test_cc_wo_sampling_w_variable_winlen(self):
         assert_array_equal(
             operators_cc.moving_count(
                 _f64([1, 2, 3, 5, 20]),
                 _f64([0, np.inf, 1.001, 5, 0.00001]),
             ),
-            _i32([1, 2, 2, 4, 1]),
+            _i32([0, 2, 2, 4, 1]),
         )
 
-    def test_cc_w_sampling_w_variable_winlength(self):
+    def test_cc_w_sampling_w_variable_winlen(self):
         assert_array_equal(
             operators_cc.moving_count(
                 _f64([1, 2, 3, 5, 20]),

--- a/temporian/implementation/numpy/operators/test/moving_count_test.py
+++ b/temporian/implementation/numpy/operators/test/moving_count_test.py
@@ -14,10 +14,10 @@
 
 import math
 
-from absl.testing import absltest
 import numpy as np
-from numpy.testing import assert_array_equal
 import pandas as pd
+from absl.testing import absltest
+from numpy.testing import assert_array_equal
 
 from temporian.core.operators.window.moving_count import MovingCountOperator
 from temporian.implementation.numpy.operators.window.moving_count import (
@@ -25,7 +25,6 @@ from temporian.implementation.numpy.operators.window.moving_count import (
     operators_cc,
 )
 from temporian.core.data import duration, node as node_lib
-from numpy.testing import assert_array_equal
 from temporian.io.pandas import from_pandas
 
 
@@ -52,6 +51,34 @@ class MovingCountOperatorTest(absltest.TestCase):
                 5.0,
             ),
             _i32([1, 2, 3, 4, 1]),
+        )
+
+    def test_cc_window_0(self):
+        assert_array_equal(
+            operators_cc.moving_count(
+                _f64([1, 2, 3, 5, 20]),
+                0,
+            ),
+            _i32([0, 0, 0, 0, 0]),
+        )
+
+    def test_cc_wo_sampling_w_variable_winlength(self):
+        assert_array_equal(
+            operators_cc.moving_count(
+                _f64([1, 2, 3, 5, 20]),
+                _f64([0, np.inf, 1.001, 5, 0]),
+            ),
+            _i32([1, 2, 2, 4, 0]),
+        )
+
+    def test_cc_w_sampling_w_variable_winlength(self):
+        assert_array_equal(
+            operators_cc.moving_count(
+                _f64([1, 2, 3, 5, 20]),
+                _f64([0, 1.5, 3.5, 3.5, 3.5, 20]),
+                _f64([0, 1, 1, 3, 0.5, 19.5]),
+            ),
+            _i32([0, 1, 1, 3, 0, 5]),
         )
 
     def test_flat(self):

--- a/temporian/implementation/numpy/operators/test/moving_max_test.py
+++ b/temporian/implementation/numpy/operators/test/moving_max_test.py
@@ -22,6 +22,7 @@ from numpy.testing import assert_array_equal
 from temporian.core.operators.window.moving_max import (
     MovingMaxOperator,
 )
+from temporian.implementation.numpy.data.io import event_set
 from temporian.implementation.numpy.operators.window.moving_max import (
     MovingMaxNumpyImplementation,
     operators_cc,
@@ -48,8 +49,8 @@ class MovingMaxOperatorTest(absltest.TestCase):
     def test_cc_wo_sampling(self):
         assert_array_equal(
             operators_cc.moving_max(
-                _f64([0, 1, 2, 3, 5, 20]),
-                _f32([nan, 10, nan, 12, 13, 14]),
+                _f64([0, 1, 2, 3, 5, 20]),  # timestamps
+                _f32([nan, 10, nan, 12, 13, 14]),  # feature
                 3.5,
             ),
             _f32([nan, 10, 10, 12, 13, 14]),
@@ -58,12 +59,22 @@ class MovingMaxOperatorTest(absltest.TestCase):
     def test_cc_w_sampling(self):
         assert_array_equal(
             operators_cc.moving_max(
-                _f64([0, 1, 2, 3, 5, 20]),
-                _f32([nan, 10, nan, 12, 13, 14]),
-                _f64([-1, 3, 40]),
+                _f64([0, 1, 2, 3, 5, 20]),  # timestamps
+                _f32([nan, 10, nan, 12, 13, 14]),  # feature
+                _f64([-1, 3, 40]),  # sampling
                 3.5,
             ),
             _f32([nan, 12, nan]),
+        )
+
+    def test_cc_wo_sampling_w_variable_winlength(self):
+        assert_array_equal(
+            operators_cc.moving_max(
+                _f64([0, 1, 2, 3, 5, 20]),  # timestamps
+                _f32([nan, 10, 11, 12, 13, 14]),  # feature
+                _f64([1, 1, 1.5, 0.5, 3.5, 20]),  # window length
+            ),
+            _f32([nan, 10, 21, 12, 36, 60]),
         )
 
     def test_flat(self):

--- a/temporian/implementation/numpy/operators/test/moving_max_test.py
+++ b/temporian/implementation/numpy/operators/test/moving_max_test.py
@@ -67,7 +67,7 @@ class MovingMaxOperatorTest(absltest.TestCase):
             _f32([nan, 12, nan]),
         )
 
-    def test_cc_wo_sampling_w_variable_winlength(self):
+    def test_cc_wo_sampling_w_variable_winlen(self):
         assert_array_equal(
             operators_cc.moving_max(
                 evset_timestamps=_f64([0, 1, 2, 3, 5, 20]),
@@ -77,7 +77,7 @@ class MovingMaxOperatorTest(absltest.TestCase):
             _f64([nan, 0, 10, 5, 10, np.nan]),
         )
 
-    def test_cc_w_sampling_w_variable_winlength(self):
+    def test_cc_w_sampling_w_variable_winlen(self):
         assert_array_equal(
             operators_cc.moving_max(
                 evset_timestamps=_f64([0, 1, 2, 3, 5, 20]),

--- a/temporian/implementation/numpy/operators/test/moving_max_test.py
+++ b/temporian/implementation/numpy/operators/test/moving_max_test.py
@@ -72,9 +72,9 @@ class MovingMaxOperatorTest(absltest.TestCase):
             operators_cc.moving_max(
                 _f64([0, 1, 2, 3, 5, 20]),  # timestamps
                 _f64([nan, 0, 10, 5, 1, 2]),  # feature
-                _f64([1, 1, 1.5, 0.5, 3.5, 20]),  # window length
+                _f64([1, 1, 1.5, 0.5, 3.5, 0]),  # window length
             ),
-            _f64([nan, 0, 10, 5, 10, 10]),
+            _f64([nan, 0, 10, 5, 10, np.nan]),
         )
 
     def test_cc_w_sampling_w_variable_winlength(self):

--- a/temporian/implementation/numpy/operators/test/moving_max_test.py
+++ b/temporian/implementation/numpy/operators/test/moving_max_test.py
@@ -67,6 +67,27 @@ class MovingMaxOperatorTest(absltest.TestCase):
             _f32([nan, 12, nan]),
         )
 
+    def test_cc_wo_sampling_w_variable_winlength(self):
+        assert_array_equal(
+            operators_cc.moving_max(
+                _f64([0, 1, 2, 3, 5, 20]),  # timestamps
+                _f64([nan, 0, 10, 5, 1, 2]),  # feature
+                _f64([1, 1, 1.5, 0.5, 3.5, 20]),  # window length
+            ),
+            _f64([nan, 0, 10, 5, 10, 10]),
+        )
+
+    def test_cc_w_sampling_w_variable_winlength(self):
+        assert_array_equal(
+            operators_cc.moving_max(
+                _f64([0, 1, 2, 3, 5, 20]),  # timestamps
+                _f64([nan, 0, 10, 5, 1, 2]),  # feature
+                _f64([-1, 1, 4, 19, 20, 20]),  # sampling
+                _f64([10, 10, 2.5, 19, 16, np.inf]),  # window length
+            ),
+            _f64([nan, 0, 10, 10, 2, 10]),
+        )
+
     def test_flat(self):
         """A simple time sequence."""
 

--- a/temporian/implementation/numpy/operators/test/moving_max_test.py
+++ b/temporian/implementation/numpy/operators/test/moving_max_test.py
@@ -67,16 +67,6 @@ class MovingMaxOperatorTest(absltest.TestCase):
             _f32([nan, 12, nan]),
         )
 
-    def test_cc_wo_sampling_w_variable_winlength(self):
-        assert_array_equal(
-            operators_cc.moving_max(
-                _f64([0, 1, 2, 3, 5, 20]),  # timestamps
-                _f32([nan, 10, 11, 12, 13, 14]),  # feature
-                _f64([1, 1, 1.5, 0.5, 3.5, 20]),  # window length
-            ),
-            _f32([nan, 10, 21, 12, 36, 60]),
-        )
-
     def test_flat(self):
         """A simple time sequence."""
 

--- a/temporian/implementation/numpy/operators/test/moving_max_test.py
+++ b/temporian/implementation/numpy/operators/test/moving_max_test.py
@@ -49,9 +49,9 @@ class MovingMaxOperatorTest(absltest.TestCase):
     def test_cc_wo_sampling(self):
         assert_array_equal(
             operators_cc.moving_max(
-                _f64([0, 1, 2, 3, 5, 20]),  # timestamps
-                _f32([nan, 10, nan, 12, 13, 14]),  # feature
-                3.5,
+                evset_timestamps=_f64([0, 1, 2, 3, 5, 20]),
+                evset_values=_f32([nan, 10, nan, 12, 13, 14]),
+                window_length=3.5,
             ),
             _f32([nan, 10, 10, 12, 13, 14]),
         )
@@ -59,10 +59,10 @@ class MovingMaxOperatorTest(absltest.TestCase):
     def test_cc_w_sampling(self):
         assert_array_equal(
             operators_cc.moving_max(
-                _f64([0, 1, 2, 3, 5, 20]),  # timestamps
-                _f32([nan, 10, nan, 12, 13, 14]),  # feature
-                _f64([-1, 3, 40]),  # sampling
-                3.5,
+                evset_timestamps=_f64([0, 1, 2, 3, 5, 20]),
+                evset_values=_f32([nan, 10, nan, 12, 13, 14]),
+                sampling_timestamps=_f64([-1, 3, 40]),
+                window_length=3.5,
             ),
             _f32([nan, 12, nan]),
         )
@@ -70,9 +70,9 @@ class MovingMaxOperatorTest(absltest.TestCase):
     def test_cc_wo_sampling_w_variable_winlength(self):
         assert_array_equal(
             operators_cc.moving_max(
-                _f64([0, 1, 2, 3, 5, 20]),  # timestamps
-                _f64([nan, 0, 10, 5, 1, 2]),  # feature
-                _f64([1, 1, 1.5, 0.5, 3.5, 0]),  # window length
+                evset_timestamps=_f64([0, 1, 2, 3, 5, 20]),
+                evset_values=_f64([nan, 0, 10, 5, 1, 2]),
+                window_length=_f64([1, 1, 1.5, 0.5, 3.5, 0]),
             ),
             _f64([nan, 0, 10, 5, 10, np.nan]),
         )
@@ -80,10 +80,10 @@ class MovingMaxOperatorTest(absltest.TestCase):
     def test_cc_w_sampling_w_variable_winlength(self):
         assert_array_equal(
             operators_cc.moving_max(
-                _f64([0, 1, 2, 3, 5, 20]),  # timestamps
-                _f64([nan, 0, 10, 5, 1, 2]),  # feature
-                _f64([-1, 1, 4, 19, 20, 20]),  # sampling
-                _f64([10, 10, 2.5, 19, 16, np.inf]),  # window length
+                evset_timestamps=_f64([0, 1, 2, 3, 5, 20]),
+                evset_values=_f64([nan, 0, 10, 5, 1, 2]),
+                sampling_timestamps=_f64([-1, 1, 4, 19, 20, 20]),
+                window_length=_f64([10, 10, 2.5, 19, 16, np.inf]),
             ),
             _f64([nan, 0, 10, 10, 2, 10]),
         )

--- a/temporian/implementation/numpy/operators/test/moving_min_test.py
+++ b/temporian/implementation/numpy/operators/test/moving_min_test.py
@@ -64,6 +64,27 @@ class MovingMinOperatorTest(absltest.TestCase):
             _f32([nan, 10, nan]),
         )
 
+    def test_cc_wo_sampling_w_variable_winlength(self):
+        assert_array_equal(
+            operators_cc.moving_min(
+                _f64([0, 1, 2, 3, 5, 20]),  # timestamps
+                _f64([nan, 0, 10, 5, 1, 2]),  # feature
+                _f64([1, 1, 1.5, 0.5, 3.5, 0]),  # window length
+            ),
+            _f64([nan, 0, 0, 5, 1, np.nan]),
+        )
+
+    def test_cc_w_sampling_w_variable_winlength(self):
+        assert_array_equal(
+            operators_cc.moving_min(
+                _f64([0, 1, 2, 3, 5, 20]),  # timestamps
+                _f64([nan, 0, 10, 5, 1, 2]),  # feature
+                _f64([-1, 1, 4, 19, 20, 20]),  # sampling
+                _f64([10, 10, 2.5, 19, 0.001, np.inf]),  # window length
+            ),
+            _f64([nan, 0, 5, 0, 2, 0]),
+        )
+
     def test_flat(self):
         """A simple time sequence."""
 

--- a/temporian/implementation/numpy/operators/test/moving_min_test.py
+++ b/temporian/implementation/numpy/operators/test/moving_min_test.py
@@ -64,7 +64,7 @@ class MovingMinOperatorTest(absltest.TestCase):
             _f32([nan, 10, nan]),
         )
 
-    def test_cc_wo_sampling_w_variable_winlength(self):
+    def test_cc_wo_sampling_w_variable_winlen(self):
         assert_array_equal(
             operators_cc.moving_min(
                 evset_timestamps=_f64([0, 1, 2, 3, 5, 20]),
@@ -74,7 +74,7 @@ class MovingMinOperatorTest(absltest.TestCase):
             _f64([nan, 0, 0, 5, 1, np.nan]),
         )
 
-    def test_cc_w_sampling_w_variable_winlength(self):
+    def test_cc_w_sampling_w_variable_winlen(self):
         assert_array_equal(
             operators_cc.moving_min(
                 evset_timestamps=_f64([0, 1, 2, 3, 5, 20]),

--- a/temporian/implementation/numpy/operators/test/moving_min_test.py
+++ b/temporian/implementation/numpy/operators/test/moving_min_test.py
@@ -67,9 +67,9 @@ class MovingMinOperatorTest(absltest.TestCase):
     def test_cc_wo_sampling_w_variable_winlength(self):
         assert_array_equal(
             operators_cc.moving_min(
-                _f64([0, 1, 2, 3, 5, 20]),  # timestamps
-                _f64([nan, 0, 10, 5, 1, 2]),  # feature
-                _f64([1, 1, 1.5, 0.5, 3.5, 0]),  # window length
+                evset_timestamps=_f64([0, 1, 2, 3, 5, 20]),
+                evset_values=_f64([nan, 0, 10, 5, 1, 2]),
+                window_length=_f64([1, 1, 1.5, 0.5, 3.5, 0]),
             ),
             _f64([nan, 0, 0, 5, 1, np.nan]),
         )
@@ -77,10 +77,10 @@ class MovingMinOperatorTest(absltest.TestCase):
     def test_cc_w_sampling_w_variable_winlength(self):
         assert_array_equal(
             operators_cc.moving_min(
-                _f64([0, 1, 2, 3, 5, 20]),  # timestamps
-                _f64([nan, 0, 10, 5, 1, 2]),  # feature
-                _f64([-1, 1, 4, 19, 20, 20]),  # sampling
-                _f64([10, 10, 2.5, 19, 0.001, np.inf]),  # window length
+                evset_timestamps=_f64([0, 1, 2, 3, 5, 20]),
+                evset_values=_f64([nan, 0, 10, 5, 1, 2]),
+                sampling_timestamps=_f64([-1, 1, 4, 19, 20, 20]),
+                window_length=_f64([10, 10, 2.5, 19, 0.001, np.inf]),
             ),
             _f64([nan, 0, 5, 0, 2, 0]),
         )

--- a/temporian/implementation/numpy/operators/test/moving_standard_deviation_test.py
+++ b/temporian/implementation/numpy/operators/test/moving_standard_deviation_test.py
@@ -52,7 +52,7 @@ class MovingStandardDeviationOperatorTest(absltest.TestCase):
             _f32([0.0, 0.0, 1.0, 1.247219, 0.0]),
         )
 
-    def test_cc_wo_sampling_w_variable_winlength(self):
+    def test_cc_wo_sampling_w_variable_winlen(self):
         assert_almost_equal(
             operators_cc.moving_standard_deviation(
                 evset_timestamps=_f64([0, 1, 2, 3, 5, 20]),
@@ -62,7 +62,7 @@ class MovingStandardDeviationOperatorTest(absltest.TestCase):
             _f32([nan, 0, 0.5, 0, 0.8164965, 1.4142135]),
         )
 
-    def test_cc_w_sampling_w_variable_winlength(self):
+    def test_cc_w_sampling_w_variable_winlen(self):
         assert_almost_equal(
             operators_cc.moving_standard_deviation(
                 evset_timestamps=_f64([0, 1, 2, 3, 5, 20]),

--- a/temporian/implementation/numpy/operators/test/moving_standard_deviation_test.py
+++ b/temporian/implementation/numpy/operators/test/moving_standard_deviation_test.py
@@ -14,10 +14,10 @@
 
 import math
 
-from absl.testing import absltest
 import numpy as np
-from numpy.testing import assert_almost_equal
 import pandas as pd
+from absl.testing import absltest
+from numpy.testing import assert_almost_equal
 
 from temporian.core.operators.window.moving_standard_deviation import (
     MovingStandardDeviationOperator,
@@ -27,8 +27,6 @@ from temporian.implementation.numpy.operators.window.moving_standard_deviation i
     operators_cc,
 )
 from temporian.core.data import node as node_lib
-import math
-from numpy.testing import assert_almost_equal
 from temporian.io.pandas import from_pandas
 
 
@@ -52,6 +50,27 @@ class MovingStandardDeviationOperatorTest(absltest.TestCase):
                 5.0,
             ),
             _f32([0.0, 0.0, 1.0, 1.247219, 0.0]),
+        )
+
+    def test_cc_wo_sampling_w_variable_winlength(self):
+        assert_almost_equal(
+            operators_cc.moving_standard_deviation(
+                _f64([0, 1, 2, 3, 5, 20]),  # timestamps
+                _f32([nan, 10, 11, 12, 13, 14]),  # feature
+                _f64([1, 1, 1.5, 0.5, 3.5, 20]),  # window length
+            ),
+            _f32([nan, 0, 0.5, 0, 0.8164965, 1.4142135]),
+        )
+
+    def test_cc_w_sampling_w_variable_winlength(self):
+        assert_almost_equal(
+            operators_cc.moving_standard_deviation(
+                _f64([0, 1, 2, 3, 5, 20]),  # timestamps
+                _f32([nan, 10, 11, 12, 13, 14]),  # feature
+                _f64([-1, 1, 4, 19, 20, 20]),  # sampling
+                _f64([10, 0.5, 2.5, 19, 16, np.inf]),  # window length
+            ),
+            _f32([nan, 0, 0.5, 1.1180339, 0.5, 1.4142135]),
         )
 
     def test_flat(self):

--- a/temporian/implementation/numpy/operators/test/moving_standard_deviation_test.py
+++ b/temporian/implementation/numpy/operators/test/moving_standard_deviation_test.py
@@ -55,9 +55,9 @@ class MovingStandardDeviationOperatorTest(absltest.TestCase):
     def test_cc_wo_sampling_w_variable_winlength(self):
         assert_almost_equal(
             operators_cc.moving_standard_deviation(
-                _f64([0, 1, 2, 3, 5, 20]),  # timestamps
-                _f32([nan, 10, 11, 12, 13, 14]),  # feature
-                _f64([1, 1, 1.5, 0.5, 3.5, 20]),  # window length
+                evset_timestamps=_f64([0, 1, 2, 3, 5, 20]),
+                evset_values=_f32([nan, 10, 11, 12, 13, 14]),
+                window_length=_f64([1, 1, 1.5, 0.5, 3.5, 20]),
             ),
             _f32([nan, 0, 0.5, 0, 0.8164965, 1.4142135]),
         )
@@ -65,10 +65,10 @@ class MovingStandardDeviationOperatorTest(absltest.TestCase):
     def test_cc_w_sampling_w_variable_winlength(self):
         assert_almost_equal(
             operators_cc.moving_standard_deviation(
-                _f64([0, 1, 2, 3, 5, 20]),  # timestamps
-                _f32([nan, 10, 11, 12, 13, 14]),  # feature
-                _f64([-1, 1, 4, 19, 20, 20]),  # sampling
-                _f64([10, 0.5, 2.5, 19, 16, np.inf]),  # window length
+                evset_timestamps=_f64([0, 1, 2, 3, 5, 20]),
+                evset_values=_f32([nan, 10, 11, 12, 13, 14]),
+                sampling_timestamps=_f64([-1, 1, 4, 19, 20, 20]),
+                window_length=_f64([10, 0.5, 2.5, 19, 16, np.inf]),
             ),
             _f32([nan, 0, 0.5, 1.1180339, 0.5, 1.4142135]),
         )

--- a/temporian/implementation/numpy/operators/test/moving_sum_test.py
+++ b/temporian/implementation/numpy/operators/test/moving_sum_test.py
@@ -62,6 +62,17 @@ class MovingSumOperatorTest(absltest.TestCase):
             _f32([0, 10, 21, 12, 36, 60]),
         )
 
+    def test_cc_w_sampling_w_variable_winlength(self):
+        assert_array_equal(
+            operators_cc.moving_sum(
+                _f64([0, 1, 2, 3, 5, 20]),  # timestamps
+                _f32([nan, 10, 11, 12, 13, 14]),  # feature
+                _f64([-1, 1, 4, 19, 20, 20]),  # sampling
+                _f64([10, 0.5, 2.5, 19, 16, np.inf]),  # window length
+            ),
+            _f32([0, 10, 23, 46, 27, 60]),
+        )
+
     def test_flat(self):
         """A simple event set."""
 

--- a/temporian/implementation/numpy/operators/test/moving_sum_test.py
+++ b/temporian/implementation/numpy/operators/test/moving_sum_test.py
@@ -45,9 +45,9 @@ class MovingSumOperatorTest(absltest.TestCase):
     def test_cc_wo_sampling(self):
         assert_array_equal(
             operators_cc.moving_sum(
-                _f64([1, 2, 3, 5, 20]),  # timestamps
-                _f32([10, nan, 12, 13, 14]),  # feature
-                5.0,
+                evset_timestamps=_f64([1, 2, 3, 5, 20]),
+                evset_values=_f32([10, nan, 12, 13, 14]),
+                window_length=5.0,
             ),
             _f32([10.0, 10.0, 22.0, 35.0, 14.0]),
         )
@@ -55,9 +55,9 @@ class MovingSumOperatorTest(absltest.TestCase):
     def test_cc_wo_sampling_w_variable_winlength(self):
         assert_array_equal(
             operators_cc.moving_sum(
-                _f64([0, 1, 2, 3, 5, 20]),  # timestamps
-                _f32([nan, 10, 11, 12, 13, 14]),  # feature
-                _f64([1, 1, 1.5, 0.5, 3.5, 20]),  # window length
+                evset_timestamps=_f64([0, 1, 2, 3, 5, 20]),
+                evset_values=_f32([nan, 10, 11, 12, 13, 14]),
+                window_length=_f64([1, 1, 1.5, 0.5, 3.5, 20]),
             ),
             _f32([0, 10, 21, 12, 36, 60]),
         )
@@ -65,10 +65,10 @@ class MovingSumOperatorTest(absltest.TestCase):
     def test_cc_w_sampling_w_variable_winlength(self):
         assert_array_equal(
             operators_cc.moving_sum(
-                _f64([0, 1, 2, 3, 5, 20]),  # timestamps
-                _f32([nan, 10, 11, 12, 13, 14]),  # feature
-                _f64([-1, 1, 4, 19, 20, 20]),  # sampling
-                _f64([10, 0.5, 2.5, 19, 16, np.inf]),  # window length
+                evset_timestamps=_f64([0, 1, 2, 3, 5, 20]),
+                evset_values=_f32([nan, 10, 11, 12, 13, 14]),
+                sampling_timestamps=_f64([-1, 1, 4, 19, 20, 20]),
+                window_length=_f64([10, 0.5, 2.5, 19, 16, np.inf]),
             ),
             _f32([0, 10, 23, 46, 27, 60]),
         )

--- a/temporian/implementation/numpy/operators/test/moving_sum_test.py
+++ b/temporian/implementation/numpy/operators/test/moving_sum_test.py
@@ -14,12 +14,11 @@
 
 import math
 
-from absl.testing import absltest
 import numpy as np
-from numpy.testing import assert_array_equal
 import pandas as pd
-
 from absl.testing import absltest
+from numpy.testing import assert_array_equal
+
 from temporian.core.operators.window.moving_sum import (
     MovingSumOperator,
 )
@@ -28,8 +27,6 @@ from temporian.implementation.numpy.operators.window.moving_sum import (
     operators_cc,
 )
 from temporian.core.data import node as node_lib
-import math
-from numpy.testing import assert_array_equal
 from temporian.io.pandas import from_pandas
 
 
@@ -48,11 +45,21 @@ class MovingSumOperatorTest(absltest.TestCase):
     def test_cc_wo_sampling(self):
         assert_array_equal(
             operators_cc.moving_sum(
-                _f64([1, 2, 3, 5, 20]),
-                _f32([10, nan, 12, 13, 14]),
+                _f64([1, 2, 3, 5, 20]),  # timestamps
+                _f32([10, nan, 12, 13, 14]),  # feature
                 5.0,
             ),
             _f32([10.0, 10.0, 22.0, 35.0, 14.0]),
+        )
+
+    def test_cc_wo_sampling_w_variable_winlength(self):
+        assert_array_equal(
+            operators_cc.moving_sum(
+                _f64([0, 1, 2, 3, 5, 20]),  # timestamps
+                _f32([nan, 10, 11, 12, 13, 14]),  # feature
+                _f64([1, 1, 1.5, 0.5, 3.5, 20]),  # window length
+            ),
+            _f32([0, 10, 21, 12, 36, 60]),
         )
 
     def test_flat(self):

--- a/temporian/implementation/numpy/operators/test/moving_sum_test.py
+++ b/temporian/implementation/numpy/operators/test/moving_sum_test.py
@@ -225,6 +225,62 @@ class MovingSumOperatorTest(absltest.TestCase):
 
         self.assertEqual(output["output"], expected_output)
 
+    def test_with_sampling_and_variable_winlength(self):
+        evset = from_pandas(
+            pd.DataFrame(
+                [
+                    [1, 10.0],
+                    [2, 11.0],
+                    [3, 12.0],
+                    [5, 13.0],
+                    [6, 14.0],
+                ],
+                columns=["timestamp", "a"],
+            )
+        )
+        sampling = from_pandas(
+            pd.DataFrame(
+                [[2], [5.5], [10]],
+                columns=["timestamp"],
+            )
+        )
+        window_length = from_pandas(
+            pd.DataFrame(
+                [
+                    [2, 0.5],
+                    [5.5, 3],
+                    [10, 8.5],
+                ],
+                columns=["timestamp", "length"],
+            ),
+            same_sampling_as=sampling,
+        )
+
+        op = MovingSumOperator(
+            input=evset.node(),
+            window_length=window_length.node(),
+            sampling=sampling.node(),
+        )
+        instance = MovingSumNumpyImplementation(op)
+
+        output = instance(
+            input=evset, sampling=sampling, window_length=window_length
+        )
+
+        expected_output = from_pandas(
+            pd.DataFrame(
+                [
+                    [2, 11.0],
+                    [5.5, 25.0],
+                    [10, 50],
+                ],
+                columns=["timestamp", "a"],
+            )
+        )
+        print(output["output"])
+
+        self.assertEqual(output["output"], expected_output)
+
     def test_with_nan(self):
         """The input features contains nan values."""
 

--- a/temporian/implementation/numpy/operators/test/simple_moving_average_test.py
+++ b/temporian/implementation/numpy/operators/test/simple_moving_average_test.py
@@ -99,6 +99,27 @@ class SimpleMovingAverageOperatorTest(absltest.TestCase):
             _f32([nan, 11.0, 11.0, nan, nan, nan, 13.0, 14]),
         )
 
+    def test_cc_wo_sampling_w_variable_winlength(self):
+        assert_array_equal(
+            cc_sma(
+                _f64([0, 1, 2, 3, 5, 20]),  # timestamps
+                _f32([nan, 10, 11, 12, 13, 14]),  # feature
+                _f64([1, 1, 1.5, 0.5, 3.5, 20]),  # window length
+            ),
+            _f32([nan, 10, 10.5, 12, 12, 12]),
+        )
+
+    def test_cc_w_sampling_w_variable_winlength(self):
+        assert_array_equal(
+            cc_sma(
+                _f64([0, 1, 2, 3, 5, 20]),  # timestamps
+                _f64([nan, 10, 11, 12, 13, 14]),  # feature
+                _f64([-1, 1, 4, 19, 20, 20]),  # sampling
+                _f64([10, 0.5, 2.5, 19, 16, np.inf]),  # window length
+            ),
+            _f64([nan, 10, 11.5, 11.5, 13.5, 12]),
+        )
+
     def test_flat(self):
         """A simple event set."""
 

--- a/temporian/implementation/numpy/operators/test/simple_moving_average_test.py
+++ b/temporian/implementation/numpy/operators/test/simple_moving_average_test.py
@@ -164,6 +164,16 @@ class SimpleMovingAverageOperatorTest(absltest.TestCase):
             _f64([11, nan, 12.5, nan, nan, 12.5]),
         )
 
+    def test_cc_w0_sampling_repeated_ts(self):
+        assert_array_equal(
+            cc_sma(
+                evset_timestamps=_f64([0, 2, 2, 2, 2, 5]),
+                evset_values=_f64([10, 11, 12, 13, 14, 15]),
+                window_length=_f64([1, 3, 0.5, np.inf, -1, 5]),
+            ),
+            _f64([10, 12, 12.5, 12, nan, 13]),
+        )
+
     def test_flat(self):
         """A simple event set."""
 

--- a/temporian/implementation/numpy/operators/test/simple_moving_average_test.py
+++ b/temporian/implementation/numpy/operators/test/simple_moving_average_test.py
@@ -131,6 +131,17 @@ class SimpleMovingAverageOperatorTest(absltest.TestCase):
             _f64([13.5, 14, 12, nan, 14, 12.5]),
         )
 
+    def test_cc_variable_winlength_shortest_duration(self):
+        assert_array_equal(
+            cc_sma(
+                _f64([1.999999, 2]),  # timestamps
+                _f64([10, 11]),  # feature
+                _f64([2, 2, 2, 2]),  # sampling
+                _f64([1, 0.001, duration.shortest, 0]),  # window length
+            ),
+            _f64([10.5, 10.5, 11, nan]),
+        )
+
     def test_flat(self):
         """A simple event set."""
 

--- a/temporian/implementation/numpy/operators/test/simple_moving_average_test.py
+++ b/temporian/implementation/numpy/operators/test/simple_moving_average_test.py
@@ -26,7 +26,7 @@ from temporian.implementation.numpy.operators.window.simple_moving_average impor
     SimpleMovingAverageNumpyImplementation,
     operators_cc,
 )
-from temporian.core.data import node as node_lib
+from temporian.core.data import duration, node as node_lib
 from temporian.io.pandas import from_pandas
 
 
@@ -118,6 +118,17 @@ class SimpleMovingAverageOperatorTest(absltest.TestCase):
                 _f64([10, 0.5, 2.5, 19, 16, np.inf]),  # window length
             ),
             _f64([nan, 10, 11.5, 11.5, 13.5, 12]),
+        )
+
+    def test_cc_variable_winlength_repeated_ts(self):
+        assert_array_equal(
+            cc_sma(
+                _f64([0, 1, 2, 3, 5, 20]),  # timestamps
+                _f64([nan, 10, 11, 12, 13, 14]),  # feature
+                _f64([20, 20, 20, 20, 20, 20]),  # sampling
+                _f64([16, 0.001, np.inf, 0, 1, 19]),  # window length
+            ),
+            _f64([13.5, 14, 12, nan, 14, 12.5]),
         )
 
     def test_flat(self):

--- a/temporian/implementation/numpy/operators/test/simple_moving_average_test.py
+++ b/temporian/implementation/numpy/operators/test/simple_moving_average_test.py
@@ -102,9 +102,9 @@ class SimpleMovingAverageOperatorTest(absltest.TestCase):
     def test_cc_wo_sampling_w_variable_winlength(self):
         assert_array_equal(
             cc_sma(
-                _f64([0, 1, 2, 3, 5, 20]),  # timestamps
-                _f32([nan, 10, 11, 12, 13, 14]),  # feature
-                _f64([1, 1, 1.5, 0.5, 3.5, 20]),  # window length
+                evset_timestamps=_f64([0, 1, 2, 3, 5, 20]),
+                evset_values=_f32([nan, 10, 11, 12, 13, 14]),
+                window_length=_f64([1, 1, 1.5, 0.5, 3.5, 20]),
             ),
             _f32([nan, 10, 10.5, 12, 12, 12]),
         )
@@ -112,10 +112,10 @@ class SimpleMovingAverageOperatorTest(absltest.TestCase):
     def test_cc_w_sampling_w_variable_winlength(self):
         assert_array_equal(
             cc_sma(
-                _f64([0, 1, 2, 3, 5, 20]),  # timestamps
-                _f64([nan, 10, 11, 12, 13, 14]),  # feature
-                _f64([-1, 1, 4, 19, 20, 20]),  # sampling
-                _f64([10, 0.5, 2.5, 19, 16, np.inf]),  # window length
+                evset_timestamps=_f64([0, 1, 2, 3, 5, 20]),
+                evset_values=_f64([nan, 10, 11, 12, 13, 14]),
+                sampling_timestamps=_f64([-1, 1, 4, 19, 20, 20]),
+                window_length=_f64([10, 0.5, 2.5, 19, 16, np.inf]),
             ),
             _f64([nan, 10, 11.5, 11.5, 13.5, 12]),
         )
@@ -123,10 +123,10 @@ class SimpleMovingAverageOperatorTest(absltest.TestCase):
     def test_cc_variable_winlength_repeated_ts(self):
         assert_array_equal(
             cc_sma(
-                _f64([0, 1, 2, 3, 5, 20]),  # timestamps
-                _f64([nan, 10, 11, 12, 13, 14]),  # feature
-                _f64([20, 20, 20, 20, 20, 20]),  # sampling
-                _f64([16, 0.001, np.inf, 0, 1, 19]),  # window length
+                evset_timestamps=_f64([0, 1, 2, 3, 5, 20]),
+                evset_values=_f64([nan, 10, 11, 12, 13, 14]),
+                sampling_timestamps=_f64([20, 20, 20, 20, 20, 20]),
+                window_length=_f64([16, 0.001, np.inf, 0, 1, 19]),
             ),
             _f64([13.5, 14, 12, nan, 14, 12.5]),
         )
@@ -134,10 +134,10 @@ class SimpleMovingAverageOperatorTest(absltest.TestCase):
     def test_cc_variable_winlength_shortest_duration(self):
         assert_array_equal(
             cc_sma(
-                _f64([1.999999, 2]),  # timestamps
-                _f64([10, 11]),  # feature
-                _f64([2, 2, 2, 2]),  # sampling
-                _f64([1, 0.001, duration.shortest, 0]),  # window length
+                evset_timestamps=_f64([1.999999, 2]),
+                evset_values=_f64([10, 11]),
+                sampling_timestamps=_f64([2, 2, 2, 2]),
+                window_length=_f64([1, 0.001, duration.shortest, 0]),
             ),
             _f64([10.5, 10.5, 11, nan]),
         )

--- a/temporian/implementation/numpy/operators/test/simple_moving_average_test.py
+++ b/temporian/implementation/numpy/operators/test/simple_moving_average_test.py
@@ -403,24 +403,19 @@ class SimpleMovingAverageOperatorTest(absltest.TestCase):
         evset = from_pandas(
             pd.DataFrame([[0, 1]], columns=["a", "timestamp"], dtype=np.float64)
         )
-        sampling = from_pandas(pd.DataFrame([[1], [2]], columns=["timestamp"]))
         window_length = from_pandas(
             pd.DataFrame(
                 [[1, 1], [2, -1]], columns=["timestamp", "b"], dtype=np.float64
             ),
-            same_sampling_as=sampling,
         )
 
         op = SimpleMovingAverageOperator(
             input=evset.node(),
             window_length=window_length.node(),
-            sampling=sampling.node(),
         )
         instance = SimpleMovingAverageNumpyImplementation(op)
 
-        instance.call(
-            input=evset, sampling=sampling, window_length=window_length
-        )
+        instance.call(input=evset, window_length=window_length)
         logging_mock.warning.assert_called_with(
             "`window_length`'s values should be strictly positive. 0, NaN and"
             " negative window lengths will output missing values."
@@ -429,11 +424,9 @@ class SimpleMovingAverageOperatorTest(absltest.TestCase):
     # TODO: move to a separate file that tests the base class
     def test_variable_window_length_invalid(self):
         evset = from_pandas(pd.DataFrame([[0, 1]], columns=["a", "timestamp"]))
-        sampling = from_pandas(pd.DataFrame([[1], [2]], columns=["timestamp"]))
 
         window_length = from_pandas(
-            pd.DataFrame([[1], [2]], columns=["timestamp"]),
-            same_sampling_as=sampling,
+            pd.DataFrame([[1], [2]], columns=["timestamp"])
         )
         with self.assertRaisesRegex(
             ValueError, "`window_length` must have exactly one float64 feature"
@@ -441,14 +434,12 @@ class SimpleMovingAverageOperatorTest(absltest.TestCase):
             SimpleMovingAverageOperator(
                 input=evset.node(),
                 window_length=window_length.node(),
-                sampling=sampling.node(),
             )
 
         window_length = from_pandas(
             pd.DataFrame(
                 [[1, 1, 1], [2, 2, 2]], columns=["timestamp", "b", "c"]
             ),
-            same_sampling_as=sampling,
         )
         with self.assertRaisesRegex(
             ValueError, "`window_length` must have exactly one float64 feature"
@@ -456,7 +447,6 @@ class SimpleMovingAverageOperatorTest(absltest.TestCase):
             SimpleMovingAverageOperator(
                 input=evset.node(),
                 window_length=window_length.node(),
-                sampling=sampling.node(),
             )
 
         window_length = from_pandas(
@@ -465,7 +455,6 @@ class SimpleMovingAverageOperatorTest(absltest.TestCase):
                 columns=["timestamp", "b", "c"],
                 dtype=np.float32,
             ),
-            same_sampling_as=sampling,
         )
         with self.assertRaisesRegex(
             ValueError, "`window_length` must have exactly one float64 feature"
@@ -473,7 +462,6 @@ class SimpleMovingAverageOperatorTest(absltest.TestCase):
             SimpleMovingAverageOperator(
                 input=evset.node(),
                 window_length=window_length.node(),
-                sampling=sampling.node(),
             )
 
 

--- a/temporian/implementation/numpy/operators/test/simple_moving_average_test.py
+++ b/temporian/implementation/numpy/operators/test/simple_moving_average_test.py
@@ -355,32 +355,6 @@ class SimpleMovingAverageOperatorTest(absltest.TestCase):
         self.assertEqual(output["output"], expected_output)
 
     # TODO: move to a separate file that tests the base class
-    def test_negative_window_length(self):
-        evset = from_pandas(pd.DataFrame([[0, 1]], columns=["a", "timestamp"]))
-        sampling = from_pandas(pd.DataFrame([[1], [2]], columns=["timestamp"]))
-        window_length = from_pandas(
-            pd.DataFrame(
-                [[1, 1], [2, -1]], columns=["timestamp", "b"], dtype=np.float64
-            ),
-            same_sampling_as=sampling,
-        )
-
-        op = SimpleMovingAverageOperator(
-            input=evset.node(),
-            window_length=window_length.node(),
-            sampling=sampling.node(),
-        )
-        instance = SimpleMovingAverageNumpyImplementation(op)
-
-        with self.assertRaisesRegex(
-            ValueError,
-            "All values in `window_length` must be strictly positive",
-        ):
-            instance.call(
-                input=evset, sampling=sampling, window_length=window_length
-            )
-
-    # TODO: move to a separate file that tests the base class
     def test_variable_window_length_invalid(self):
         evset = from_pandas(pd.DataFrame([[0, 1]], columns=["a", "timestamp"]))
         sampling = from_pandas(pd.DataFrame([[1], [2]], columns=["timestamp"]))

--- a/temporian/implementation/numpy/operators/test/simple_moving_average_test.py
+++ b/temporian/implementation/numpy/operators/test/simple_moving_average_test.py
@@ -143,6 +143,16 @@ class SimpleMovingAverageOperatorTest(absltest.TestCase):
             _f64([10.5, 10.5, 11, nan]),
         )
 
+    def test_cc_variable_winlength_0_or_negative(self):
+        assert_array_equal(
+            cc_sma(
+                evset_timestamps=_f64([0, 1, 2, 3, 5, 20]),
+                evset_values=_f64([nan, 10, 11, 12, 13, 14]),
+                window_length=_f64([1, 2, 0, -3, 6, -10]),
+            ),
+            _f64([nan, 10, nan, nan, 12, nan]),
+        )
+
     def test_flat(self):
         """A simple event set."""
 

--- a/temporian/implementation/numpy/operators/test/simple_moving_average_test.py
+++ b/temporian/implementation/numpy/operators/test/simple_moving_average_test.py
@@ -143,23 +143,23 @@ class SimpleMovingAverageOperatorTest(absltest.TestCase):
             _f64([10.5, 10.5, 11, nan]),
         )
 
-    def test_cc_wo_sampling_w_variable_winlength_0_or_negative(self):
+    def test_cc_wo_sampling_w_variable_winlength_invalid_values(self):
         assert_array_equal(
             cc_sma(
-                evset_timestamps=_f64([0, 1, 2, 3, 5, 20]),
-                evset_values=_f64([nan, 10, 11, 12, 13, 14]),
-                window_length=_f64([1, 2, -20, 0, 5, -10]),
+                evset_timestamps=_f64([0, 1, 2, 3, 5, 6, 20]),
+                evset_values=_f64([nan, 10, 11, 12, 13, 14, 15]),
+                window_length=_f64([1, -20, 3, 0, 10, nan, 19]),
             ),
-            _f64([nan, 10, nan, nan, 11.5, nan]),
+            _f64([nan, nan, 10.5, nan, 11.5, nan, 13]),
         )
 
-    def test_cc_w_sampling_w_variable_winlength_0_or_negative(self):
+    def test_cc_w_sampling_variable_winlength_invalid_values(self):
         assert_array_equal(
             cc_sma(
                 evset_timestamps=_f64([0, 1, 2, 3, 5, 20]),
                 evset_values=_f64([nan, 10, 11, 12, 13, 14]),
                 sampling_timestamps=_f64([2, 2, 5, 5, 20, 20]),
-                window_length=_f64([1, -10, 3, 0, -1000, 19]),
+                window_length=_f64([1, -10, 3, 0, nan, 19]),
             ),
             _f64([11, nan, 12.5, nan, nan, 12.5]),
         )
@@ -309,13 +309,7 @@ class SimpleMovingAverageOperatorTest(absltest.TestCase):
 
         evset = from_pandas(
             pd.DataFrame(
-                [
-                    [10.0, 1],
-                    [11.0, 2],
-                    [12.0, 3],
-                    [13.0, 5],
-                    [14.0, 6],
-                ],
+                [[10.0, 1], [11.0, 2], [12.0, 3], [13.0, 5], [14.0, 6]],
                 columns=["a", "timestamp"],
             )
         )
@@ -335,15 +329,7 @@ class SimpleMovingAverageOperatorTest(absltest.TestCase):
 
         sampling_data = from_pandas(
             pd.DataFrame(
-                [
-                    [-1.0],
-                    [1.0],
-                    [1.1],
-                    [3.0],
-                    [3.5],
-                    [6.0],
-                    [10.0],
-                ],
+                [[-1.0], [1.0], [1.1], [3.0], [3.5], [6.0], [10.0]],
                 columns=["timestamp"],
             )
         )
@@ -371,13 +357,7 @@ class SimpleMovingAverageOperatorTest(absltest.TestCase):
 
         evset = from_pandas(
             pd.DataFrame(
-                [
-                    [nan, 1],
-                    [11.0, 2],
-                    [nan, 3],
-                    [13.0, 5],
-                    [14.0, 6],
-                ],
+                [[nan, 1], [11.0, 2], [nan, 3], [13.0, 5], [14.0, 6]],
                 columns=["a", "timestamp"],
             )
         )
@@ -391,16 +371,7 @@ class SimpleMovingAverageOperatorTest(absltest.TestCase):
 
         sampling_data = from_pandas(
             pd.DataFrame(
-                [
-                    [1],
-                    [2],
-                    [2.5],
-                    [3],
-                    [3.5],
-                    [4],
-                    [5],
-                    [6],
-                ],
+                [[1], [2], [2.5], [3], [3.5], [4], [5], [6]],
                 columns=["timestamp"],
             )
         )
@@ -451,7 +422,7 @@ class SimpleMovingAverageOperatorTest(absltest.TestCase):
             input=evset, sampling=sampling, window_length=window_length
         )
         logging_mock.warning.assert_called_with(
-            "`window_length`'s values should be strictly positive. 0 and"
+            "`window_length`'s values should be strictly positive. 0, NaN and"
             " negative window lengths will output missing values."
         )
 

--- a/temporian/implementation/numpy/operators/test/simple_moving_average_test.py
+++ b/temporian/implementation/numpy/operators/test/simple_moving_average_test.py
@@ -351,7 +351,8 @@ class SimpleMovingAverageOperatorTest(absltest.TestCase):
         instance = SimpleMovingAverageNumpyImplementation(op)
 
         with self.assertRaisesRegex(
-            ValueError, "All values in `window_length` must be positive"
+            ValueError,
+            "All values in `window_length` must be strictly positive",
         ):
             instance.call(
                 input=evset, sampling=sampling, window_length=window_length

--- a/temporian/implementation/numpy/operators/test/simple_moving_average_test.py
+++ b/temporian/implementation/numpy/operators/test/simple_moving_average_test.py
@@ -100,7 +100,7 @@ class SimpleMovingAverageOperatorTest(absltest.TestCase):
             _f32([nan, 11.0, 11.0, nan, nan, nan, 13.0, 14]),
         )
 
-    def test_cc_wo_sampling_w_variable_winlength(self):
+    def test_cc_wo_sampling_w_variable_winlen(self):
         assert_array_equal(
             cc_sma(
                 evset_timestamps=_f64([0, 1, 2, 3, 5, 20]),
@@ -110,7 +110,7 @@ class SimpleMovingAverageOperatorTest(absltest.TestCase):
             _f32([nan, 10, 10.5, 12, 12, 12]),
         )
 
-    def test_cc_w_sampling_w_variable_winlength(self):
+    def test_cc_w_sampling_w_variable_winlen(self):
         assert_array_equal(
             cc_sma(
                 evset_timestamps=_f64([0, 1, 2, 3, 5, 20]),
@@ -121,7 +121,7 @@ class SimpleMovingAverageOperatorTest(absltest.TestCase):
             _f64([nan, 10, 11.5, 11.5, 13.5, 12]),
         )
 
-    def test_cc_variable_winlength_repeated_ts(self):
+    def test_cc_variable_winlen_repeated_ts(self):
         assert_array_equal(
             cc_sma(
                 evset_timestamps=_f64([0, 1, 2, 3, 5, 20]),
@@ -132,7 +132,7 @@ class SimpleMovingAverageOperatorTest(absltest.TestCase):
             _f64([13.5, 14, 12, nan, 14, 12.5]),
         )
 
-    def test_cc_variable_winlength_shortest_duration(self):
+    def test_cc_variable_winlen_shortest_duration(self):
         assert_array_equal(
             cc_sma(
                 evset_timestamps=_f64([1.999999, 2]),
@@ -143,7 +143,7 @@ class SimpleMovingAverageOperatorTest(absltest.TestCase):
             _f64([10.5, 10.5, 11, nan]),
         )
 
-    def test_cc_wo_sampling_w_variable_winlength_invalid_values(self):
+    def test_cc_wo_sampling_w_variable_winlen_invalid_values(self):
         assert_array_equal(
             cc_sma(
                 evset_timestamps=_f64([0, 1, 2, 3, 5, 6, 20]),
@@ -153,7 +153,7 @@ class SimpleMovingAverageOperatorTest(absltest.TestCase):
             _f64([nan, nan, 10.5, nan, 11.5, nan, 13]),
         )
 
-    def test_cc_w_sampling_variable_winlength_invalid_values(self):
+    def test_cc_w_sampling_variable_winlen_invalid_values(self):
         assert_array_equal(
             cc_sma(
                 evset_timestamps=_f64([0, 1, 2, 3, 5, 20]),
@@ -174,7 +174,7 @@ class SimpleMovingAverageOperatorTest(absltest.TestCase):
             _f64([10, 12, 12.5, 12, nan, 13]),
         )
 
-    def test_variable_winlength_duped_ts_same_winlength(self):
+    def test_variable_winlen_duped_ts_same_winlength(self):
         assert_array_equal(
             cc_sma(
                 evset_timestamps=_f64([2, 2, 2, 2]),
@@ -193,7 +193,7 @@ class SimpleMovingAverageOperatorTest(absltest.TestCase):
             _f64([nan, 12, 12, 11.5]),
         )
 
-    def test_variable_winlength_empty_arrays(self):
+    def test_variable_winlen_empty_arrays(self):
         assert_array_equal(
             cc_sma(
                 evset_timestamps=_f64([1]),
@@ -397,7 +397,7 @@ class SimpleMovingAverageOperatorTest(absltest.TestCase):
 
     # TODO: move to a separate file that tests the base class
     @patch("temporian.implementation.numpy.operators.window.base.logging")
-    def test_negative_window_length(self, logging_mock):
+    def test_invalid_window_length_warning(self, logging_mock):
         """Tests that warning is shown when receiving non strictly positive
         values in window_length."""
         evset = from_pandas(

--- a/temporian/implementation/numpy/operators/test/simple_moving_average_test.py
+++ b/temporian/implementation/numpy/operators/test/simple_moving_average_test.py
@@ -193,6 +193,25 @@ class SimpleMovingAverageOperatorTest(absltest.TestCase):
             _f64([nan, 12, 12, 11.5]),
         )
 
+    def test_variable_winlength_empty_arrays(self):
+        assert_array_equal(
+            cc_sma(
+                evset_timestamps=_f64([1]),
+                evset_values=_f64([10]),
+                sampling_timestamps=_f64([]),
+                window_length=_f64([]),
+            ),
+            _f64([]),
+        )
+        assert_array_equal(
+            cc_sma(
+                evset_timestamps=_f64([]),
+                evset_values=_f64([]),
+                window_length=_f64([]),
+            ),
+            _f64([]),
+        )
+
     def test_flat(self):
         """A simple event set."""
 

--- a/temporian/implementation/numpy/operators/test/simple_moving_average_test.py
+++ b/temporian/implementation/numpy/operators/test/simple_moving_average_test.py
@@ -332,11 +332,14 @@ class SimpleMovingAverageOperatorTest(absltest.TestCase):
 
         self.assertEqual(output["output"], expected_output)
 
+    # TODO: move to a separate file that tests the base class
     def test_negative_window_length(self):
         evset = from_pandas(pd.DataFrame([[0, 1]], columns=["a", "timestamp"]))
         sampling = from_pandas(pd.DataFrame([[1], [2]], columns=["timestamp"]))
         window_length = from_pandas(
-            pd.DataFrame([[1, 1], [2, -1]], columns=["timestamp", "b"]),
+            pd.DataFrame(
+                [[1, 1], [2, -1]], columns=["timestamp", "b"], dtype=np.float64
+            ),
             same_sampling_as=sampling,
         )
 
@@ -354,7 +357,8 @@ class SimpleMovingAverageOperatorTest(absltest.TestCase):
                 input=evset, sampling=sampling, window_length=window_length
             )
 
-    def test_window_length_not_1_feature(self):
+    # TODO: move to a separate file that tests the base class
+    def test_variable_window_length_invalid(self):
         evset = from_pandas(pd.DataFrame([[0, 1]], columns=["a", "timestamp"]))
         sampling = from_pandas(pd.DataFrame([[1], [2]], columns=["timestamp"]))
 
@@ -363,7 +367,7 @@ class SimpleMovingAverageOperatorTest(absltest.TestCase):
             same_sampling_as=sampling,
         )
         with self.assertRaisesRegex(
-            ValueError, "`window_length` must have exactly one feature"
+            ValueError, "`window_length` must have exactly one float64 feature"
         ):
             SimpleMovingAverageOperator(
                 input=evset.node(),
@@ -378,7 +382,24 @@ class SimpleMovingAverageOperatorTest(absltest.TestCase):
             same_sampling_as=sampling,
         )
         with self.assertRaisesRegex(
-            ValueError, "`window_length` must have exactly one feature"
+            ValueError, "`window_length` must have exactly one float64 feature"
+        ):
+            SimpleMovingAverageOperator(
+                input=evset.node(),
+                window_length=window_length.node(),
+                sampling=sampling.node(),
+            )
+
+        window_length = from_pandas(
+            pd.DataFrame(
+                [[1, 1, 1], [2, 2, 2]],
+                columns=["timestamp", "b", "c"],
+                dtype=np.float32,
+            ),
+            same_sampling_as=sampling,
+        )
+        with self.assertRaisesRegex(
+            ValueError, "`window_length` must have exactly one float64 feature"
         ):
             SimpleMovingAverageOperator(
                 input=evset.node(),

--- a/temporian/implementation/numpy/operators/test/simple_moving_average_test.py
+++ b/temporian/implementation/numpy/operators/test/simple_moving_average_test.py
@@ -143,14 +143,25 @@ class SimpleMovingAverageOperatorTest(absltest.TestCase):
             _f64([10.5, 10.5, 11, nan]),
         )
 
-    def test_cc_variable_winlength_0_or_negative(self):
+    def test_cc_wo_sampling_w_variable_winlength_0_or_negative(self):
         assert_array_equal(
             cc_sma(
                 evset_timestamps=_f64([0, 1, 2, 3, 5, 20]),
                 evset_values=_f64([nan, 10, 11, 12, 13, 14]),
-                window_length=_f64([1, 2, 0, -3, 6, -10]),
+                window_length=_f64([1, 2, -20, 0, 5, -10]),
             ),
-            _f64([nan, 10, nan, nan, 12, nan]),
+            _f64([nan, 10, nan, nan, 11.5, nan]),
+        )
+
+    def test_cc_w_sampling_w_variable_winlength_0_or_negative(self):
+        assert_array_equal(
+            cc_sma(
+                evset_timestamps=_f64([0, 1, 2, 3, 5, 20]),
+                evset_values=_f64([nan, 10, 11, 12, 13, 14]),
+                sampling_timestamps=_f64([2, 2, 5, 5, 20, 20]),
+                window_length=_f64([1, -10, 3, 0, -1000, 19]),
+            ),
+            _f64([11, nan, 12.5, nan, nan, 12.5]),
         )
 
     def test_flat(self):

--- a/temporian/implementation/numpy/operators/test/simple_moving_average_test.py
+++ b/temporian/implementation/numpy/operators/test/simple_moving_average_test.py
@@ -164,7 +164,7 @@ class SimpleMovingAverageOperatorTest(absltest.TestCase):
             _f64([11, nan, 12.5, nan, nan, 12.5]),
         )
 
-    def test_cc_w0_sampling_repeated_ts(self):
+    def test_cc_wo_sampling_repeated_ts(self):
         assert_array_equal(
             cc_sma(
                 evset_timestamps=_f64([0, 2, 2, 2, 2, 5]),
@@ -172,6 +172,25 @@ class SimpleMovingAverageOperatorTest(absltest.TestCase):
                 window_length=_f64([1, 3, 0.5, np.inf, -1, 5]),
             ),
             _f64([10, 12, 12.5, 12, nan, 13]),
+        )
+
+    def test_variable_winlength_duped_ts_same_winlength(self):
+        assert_array_equal(
+            cc_sma(
+                evset_timestamps=_f64([2, 2, 2, 2]),
+                evset_values=_f64([10, 11, 12, 13]),
+                window_length=_f64([0, 1, 1, 2]),
+            ),
+            _f64([nan, 11.5, 11.5, 11.5]),
+        )
+        assert_array_equal(
+            cc_sma(
+                evset_timestamps=_f64([0, 1, 2, 3]),
+                evset_values=_f64([10, 11, 12, 13]),
+                sampling_timestamps=_f64([2, 2, 2, 2]),
+                window_length=_f64([0, 1, 1, 2]),
+            ),
+            _f64([nan, 12, 12, 11.5]),
         )
 
     def test_flat(self):

--- a/temporian/implementation/numpy/operators/window/base.py
+++ b/temporian/implementation/numpy/operators/window/base.py
@@ -68,12 +68,6 @@ class BaseWindowNumpyImplementation(OperatorImplementation):
                     window_length_data = window_length.data[index_key].features[
                         0
                     ]
-                    # Check all window length values are positive
-                    if not np.all(window_length_data > 0):
-                        raise ValueError(
-                            "All values in `window_length` must be strictly"
-                            " positive."
-                        )
 
                 self._compute(
                     src_timestamps=input_data.timestamps,

--- a/temporian/implementation/numpy/operators/window/base.py
+++ b/temporian/implementation/numpy/operators/window/base.py
@@ -69,11 +69,11 @@ class BaseWindowNumpyImplementation(OperatorImplementation):
                     window_length_data = window_length.data[index_key].features[
                         0
                     ]
-                    # Check all window length values are positive, else warn
+                    # Warn if not all window length values are positive
                     if not np.all(window_length_data > 0):
                         logging.warning(
                             "`window_length`'s values should be strictly"
-                            " positive. 0 and negative window lengths will"
+                            " positive. 0, NaN and negative window lengths will"
                             " output missing values."
                         )
 

--- a/temporian/implementation/numpy/operators/window/base.py
+++ b/temporian/implementation/numpy/operators/window/base.py
@@ -63,14 +63,12 @@ class BaseWindowNumpyImplementation(OperatorImplementation):
             if index_key in input.data:
                 input_data = input.data[index_key]
 
-                window_length_data = (
-                    window_length.data[index_key].features[0]
-                    if window_length is not None
-                    else None
-                )
-
-                # Check all window length values are positive
-                if window_length_data is not None:
+                window_length_data = None
+                if window_length is not None:
+                    window_length_data = window_length.data[index_key].features[
+                        0
+                    ]
+                    # Check all window length values are positive
                     if not np.all(window_length_data >= 0):
                         raise ValueError(
                             "All values in `window_length` must be positive."

--- a/temporian/implementation/numpy/operators/window/base.py
+++ b/temporian/implementation/numpy/operators/window/base.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 from abc import abstractmethod
+import logging
 from typing import Dict, Optional, List, Any
 
 import numpy as np
@@ -68,6 +69,13 @@ class BaseWindowNumpyImplementation(OperatorImplementation):
                     window_length_data = window_length.data[index_key].features[
                         0
                     ]
+                    # Check all window length values are positive, else warn
+                    if not np.all(window_length_data > 0):
+                        logging.warning(
+                            "`window_length`'s values should be strictly"
+                            " positive. 0 and negative window lengths will"
+                            " output missing values."
+                        )
 
                 self._compute(
                     src_timestamps=input_data.timestamps,

--- a/temporian/implementation/numpy/operators/window/base.py
+++ b/temporian/implementation/numpy/operators/window/base.py
@@ -40,6 +40,7 @@ class BaseWindowNumpyImplementation(OperatorImplementation):
         self,
         input: EventSet,
         sampling: Optional[EventSet] = None,
+        window_length: Optional[EventSet] = None,
     ) -> Dict[str, EventSet]:
         assert isinstance(self.operator, BaseWindowOperator)
 
@@ -62,11 +63,18 @@ class BaseWindowNumpyImplementation(OperatorImplementation):
             if index_key in input.data:
                 input_data = input.data[index_key]
 
+                window_length_data = None
+                if window_length is not None:
+                    window_length_data = window_length.data[index_key].features[
+                        0
+                    ]
+
                 self._compute(
                     src_timestamps=input_data.timestamps,
                     src_features=input_data.features,
                     sampling_timestamps=sampling_data.timestamps,
                     dst_features=output_data.features,
+                    window_length=window_length_data,
                 )
             else:
                 # Sets the feature data as missing.
@@ -99,6 +107,7 @@ class BaseWindowNumpyImplementation(OperatorImplementation):
         src_features: List[np.ndarray],
         sampling_timestamps: np.ndarray,
         dst_features: List[np.ndarray],
+        window_length: Optional[np.ndarray] = None,
     ) -> None:
         assert isinstance(self.operator, BaseWindowOperator)
 
@@ -107,7 +116,7 @@ class BaseWindowNumpyImplementation(OperatorImplementation):
             kwargs = {
                 "evset_timestamps": src_timestamps,
                 "evset_values": src_ts,
-                "window_length": self.operator.window_length,
+                "window_length": window_length or self.operator.window_length,
             }
             if self.operator.has_sampling:
                 kwargs["sampling_timestamps"] = sampling_timestamps

--- a/temporian/implementation/numpy/operators/window/base.py
+++ b/temporian/implementation/numpy/operators/window/base.py
@@ -69,9 +69,10 @@ class BaseWindowNumpyImplementation(OperatorImplementation):
                         0
                     ]
                     # Check all window length values are positive
-                    if not np.all(window_length_data >= 0):
+                    if not np.all(window_length_data > 0):
                         raise ValueError(
-                            "All values in `window_length` must be positive."
+                            "All values in `window_length` must be strictly"
+                            " positive."
                         )
 
                 self._compute(

--- a/temporian/implementation/numpy/operators/window/base.py
+++ b/temporian/implementation/numpy/operators/window/base.py
@@ -69,6 +69,13 @@ class BaseWindowNumpyImplementation(OperatorImplementation):
                     else None
                 )
 
+                # Check all window length values are positive
+                if window_length_data is not None:
+                    if not np.all(window_length_data >= 0):
+                        raise ValueError(
+                            "All values in `window_length` must be positive."
+                        )
+
                 self._compute(
                     src_timestamps=input_data.timestamps,
                     src_features=input_data.features,

--- a/temporian/implementation/numpy/operators/window/base.py
+++ b/temporian/implementation/numpy/operators/window/base.py
@@ -126,7 +126,6 @@ class BaseWindowNumpyImplementation(OperatorImplementation):
             }
             if self.operator.has_sampling:
                 kwargs["sampling_timestamps"] = sampling_timestamps
-            print(kwargs)
             dst_feature = implementation(**kwargs)
             dst_features.append(dst_feature)
 

--- a/temporian/implementation/numpy/operators/window/base.py
+++ b/temporian/implementation/numpy/operators/window/base.py
@@ -63,11 +63,11 @@ class BaseWindowNumpyImplementation(OperatorImplementation):
             if index_key in input.data:
                 input_data = input.data[index_key]
 
-                window_length_data = None
-                if window_length is not None:
-                    window_length_data = window_length.data[index_key].features[
-                        0
-                    ]
+                window_length_data = (
+                    window_length.data[index_key].features[0]
+                    if window_length is not None
+                    else None
+                )
 
                 self._compute(
                     src_timestamps=input_data.timestamps,
@@ -111,15 +111,22 @@ class BaseWindowNumpyImplementation(OperatorImplementation):
     ) -> None:
         assert isinstance(self.operator, BaseWindowOperator)
 
+        effective_window_length = (
+            window_length
+            if window_length is not None
+            else self.operator.window_length
+        )
+
         implementation = self._implementation()
         for src_ts in src_features:
             kwargs = {
                 "evset_timestamps": src_timestamps,
                 "evset_values": src_ts,
-                "window_length": window_length or self.operator.window_length,
+                "window_length": effective_window_length,
             }
             if self.operator.has_sampling:
                 kwargs["sampling_timestamps"] = sampling_timestamps
+            print(kwargs)
             dst_feature = implementation(**kwargs)
             dst_features.append(dst_feature)
 

--- a/temporian/implementation/numpy/operators/window/moving_count.py
+++ b/temporian/implementation/numpy/operators/window/moving_count.py
@@ -12,8 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import List, Optional
+from typing import List, Optional, Union
 import numpy as np
+from temporian.core.data.duration_utils import NormalizedDuration
 
 from temporian.core.operators.window.moving_count import (
     MovingCountOperator,
@@ -35,26 +36,19 @@ class MovingCountNumpyImplementation(BaseWindowNumpyImplementation):
         self,
         src_timestamps: np.ndarray,
         src_features: List[np.ndarray],
-        sampling_timestamps: np.ndarray,
+        sampling_timestamps: Optional[np.ndarray],
         dst_features: List[np.ndarray],
-        window_length: Optional[np.ndarray] = None,
+        window_length: Union[NormalizedDuration, np.ndarray],
     ) -> None:
         assert isinstance(self.operator, MovingCountOperator)
-
-        # TODO (ian): unify this with the logic in base class
-        effective_window_length = (
-            window_length
-            if self.operator.has_variable_winlen
-            else self.operator.window_length
-        )
 
         del src_features  # Features are ignored
 
         kwargs = {
             "evset_timestamps": src_timestamps,
-            "window_length": effective_window_length,
+            "window_length": window_length,
         }
-        if self.operator.has_sampling or self.operator.has_variable_winlen:
+        if sampling_timestamps is not None:
             kwargs["sampling_timestamps"] = sampling_timestamps
         dst_feature = operators_cc.moving_count(**kwargs)
         dst_features.append(dst_feature)

--- a/temporian/implementation/numpy/operators/window/moving_count.py
+++ b/temporian/implementation/numpy/operators/window/moving_count.py
@@ -41,9 +41,10 @@ class MovingCountNumpyImplementation(BaseWindowNumpyImplementation):
     ) -> None:
         assert isinstance(self.operator, MovingCountOperator)
 
+        # TODO (ian): unify this with the logic in base class
         effective_window_length = (
             window_length
-            if window_length is not None
+            if self.operator.has_variable_winlen
             else self.operator.window_length
         )
 
@@ -53,7 +54,7 @@ class MovingCountNumpyImplementation(BaseWindowNumpyImplementation):
             "evset_timestamps": src_timestamps,
             "window_length": effective_window_length,
         }
-        if self.operator.has_sampling:
+        if self.operator.has_sampling or self.operator.has_variable_winlen:
             kwargs["sampling_timestamps"] = sampling_timestamps
         dst_feature = operators_cc.moving_count(**kwargs)
         dst_features.append(dst_feature)

--- a/temporian/implementation/numpy/operators/window/moving_count.py
+++ b/temporian/implementation/numpy/operators/window/moving_count.py
@@ -41,11 +41,17 @@ class MovingCountNumpyImplementation(BaseWindowNumpyImplementation):
     ) -> None:
         assert isinstance(self.operator, MovingCountOperator)
 
+        effective_window_length = (
+            window_length
+            if window_length is not None
+            else self.operator.window_length
+        )
+
         del src_features  # Features are ignored
 
         kwargs = {
             "evset_timestamps": src_timestamps,
-            "window_length": window_length or self.operator.window_length,
+            "window_length": effective_window_length,
         }
         if self.operator.has_sampling:
             kwargs["sampling_timestamps"] = sampling_timestamps

--- a/temporian/implementation/numpy/operators/window/moving_count.py
+++ b/temporian/implementation/numpy/operators/window/moving_count.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import List
+from typing import List, Optional
 import numpy as np
 
 from temporian.core.operators.window.moving_count import (
@@ -37,6 +37,7 @@ class MovingCountNumpyImplementation(BaseWindowNumpyImplementation):
         src_features: List[np.ndarray],
         sampling_timestamps: np.ndarray,
         dst_features: List[np.ndarray],
+        window_length: Optional[np.ndarray] = None,
     ) -> None:
         assert isinstance(self.operator, MovingCountOperator)
 
@@ -44,7 +45,7 @@ class MovingCountNumpyImplementation(BaseWindowNumpyImplementation):
 
         kwargs = {
             "evset_timestamps": src_timestamps,
-            "window_length": self.operator.window_length,
+            "window_length": window_length or self.operator.window_length,
         }
         if self.operator.has_sampling:
             kwargs["sampling_timestamps"] = sampling_timestamps

--- a/temporian/implementation/numpy_cc/operators/since_last.cc
+++ b/temporian/implementation/numpy_cc/operators/since_last.cc
@@ -46,7 +46,7 @@ py::array_t<double> since_last(const py::array_t<double> &event_timestamps,
   return since_last;
 }
 
-}  // namespace
+} // namespace
 
 void init_since_last(py::module &m) {
   m.def("since_last", &since_last, "", py::arg("event_timestamps").noconvert(),

--- a/temporian/implementation/numpy_cc/operators/window.cc
+++ b/temporian/implementation/numpy_cc/operators/window.cc
@@ -158,6 +158,7 @@ py::array_t<OUTPUT> accumulate(const ArrayD &evset_timestamps,
     // values in v_timestamps.
 
     curr_ts = v_timestamps[end_idx];
+    // TODO: raise if negative
     curr_window_length = v_window_length[end_idx];
 
     // Add all values with same timestamp as the current one.
@@ -232,6 +233,7 @@ py::array_t<OUTPUT> accumulate(const ArrayD &evset_timestamps,
 
   for (size_t sampling_idx = 0; sampling_idx < n_sampling; sampling_idx++) {
     const auto right_limit = v_sampling[sampling_idx];
+    // TODO: raise if negative
     const auto curr_window_length = v_window_length[sampling_idx];
 
     while (end_idx < n_event && v_timestamps[end_idx] <= right_limit) {

--- a/temporian/implementation/numpy_cc/operators/window.cc
+++ b/temporian/implementation/numpy_cc/operators/window.cc
@@ -158,7 +158,6 @@ py::array_t<OUTPUT> accumulate(const ArrayD &evset_timestamps,
     // values in v_timestamps.
 
     curr_ts = v_timestamps[end_idx];
-    // TODO: raise if negative
     curr_window_length = v_window_length[end_idx];
 
     // Add all values with same timestamp as the current one.

--- a/temporian/implementation/numpy_cc/operators/window.cc
+++ b/temporian/implementation/numpy_cc/operators/window.cc
@@ -232,7 +232,6 @@ py::array_t<OUTPUT> accumulate(const ArrayD &evset_timestamps,
 
   for (size_t sampling_idx = 0; sampling_idx < n_sampling; sampling_idx++) {
     const auto right_limit = v_sampling[sampling_idx];
-    // TODO: raise if negative
     const auto curr_window_length = v_window_length[sampling_idx];
 
     while (end_idx < n_event && v_timestamps[end_idx] <= right_limit) {

--- a/temporian/implementation/numpy_cc/operators/window.cc
+++ b/temporian/implementation/numpy_cc/operators/window.cc
@@ -13,6 +13,8 @@
 namespace {
 namespace py = pybind11;
 
+using namespace std; // REMOVE
+
 typedef py::array_t<double> ArrayD;
 typedef py::array_t<float> ArrayF;
 
@@ -27,6 +29,7 @@ template <typename INPUT, typename OUTPUT, typename TAccumulator>
 py::array_t<OUTPUT> accumulate(const ArrayD &evset_timestamps,
                                const py::array_t<INPUT> &evset_values,
                                const double window_length) {
+  cout << "No external sampling, constant window length\n";
   // Input size
   const size_t n_event = evset_timestamps.shape(0);
 
@@ -86,6 +89,7 @@ py::array_t<OUTPUT> accumulate(const ArrayD &evset_timestamps,
                                const py::array_t<INPUT> &evset_values,
                                const ArrayD &sampling_timestamps,
                                const double window_length) {
+  cout << "External sampling, constant window length\n";
   // Input size
   const size_t n_event = evset_timestamps.shape(0);
   const size_t n_sampling = sampling_timestamps.shape(0);
@@ -130,6 +134,7 @@ template <typename INPUT, typename OUTPUT, typename TAccumulator>
 py::array_t<OUTPUT> accumulate(const ArrayD &evset_timestamps,
                                const py::array_t<INPUT> &evset_values,
                                const ArrayD &window_length) {
+  cout << "No external sampling, variable window length\n";
   // Input size
   const size_t n_event = evset_timestamps.shape(0);
 
@@ -212,12 +217,13 @@ py::array_t<OUTPUT> accumulate(const ArrayD &evset_timestamps,
                                const py::array_t<INPUT> &evset_values,
                                const ArrayD &sampling_timestamps,
                                const ArrayD &window_length) {
+  cout << "External sampling, variable window length\n";
   // Input size
   const size_t n_event = evset_timestamps.shape(0);
   const size_t n_sampling = sampling_timestamps.shape(0);
 
   // Allocate output array
-  auto output = py::array_t<OUTPUT>(n_event);
+  auto output = py::array_t<OUTPUT>(n_sampling);
 
   auto v_output = output.template mutable_unchecked<1>();
   auto v_timestamps = evset_timestamps.unchecked<1>();

--- a/temporian/implementation/numpy_cc/operators/window.cc
+++ b/temporian/implementation/numpy_cc/operators/window.cc
@@ -173,28 +173,25 @@ py::array_t<OUTPUT> accumulate(const ArrayD &evset_timestamps,
       first_diff_ts_idx++;
     }
 
-    if (end_idx > 0) {
-      const auto prev_end_idx = end_idx - 1;
-      // Move begin_idx forward or backwards depending on begin_diff.
-      if (begin_moved_forward(curr_ts, v_timestamps[prev_end_idx],
-                              curr_window_length,
-                              v_window_length[prev_end_idx])) {
-        // Window's beginning moved forward
-        while (begin_idx < n_event &&
-               v_timestamps[end_idx] - v_timestamps[begin_idx] >=
-                   curr_window_length) {
-          accumulator.Remove(v_values[begin_idx]);
-          begin_idx++;
-        }
-      } else {
-        // Window's beginning moved backwards.
-        // Note < instead of <= to respect (] window boundaries.
-        while (begin_idx > 0 &&
-               v_timestamps[end_idx] - v_timestamps[begin_idx - 1] <
-                   curr_window_length) {
-          begin_idx--;
-          accumulator.AddLeft(v_values[begin_idx]);
-        }
+    // Move window's left limit forwards or backwards.
+    if (end_idx == 0 ||
+        begin_moved_forward(curr_ts, v_timestamps[end_idx - 1],
+                            curr_window_length, v_window_length[end_idx - 1])) {
+      // Window's beginning moved forward
+      while (begin_idx < n_event &&
+             v_timestamps[end_idx] - v_timestamps[begin_idx] >=
+                 curr_window_length) {
+        accumulator.Remove(v_values[begin_idx]);
+        begin_idx++;
+      }
+    } else {
+      // Window's beginning moved backwards.
+      // Note < instead of <= to respect (] window boundaries.
+      while (begin_idx > 0 &&
+             v_timestamps[end_idx] - v_timestamps[begin_idx - 1] <
+                 curr_window_length) {
+        begin_idx--;
+        accumulator.AddLeft(v_values[begin_idx]);
       }
     }
 
@@ -247,25 +244,24 @@ py::array_t<OUTPUT> accumulate(const ArrayD &evset_timestamps,
       end_idx++;
     }
 
-    if (end_idx > 0) {
-      const auto prev_end_idx = sampling_idx - 1;
-      // Move begin_idx forward or backwards depending on begin_diff.
-      if (begin_moved_forward(right_limit, v_sampling[prev_end_idx],
-                              curr_window_length,
-                              v_window_length[prev_end_idx])) {
-        while (begin_idx < n_event &&
-               right_limit - v_timestamps[begin_idx] >= curr_window_length) {
-          accumulator.Remove(v_values[begin_idx]);
-          begin_idx++;
-        }
-      } else {
-        // Window's beginning moved backwards.
-        // Note < instead of <= to respect (] window boundaries.
-        while (begin_idx > 0 &&
-               right_limit - v_timestamps[begin_idx - 1] < curr_window_length) {
-          begin_idx--;
-          accumulator.AddLeft(v_values[begin_idx]);
-        }
+    // Move window's left limit forwards or backwards.
+    if (sampling_idx == 0 ||
+        begin_moved_forward(right_limit, v_sampling[sampling_idx - 1],
+                            curr_window_length,
+                            v_window_length[sampling_idx - 1])) {
+      // Window's beginning moved forward
+      while (begin_idx < n_event &&
+             right_limit - v_timestamps[begin_idx] >= curr_window_length) {
+        accumulator.Remove(v_values[begin_idx]);
+        begin_idx++;
+      }
+    } else {
+      // Window's beginning moved backwards.
+      // Note < instead of <= to respect (] window boundaries.
+      while (begin_idx > 0 &&
+             right_limit - v_timestamps[begin_idx - 1] < curr_window_length) {
+        begin_idx--;
+        accumulator.AddLeft(v_values[begin_idx]);
       }
     }
 

--- a/temporian/implementation/numpy_cc/operators/window.cc
+++ b/temporian/implementation/numpy_cc/operators/window.cc
@@ -13,6 +13,8 @@
 namespace {
 namespace py = pybind11;
 
+using namespace std;
+
 typedef py::array_t<double> ArrayD;
 typedef py::array_t<float> ArrayF;
 
@@ -166,7 +168,11 @@ py::array_t<OUTPUT> accumulate(const ArrayD &evset_timestamps,
     // v_timestamps[end_idx], and there may be several contiguous equal
     // values in v_timestamps.
     const auto curr_ts = v_timestamps[idx];
-    const auto curr_window_length = v_window_length[idx];
+    auto curr_window_length = v_window_length[idx];
+
+    if (std::isnan(curr_window_length)) {
+      curr_window_length = 0;
+    }
 
     while (end_idx < n_event && v_timestamps[end_idx] <= curr_ts) {
       accumulator.Add(v_values[end_idx]);
@@ -177,7 +183,7 @@ py::array_t<OUTPUT> accumulate(const ArrayD &evset_timestamps,
     if (idx == 0 ||
         begin_moved_forward(curr_ts, v_timestamps[idx - 1], curr_window_length,
                             v_window_length[idx - 1])) {
-      // Window's beginning moved forward
+      // Window's beginning moved forwards.
       while (begin_idx < n_event &&
              v_timestamps[idx] - v_timestamps[begin_idx] >=
                  curr_window_length) {
@@ -229,7 +235,11 @@ py::array_t<OUTPUT> accumulate(const ArrayD &evset_timestamps,
 
   for (size_t sampling_idx = 0; sampling_idx < n_sampling; sampling_idx++) {
     const auto right_limit = v_sampling[sampling_idx];
-    const auto curr_window_length = v_window_length[sampling_idx];
+    auto curr_window_length = v_window_length[sampling_idx];
+
+    if (std::isnan(curr_window_length)) {
+      curr_window_length = 0;
+    }
 
     while (end_idx < n_event && v_timestamps[end_idx] <= right_limit) {
       accumulator.Add(v_values[end_idx]);
@@ -241,7 +251,7 @@ py::array_t<OUTPUT> accumulate(const ArrayD &evset_timestamps,
         begin_moved_forward(right_limit, v_sampling[sampling_idx - 1],
                             curr_window_length,
                             v_window_length[sampling_idx - 1])) {
-      // Window's beginning moved forward
+      // Window's beginning moved forwards.
       while (begin_idx < n_event &&
              right_limit - v_timestamps[begin_idx] >= curr_window_length) {
         accumulator.Remove(v_values[begin_idx]);

--- a/temporian/implementation/numpy_cc/operators/window.cc
+++ b/temporian/implementation/numpy_cc/operators/window.cc
@@ -10,358 +10,304 @@
 #include <type_traits>
 #include <vector>
 
-namespace
-{
-  namespace py = pybind11;
+namespace {
+namespace py = pybind11;
 
-  typedef py::array_t<double> ArrayD;
-  typedef py::array_t<float> ArrayF;
+typedef py::array_t<double> ArrayD;
+typedef py::array_t<float> ArrayF;
 
-  // Apply TAccumulator over the data sequentially and get aggregated results
-  // Use evset's timestamps
-  template <typename INPUT, typename OUTPUT, typename TAccumulator>
-  py::array_t<OUTPUT> accumulate(const ArrayD &evset_timestamps,
-                                 const py::array_t<INPUT> &evset_values,
-                                 const double window_length)
-  {
-    // Input size
-    const size_t n_event = evset_timestamps.shape(0);
+// Apply TAccumulator over the data sequentially and get aggregated results
+// Use evset's timestamps
+template <typename INPUT, typename OUTPUT, typename TAccumulator>
+py::array_t<OUTPUT> accumulate(const ArrayD &evset_timestamps,
+                               const py::array_t<INPUT> &evset_values,
+                               const double window_length) {
+  // Input size
+  const size_t n_event = evset_timestamps.shape(0);
 
-    // Allocate output array
-    auto output = py::array_t<OUTPUT>(n_event);
+  // Allocate output array
+  auto output = py::array_t<OUTPUT>(n_event);
 
-    auto v_output = output.template mutable_unchecked<1>();
-    auto v_timestamps = evset_timestamps.unchecked<1>();
-    auto v_values = evset_values.template unchecked<1>();
+  auto v_output = output.template mutable_unchecked<1>();
+  auto v_timestamps = evset_timestamps.unchecked<1>();
+  auto v_values = evset_values.template unchecked<1>();
 
-    TAccumulator accumulator;
+  TAccumulator accumulator;
 
-    // Index of the first value in the window.
-    size_t begin_idx = 0;
-    // Index of the first value outside the window.
-    size_t end_idx = 0;
+  // Index of the first value in the window.
+  size_t begin_idx = 0;
+  // Index of the first value outside the window.
+  size_t end_idx = 0;
 
-    while (end_idx < n_event)
-    {
-      // Note: We accumulate values in (t-window_length, t] with t=
-      // v_timestamps[end_idx], and there may be several contiguous equal
-      // values in v_timestamps.
+  while (end_idx < n_event) {
+    // Note: We accumulate values in (t-window_length, t] with t=
+    // v_timestamps[end_idx], and there may be several contiguous equal
+    // values in v_timestamps.
 
-      // Add all values with same timestamp as the current one.
+    // Add all values with same timestamp as the current one.
+    accumulator.Add(v_values[end_idx]);
+    const auto current_ts = v_timestamps[end_idx];
+    size_t first_diff_ts_idx = end_idx + 1;
+    while (first_diff_ts_idx < n_event &&
+           v_timestamps[first_diff_ts_idx] == current_ts) {
+      accumulator.Add(v_values[first_diff_ts_idx]);
+      first_diff_ts_idx++;
+    }
+
+    // Remove all values that no longer belong to the window.
+    while (begin_idx < n_event &&
+           // Compare both sides around ~0 to get maximum float resolution
+           v_timestamps[end_idx] - v_timestamps[begin_idx] >= window_length) {
+      accumulator.Remove(v_values[begin_idx]);
+      begin_idx++;
+    }
+
+    // Set current value of window to all values with the same timestamp.
+    const auto result = accumulator.Result();
+    for (size_t i = end_idx; i < first_diff_ts_idx; i++) {
+      v_output[i] = result;
+    }
+
+    // Move pointer to the index of the last value with the same timestamp.
+    end_idx = first_diff_ts_idx;
+  }
+
+  return output;
+}
+
+// Apply TAccumulator over the data sequentially and get aggregated results
+// Use external sampling_timestamps
+template <typename INPUT, typename OUTPUT, typename TAccumulator>
+py::array_t<OUTPUT> accumulate(const ArrayD &evset_timestamps,
+                               const py::array_t<INPUT> &evset_values,
+                               const ArrayD &sampling_timestamps,
+                               const double window_length) {
+  // Input size
+  const size_t n_event = evset_timestamps.shape(0);
+  const size_t n_sampling = sampling_timestamps.shape(0);
+
+  // Allocate output array
+  auto output = py::array_t<OUTPUT>(n_sampling);
+
+  auto v_output = output.template mutable_unchecked<1>();
+  auto v_timestamps = evset_timestamps.unchecked<1>();
+  auto v_values = evset_values.template unchecked<1>();
+  auto v_sampling = sampling_timestamps.unchecked<1>();
+
+  TAccumulator accumulator;
+
+  size_t begin_idx = 0;
+  size_t end_idx = 0;
+
+  for (size_t sampling_idx = 0; sampling_idx < n_sampling; sampling_idx++) {
+    const auto right_limit = v_sampling[sampling_idx];
+
+    while (end_idx < n_event && v_timestamps[end_idx] <= right_limit) {
       accumulator.Add(v_values[end_idx]);
-      const auto current_ts = v_timestamps[end_idx];
-      size_t first_diff_ts_idx = end_idx + 1;
-      while (first_diff_ts_idx < n_event &&
-             v_timestamps[first_diff_ts_idx] == current_ts)
-      {
-        accumulator.Add(v_values[first_diff_ts_idx]);
-        first_diff_ts_idx++;
-      }
-
-      // Remove all values that no longer belong to the window.
-      while (begin_idx < n_event &&
-             // Compare both sides around ~0 to get maximum float resolution
-             v_timestamps[end_idx] - v_timestamps[begin_idx] >= window_length)
-      {
-        accumulator.Remove(v_values[begin_idx]);
-        begin_idx++;
-      }
-
-      // Set current value of window to all values with the same timestamp.
-      const auto result = accumulator.Result();
-      for (size_t i = end_idx; i < first_diff_ts_idx; i++)
-      {
-        v_output[i] = result;
-      }
-
-      // Move pointer to the index of the last value with the same timestamp.
-      end_idx = first_diff_ts_idx;
+      end_idx++;
     }
 
-    return output;
+    while (begin_idx < n_event &&
+           // Compare both sides around ~0 to get maximum float resolution
+           v_sampling[sampling_idx] - v_timestamps[begin_idx] >=
+               window_length) {
+      accumulator.Remove(v_values[begin_idx]);
+      begin_idx++;
+    }
+
+    v_output[sampling_idx] = accumulator.Result();
   }
 
-  // Apply TAccumulator over the data sequentially and get aggregated results
-  // Use external sampling_timestamps
-  template <typename INPUT, typename OUTPUT, typename TAccumulator>
-  py::array_t<OUTPUT> accumulate(const ArrayD &evset_timestamps,
-                                 const py::array_t<INPUT> &evset_values,
-                                 const ArrayD &sampling_timestamps,
-                                 const double window_length)
-  {
-    // Input size
-    const size_t n_event = evset_timestamps.shape(0);
-    const size_t n_sampling = sampling_timestamps.shape(0);
+  return output;
+}
 
-    // Allocate output array
-    auto output = py::array_t<OUTPUT>(n_sampling);
+// Note: We only use inheritence to compile check the code.
+template <typename INPUT, typename OUTPUT> struct Accumulator {
+  virtual ~Accumulator() = default;
+  virtual void Add(INPUT value) = 0;
+  virtual void Remove(INPUT value) = 0;
+  virtual OUTPUT Result() = 0;
+};
 
-    auto v_output = output.template mutable_unchecked<1>();
-    auto v_timestamps = evset_timestamps.unchecked<1>();
-    auto v_values = evset_values.template unchecked<1>();
-    auto v_sampling = sampling_timestamps.unchecked<1>();
-
-    TAccumulator accumulator;
-
-    size_t begin_idx = 0;
-    size_t end_idx = 0;
-
-    for (size_t sampling_idx = 0; sampling_idx < n_sampling; sampling_idx++)
-    {
-      const auto right_limit = v_sampling[sampling_idx];
-
-      while (end_idx < n_event && v_timestamps[end_idx] <= right_limit)
-      {
-        accumulator.Add(v_values[end_idx]);
-        end_idx++;
+template <typename INPUT, typename OUTPUT>
+struct SimpleMovingAverageAccumulator : Accumulator<INPUT, OUTPUT> {
+  void Add(INPUT value) override {
+    if constexpr (std::numeric_limits<INPUT>::has_quiet_NaN) {
+      if (std::isnan(value)) {
+        return;
       }
-
-      while (begin_idx < n_event &&
-             // Compare both sides around ~0 to get maximum float resolution
-             v_sampling[sampling_idx] - v_timestamps[begin_idx] >= window_length)
-      {
-        accumulator.Remove(v_values[begin_idx]);
-        begin_idx++;
-      }
-
-      v_output[sampling_idx] = accumulator.Result();
     }
-
-    return output;
+    sum_values += value;
+    num_values++;
   }
 
-  // Note: We only use inheritence to compile check the code.
-  template <typename INPUT, typename OUTPUT>
-  struct Accumulator
-  {
-    virtual ~Accumulator() = default;
-    virtual void Add(INPUT value) = 0;
-    virtual void Remove(INPUT value) = 0;
-    virtual OUTPUT Result() = 0;
-  };
-
-  template <typename INPUT, typename OUTPUT>
-  struct SimpleMovingAverageAccumulator : Accumulator<INPUT, OUTPUT>
-  {
-    void Add(INPUT value) override
-    {
-      if constexpr (std::numeric_limits<INPUT>::has_quiet_NaN)
-      {
-        if (std::isnan(value))
-        {
-          return;
-        }
+  void Remove(INPUT value) override {
+    if constexpr (std::numeric_limits<INPUT>::has_quiet_NaN) {
+      if (std::isnan(value)) {
+        return;
       }
-      sum_values += value;
-      num_values++;
+    }
+    sum_values -= value;
+    num_values--;
+  }
+
+  OUTPUT Result() override {
+    return (num_values > 0) ? (sum_values / num_values)
+                            : std::numeric_limits<OUTPUT>::quiet_NaN();
+  }
+
+  // TODO(gbm): Increase precision of accumulator.
+
+  // Sum of the values in the rolling window (RW).
+  double sum_values = 0;
+  // Number of values in the RW.
+  int num_values = 0;
+};
+
+template <typename INPUT, typename OUTPUT>
+struct MovingStandardDeviationAccumulator : Accumulator<INPUT, OUTPUT> {
+  void Add(INPUT value) override {
+    if constexpr (std::numeric_limits<INPUT>::has_quiet_NaN) {
+      if (std::isnan(value)) {
+        return;
+      }
+    }
+    sum_values += value;
+    sum_square_values += value * value;
+    num_values++;
+  }
+
+  void Remove(INPUT value) override {
+    if constexpr (std::numeric_limits<INPUT>::has_quiet_NaN) {
+      if (std::isnan(value)) {
+        return;
+      }
+    }
+    sum_values -= value;
+    sum_square_values -= value * value;
+    num_values--;
+  }
+
+  OUTPUT Result() override {
+    if (num_values == 0) {
+      return std::numeric_limits<OUTPUT>::quiet_NaN();
+    }
+    const auto mean = sum_values / num_values;
+    return sqrt(sum_square_values / num_values - mean * mean);
+  }
+
+  // Sum of the values in the rolling window (RW).
+  double sum_values = 0;
+  double sum_square_values = 0;
+  // Number of values in the RW.
+  int num_values = 0;
+};
+
+template <typename OUTPUT>
+struct MovingCountAccumulator : Accumulator<double, OUTPUT> {
+  void Add(double value) override {
+    static_assert(std::is_same<OUTPUT, int32_t>::value,
+                  "OUTPUT must be int32_t");
+    num_values++;
+  }
+
+  void Remove(double value) override { num_values--; }
+
+  OUTPUT Result() override { return num_values; }
+
+  // Number of values in the RW.
+  int32_t num_values = 0;
+};
+
+template <typename INPUT, typename OUTPUT>
+struct MovingSumAccumulator : Accumulator<INPUT, OUTPUT> {
+  void Add(INPUT value) override {
+    if constexpr (std::numeric_limits<INPUT>::has_quiet_NaN) {
+      if (std::isnan(value)) {
+        return;
+      }
+    }
+    sum_values += value;
+  }
+
+  void Remove(INPUT value) override {
+    if constexpr (std::numeric_limits<INPUT>::has_quiet_NaN) {
+      if (std::isnan(value)) {
+        return;
+      }
+    }
+    sum_values -= value;
+  }
+
+  OUTPUT Result() override { return sum_values; }
+
+  // Sum of the values in the rolling window (RW).
+  double sum_values = 0;
+};
+
+template <typename INPUT, typename OUTPUT>
+struct MovingExtremumAccumulator : Accumulator<INPUT, OUTPUT> {
+  virtual ~MovingExtremumAccumulator() = default;
+  virtual bool Compare(INPUT a, INPUT b) = 0;
+
+  void Add(INPUT value) override {
+    if constexpr (std::numeric_limits<INPUT>::has_quiet_NaN) {
+      if (std::isnan(value)) {
+        return;
+      }
     }
 
-    void Remove(INPUT value) override
-    {
-      if constexpr (std::numeric_limits<INPUT>::has_quiet_NaN)
-      {
-        if (std::isnan(value))
-        {
-          return;
-        }
+    if (values.empty() || Compare(value, current_extremum)) {
+      // The value is the new
+      current_extremum = value;
+    }
+    values.push_back(value);
+  }
+
+  void Remove(INPUT value) override {
+    if constexpr (std::numeric_limits<INPUT>::has_quiet_NaN) {
+      if (std::isnan(value)) {
+        return;
       }
-      sum_values -= value;
-      num_values--;
     }
 
-    OUTPUT Result() override
-    {
-      return (num_values > 0) ? (sum_values / num_values)
-                              : std::numeric_limits<OUTPUT>::quiet_NaN();
-    }
-
-    // TODO(gbm): Increase precision of accumulator.
-
-    // Sum of the values in the rolling window (RW).
-    double sum_values = 0;
-    // Number of values in the RW.
-    int num_values = 0;
-  };
-
-  template <typename INPUT, typename OUTPUT>
-  struct MovingStandardDeviationAccumulator : Accumulator<INPUT, OUTPUT>
-  {
-    void Add(INPUT value) override
-    {
-      if constexpr (std::numeric_limits<INPUT>::has_quiet_NaN)
-      {
-        if (std::isnan(value))
-        {
-          return;
-        }
-      }
-      sum_values += value;
-      sum_square_values += value * value;
-      num_values++;
-    }
-
-    void Remove(INPUT value) override
-    {
-      if constexpr (std::numeric_limits<INPUT>::has_quiet_NaN)
-      {
-        if (std::isnan(value))
-        {
-          return;
-        }
-      }
-      sum_values -= value;
-      sum_square_values -= value * value;
-      num_values--;
-    }
-
-    OUTPUT Result() override
-    {
-      if (num_values == 0)
-      {
-        return std::numeric_limits<OUTPUT>::quiet_NaN();
-      }
-      const auto mean = sum_values / num_values;
-      return sqrt(sum_square_values / num_values - mean * mean);
-    }
-
-    // Sum of the values in the rolling window (RW).
-    double sum_values = 0;
-    double sum_square_values = 0;
-    // Number of values in the RW.
-    int num_values = 0;
-  };
-
-  template <typename OUTPUT>
-  struct MovingCountAccumulator : Accumulator<double, OUTPUT>
-  {
-    void Add(double value) override
-    {
-      static_assert(std::is_same<OUTPUT, int32_t>::value,
-                    "OUTPUT must be int32_t");
-      num_values++;
-    }
-
-    void Remove(double value) override { num_values--; }
-
-    OUTPUT Result() override { return num_values; }
-
-    // Number of values in the RW.
-    int32_t num_values = 0;
-  };
-
-  template <typename INPUT, typename OUTPUT>
-  struct MovingSumAccumulator : Accumulator<INPUT, OUTPUT>
-  {
-    void Add(INPUT value) override
-    {
-      if constexpr (std::numeric_limits<INPUT>::has_quiet_NaN)
-      {
-        if (std::isnan(value))
-        {
-          return;
-        }
-      }
-      sum_values += value;
-    }
-
-    void Remove(INPUT value) override
-    {
-      if constexpr (std::numeric_limits<INPUT>::has_quiet_NaN)
-      {
-        if (std::isnan(value))
-        {
-          return;
-        }
-      }
-      sum_values -= value;
-    }
-
-    OUTPUT Result() override { return sum_values; }
-
-    // Sum of the values in the rolling window (RW).
-    double sum_values = 0;
-  };
-
-  template <typename INPUT, typename OUTPUT>
-  struct MovingExtremumAccumulator : Accumulator<INPUT, OUTPUT>
-  {
-    virtual ~MovingExtremumAccumulator() = default;
-    virtual bool Compare(INPUT a, INPUT b) = 0;
-
-    void Add(INPUT value) override
-    {
-      if constexpr (std::numeric_limits<INPUT>::has_quiet_NaN)
-      {
-        if (std::isnan(value))
-        {
-          return;
-        }
-      }
-
-      if (values.empty() || Compare(value, current_extremum))
-      {
-        // The value is the new
-        current_extremum = value;
-      }
-      values.push_back(value);
-    }
-
-    void Remove(INPUT value) override
-    {
-      if constexpr (std::numeric_limits<INPUT>::has_quiet_NaN)
-      {
-        if (std::isnan(value))
-        {
-          return;
-        }
-      }
-
-      if (values.size() == 1)
-      {
-        values.clear();
-      }
-      else
-      {
-        assert(!values.empty());
-        assert(values.front() == value);
-        values.pop_front();
-        if (value == current_extremum)
-        {
-          // Compute the extremum on the remaining items.
-          current_extremum = values.front();
-          for (const auto value : values)
-          {
-            if (Compare(value, current_extremum))
-            {
-              current_extremum = value;
-            }
+    if (values.size() == 1) {
+      values.clear();
+    } else {
+      assert(!values.empty());
+      assert(values.front() == value);
+      values.pop_front();
+      if (value == current_extremum) {
+        // Compute the extremum on the remaining items.
+        current_extremum = values.front();
+        for (const auto value : values) {
+          if (Compare(value, current_extremum)) {
+            current_extremum = value;
           }
         }
       }
     }
+  }
 
-    OUTPUT Result() override
-    {
-      return values.empty() ? std::numeric_limits<OUTPUT>::quiet_NaN()
-                            : current_extremum;
-    }
+  OUTPUT Result() override {
+    return values.empty() ? std::numeric_limits<OUTPUT>::quiet_NaN()
+                          : current_extremum;
+  }
 
-    // TODO(gbm): Implement without memory copy.
-    std::deque<INPUT> values;
-    INPUT current_extremum;
-  };
+  // TODO(gbm): Implement without memory copy.
+  std::deque<INPUT> values;
+  INPUT current_extremum;
+};
 
-  template <typename INPUT, typename OUTPUT>
-  struct MovingMinAccumulator : MovingExtremumAccumulator<INPUT, OUTPUT>
-  {
-    bool Compare(INPUT a, INPUT b) { return a < b; }
-  };
+template <typename INPUT, typename OUTPUT>
+struct MovingMinAccumulator : MovingExtremumAccumulator<INPUT, OUTPUT> {
+  bool Compare(INPUT a, INPUT b) { return a < b; }
+};
 
-  template <typename INPUT, typename OUTPUT>
-  struct MovingMaxAccumulator : MovingExtremumAccumulator<INPUT, OUTPUT>
-  {
-    bool Compare(INPUT a, INPUT b) { return a > b; }
-  };
+template <typename INPUT, typename OUTPUT>
+struct MovingMaxAccumulator : MovingExtremumAccumulator<INPUT, OUTPUT> {
+  bool Compare(INPUT a, INPUT b) { return a > b; }
+};
 
 // Instantiate the "accumulate" function with an accumulator for both float32
 // and float64 precision.
@@ -371,72 +317,68 @@ namespace
 //   INPUT: Input value type.
 //   OUTPUT: Output value type.
 //   ACCUMULATOR: Accumulator class.
-#define REGISTER_CC_FUNC(NAME, INPUT, OUTPUT, ACCUMULATOR)                    \
-                                                                              \
-  py::array_t<OUTPUT> NAME(const ArrayD &evset_timestamps,                    \
-                           const py::array_t<INPUT> &evset_values,            \
-                           const double window_length)                        \
-  {                                                                           \
-    return accumulate<INPUT, OUTPUT, ACCUMULATOR<INPUT, OUTPUT>>(             \
-        evset_timestamps, evset_values, window_length);                       \
-  }                                                                           \
-                                                                              \
-  py::array_t<OUTPUT> NAME(                                                   \
-      const ArrayD &evset_timestamps, const py::array_t<INPUT> &evset_values, \
-      const ArrayD &sampling_timestamps, const double window_length)          \
-  {                                                                           \
-    return accumulate<INPUT, OUTPUT, ACCUMULATOR<INPUT, OUTPUT>>(             \
-        evset_timestamps, evset_values, sampling_timestamps, window_length);  \
+#define REGISTER_CC_FUNC(NAME, INPUT, OUTPUT, ACCUMULATOR)                     \
+                                                                               \
+  py::array_t<OUTPUT> NAME(const ArrayD &evset_timestamps,                     \
+                           const py::array_t<INPUT> &evset_values,             \
+                           const double window_length) {                       \
+    return accumulate<INPUT, OUTPUT, ACCUMULATOR<INPUT, OUTPUT>>(              \
+        evset_timestamps, evset_values, window_length);                        \
+  }                                                                            \
+                                                                               \
+  py::array_t<OUTPUT> NAME(                                                    \
+      const ArrayD &evset_timestamps, const py::array_t<INPUT> &evset_values,  \
+      const ArrayD &sampling_timestamps, const double window_length) {         \
+    return accumulate<INPUT, OUTPUT, ACCUMULATOR<INPUT, OUTPUT>>(              \
+        evset_timestamps, evset_values, sampling_timestamps, window_length);   \
   }
 
 // Similar to REGISTER_CC_FUNC, but without inputs
-#define REGISTER_CC_FUNC_NO_INPUT(NAME, OUTPUT, ACCUMULATOR)     \
-                                                                 \
-  py::array_t<OUTPUT> NAME(const ArrayD &evset_timestamps,       \
-                           const double window_length)           \
-  {                                                              \
-    return accumulate<double, OUTPUT, ACCUMULATOR<OUTPUT>>(      \
-        evset_timestamps, evset_timestamps, window_length);      \
-  }                                                              \
-                                                                 \
-  py::array_t<OUTPUT> NAME(const ArrayD &evset_timestamps,       \
-                           const ArrayD &sampling_timestamps,    \
-                           const double window_length)           \
-  {                                                              \
-    return accumulate<double, OUTPUT, ACCUMULATOR<OUTPUT>>(      \
-        evset_timestamps, evset_timestamps, sampling_timestamps, \
-        window_length);                                          \
+#define REGISTER_CC_FUNC_NO_INPUT(NAME, OUTPUT, ACCUMULATOR)                   \
+                                                                               \
+  py::array_t<OUTPUT> NAME(const ArrayD &evset_timestamps,                     \
+                           const double window_length) {                       \
+    return accumulate<double, OUTPUT, ACCUMULATOR<OUTPUT>>(                    \
+        evset_timestamps, evset_timestamps, window_length);                    \
+  }                                                                            \
+                                                                               \
+  py::array_t<OUTPUT> NAME(const ArrayD &evset_timestamps,                     \
+                           const ArrayD &sampling_timestamps,                  \
+                           const double window_length) {                       \
+    return accumulate<double, OUTPUT, ACCUMULATOR<OUTPUT>>(                    \
+        evset_timestamps, evset_timestamps, sampling_timestamps,               \
+        window_length);                                                        \
   }
 
-  // Note: ";" are not needed for the code, but are required for our code
-  // formatter.
+// Note: ";" are not needed for the code, but are required for our code
+// formatter.
 
-  REGISTER_CC_FUNC(simple_moving_average, float, float,
-                   SimpleMovingAverageAccumulator);
-  REGISTER_CC_FUNC(simple_moving_average, double, double,
-                   SimpleMovingAverageAccumulator);
+REGISTER_CC_FUNC(simple_moving_average, float, float,
+                 SimpleMovingAverageAccumulator);
+REGISTER_CC_FUNC(simple_moving_average, double, double,
+                 SimpleMovingAverageAccumulator);
 
-  REGISTER_CC_FUNC(moving_standard_deviation, float, float,
-                   MovingStandardDeviationAccumulator);
-  REGISTER_CC_FUNC(moving_standard_deviation, double, double,
-                   MovingStandardDeviationAccumulator);
+REGISTER_CC_FUNC(moving_standard_deviation, float, float,
+                 MovingStandardDeviationAccumulator);
+REGISTER_CC_FUNC(moving_standard_deviation, double, double,
+                 MovingStandardDeviationAccumulator);
 
-  REGISTER_CC_FUNC(moving_sum, float, float, MovingSumAccumulator);
-  REGISTER_CC_FUNC(moving_sum, double, double, MovingSumAccumulator);
-  REGISTER_CC_FUNC(moving_sum, int32_t, int32_t, MovingSumAccumulator);
-  REGISTER_CC_FUNC(moving_sum, int64_t, int64_t, MovingSumAccumulator);
+REGISTER_CC_FUNC(moving_sum, float, float, MovingSumAccumulator);
+REGISTER_CC_FUNC(moving_sum, double, double, MovingSumAccumulator);
+REGISTER_CC_FUNC(moving_sum, int32_t, int32_t, MovingSumAccumulator);
+REGISTER_CC_FUNC(moving_sum, int64_t, int64_t, MovingSumAccumulator);
 
-  REGISTER_CC_FUNC(moving_min, float, float, MovingMinAccumulator);
-  REGISTER_CC_FUNC(moving_min, double, double, MovingMinAccumulator);
-  REGISTER_CC_FUNC(moving_min, int32_t, int32_t, MovingMinAccumulator);
-  REGISTER_CC_FUNC(moving_min, int64_t, int64_t, MovingMinAccumulator);
+REGISTER_CC_FUNC(moving_min, float, float, MovingMinAccumulator);
+REGISTER_CC_FUNC(moving_min, double, double, MovingMinAccumulator);
+REGISTER_CC_FUNC(moving_min, int32_t, int32_t, MovingMinAccumulator);
+REGISTER_CC_FUNC(moving_min, int64_t, int64_t, MovingMinAccumulator);
 
-  REGISTER_CC_FUNC(moving_max, float, float, MovingMaxAccumulator);
-  REGISTER_CC_FUNC(moving_max, double, double, MovingMaxAccumulator);
-  REGISTER_CC_FUNC(moving_max, int32_t, int32_t, MovingMaxAccumulator);
-  REGISTER_CC_FUNC(moving_max, int64_t, int64_t, MovingMaxAccumulator);
+REGISTER_CC_FUNC(moving_max, float, float, MovingMaxAccumulator);
+REGISTER_CC_FUNC(moving_max, double, double, MovingMaxAccumulator);
+REGISTER_CC_FUNC(moving_max, int32_t, int32_t, MovingMaxAccumulator);
+REGISTER_CC_FUNC(moving_max, int64_t, int64_t, MovingMaxAccumulator);
 
-  REGISTER_CC_FUNC_NO_INPUT(moving_count, int32_t, MovingCountAccumulator);
+REGISTER_CC_FUNC_NO_INPUT(moving_count, int32_t, MovingCountAccumulator);
 } // namespace
 
 // Register c++ functions to pybind with and without sampling.
@@ -470,8 +412,7 @@ namespace
   m.def(#NAME, py::overload_cast<const ArrayD &, double>(&NAME), "",           \
         py::arg("evset_timestamps").noconvert(), py::arg("window_length"));
 
-void init_window(py::module &m)
-{
+void init_window(py::module &m) {
   ADD_PY_DEF(simple_moving_average, float, float)
   ADD_PY_DEF(simple_moving_average, double, double)
 

--- a/temporian/implementation/numpy_cc/operators/window.cc
+++ b/temporian/implementation/numpy_cc/operators/window.cc
@@ -13,8 +13,6 @@
 namespace {
 namespace py = pybind11;
 
-using namespace std;
-
 typedef py::array_t<double> ArrayD;
 typedef py::array_t<float> ArrayF;
 

--- a/temporian/implementation/numpy_cc/operators/window.cc
+++ b/temporian/implementation/numpy_cc/operators/window.cc
@@ -13,8 +13,6 @@
 namespace {
 namespace py = pybind11;
 
-using namespace std; // REMOVE
-
 typedef py::array_t<double> ArrayD;
 typedef py::array_t<float> ArrayF;
 
@@ -29,7 +27,6 @@ template <typename INPUT, typename OUTPUT, typename TAccumulator>
 py::array_t<OUTPUT> accumulate(const ArrayD &evset_timestamps,
                                const py::array_t<INPUT> &evset_values,
                                const double window_length) {
-  cout << "No external sampling, constant window length\n";
   // Input size
   const size_t n_event = evset_timestamps.shape(0);
 
@@ -89,7 +86,6 @@ py::array_t<OUTPUT> accumulate(const ArrayD &evset_timestamps,
                                const py::array_t<INPUT> &evset_values,
                                const ArrayD &sampling_timestamps,
                                const double window_length) {
-  cout << "External sampling, constant window length\n";
   // Input size
   const size_t n_event = evset_timestamps.shape(0);
   const size_t n_sampling = sampling_timestamps.shape(0);
@@ -134,7 +130,6 @@ template <typename INPUT, typename OUTPUT, typename TAccumulator>
 py::array_t<OUTPUT> accumulate(const ArrayD &evset_timestamps,
                                const py::array_t<INPUT> &evset_values,
                                const ArrayD &window_length) {
-  cout << "No external sampling, variable window length\n";
   // Input size
   const size_t n_event = evset_timestamps.shape(0);
 
@@ -217,7 +212,6 @@ py::array_t<OUTPUT> accumulate(const ArrayD &evset_timestamps,
                                const py::array_t<INPUT> &evset_values,
                                const ArrayD &sampling_timestamps,
                                const ArrayD &window_length) {
-  cout << "External sampling, variable window length\n";
   // Input size
   const size_t n_event = evset_timestamps.shape(0);
   const size_t n_sampling = sampling_timestamps.shape(0);

--- a/temporian/implementation/numpy_cc/operators/window.cc
+++ b/temporian/implementation/numpy_cc/operators/window.cc
@@ -434,8 +434,8 @@ struct MovingExtremumAccumulator : Accumulator<INPUT, OUTPUT> {
       }
     }
 
-    assert(values.front() == value);
     assert(!values.empty());
+    assert(values.front() == value);
 
     if (values.size() == 1) {
       values.clear();

--- a/temporian/implementation/numpy_cc/operators/window.cc
+++ b/temporian/implementation/numpy_cc/operators/window.cc
@@ -141,6 +141,9 @@ py::array_t<OUTPUT> accumulate(const ArrayD &evset_timestamps,
   auto v_values = evset_values.template unchecked<1>();
   auto v_window_length = window_length.unchecked<1>();
 
+  assert(v_timestamps.shape(0) == v_window_length.shape(0));
+  assert(v_timestamps.shape(0) == v_values.shape(0));
+
   TAccumulator accumulator;
 
   // Index of the first value in the window.
@@ -148,21 +151,16 @@ py::array_t<OUTPUT> accumulate(const ArrayD &evset_timestamps,
   // Index of the first value outside the window.
   size_t end_idx = 0;
 
-  double curr_ts;
-  double curr_window_length;
-  size_t first_diff_ts_idx;
-
   while (end_idx < n_event) {
     // Note: We accumulate values in (t-window_length, t] with t=
     // v_timestamps[end_idx], and there may be several contiguous equal
     // values in v_timestamps.
-
-    curr_ts = v_timestamps[end_idx];
-    curr_window_length = v_window_length[end_idx];
+    const auto curr_ts = v_timestamps[end_idx];
+    const auto curr_window_length = v_window_length[end_idx];
 
     // Add all values with same timestamp as the current one.
     accumulator.Add(v_values[end_idx]);
-    first_diff_ts_idx = end_idx + 1;
+    auto first_diff_ts_idx = end_idx + 1;
     while (first_diff_ts_idx < n_event &&
            v_timestamps[first_diff_ts_idx] == curr_ts) {
       accumulator.Add(v_values[first_diff_ts_idx]);
@@ -224,6 +222,9 @@ py::array_t<OUTPUT> accumulate(const ArrayD &evset_timestamps,
   auto v_values = evset_values.template unchecked<1>();
   auto v_sampling = sampling_timestamps.unchecked<1>();
   auto v_window_length = window_length.unchecked<1>();
+
+  assert(v_timestamps.shape(0) == v_values.shape(0));
+  assert(v_sampling.shape(0) == v_window_length.shape(0));
 
   TAccumulator accumulator;
 


### PR DESCRIPTION
Python
- made a new `WindowlLength` type for the `window_length` param, so that it can be either a `Duration` or `EventSet`.
- if a `Duration` it gets serialized as an attribute, if an `EventSet` it gets serialized  as an input. this is transparent to the user.
- implementation checks whether a `window_length` input `EventSet` was received, else it uses the attribute (one of them will be None)
- could make sense to make these two different attributes (`window_length` and `variable_window_length`), though I like this approach better

CPP
- added 2 new `accumulate()` overloads for variable window length with and without external sampling and extended cpp and python defs for them