### PR TITLE
Fix longlong timestamps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@
 
 ### Fixes
 
+- Fixed issues when loading timestamps from `np.longlong` and other dtypes.
+
 ## 0.1.4
 
 ### Features

--- a/temporian/core/data/duration_utils.py
+++ b/temporian/core/data/duration_utils.py
@@ -44,8 +44,6 @@ NormalizedDuration = float
 Timestamp = Union[np.datetime64, datetime.datetime, int, float]
 NormalizedTimestamp = float
 
-MIN_TIMESTAMP_S = datetime.datetime(1900, 1, 1).timestamp()
-
 
 def normalize_duration(x: Duration) -> NormalizedDuration:
     if isinstance(x, (int, float)) and x > 0:
@@ -76,6 +74,10 @@ def normalize_timestamp(x: Timestamp) -> NormalizedTimestamp:
 def datetime64_array_to_float64(array_datetimes: np.ndarray) -> np.ndarray:
     # Avoid copying, already done in last division by 1e9
     features_ns = array_datetimes.astype("datetime64[ns]", copy=False)
+    if np.isnan(features_ns).any():
+        raise ValueError(
+            "Timestamps contain null/NaT values, which are not supported."
+        )
     return features_ns.astype(np.float64, copy=False) / 1e9
 
 

--- a/temporian/core/data/duration_utils.py
+++ b/temporian/core/data/duration_utils.py
@@ -44,6 +44,8 @@ NormalizedDuration = float
 Timestamp = Union[np.datetime64, datetime.datetime, int, float]
 NormalizedTimestamp = float
 
+MIN_TIMESTAMP_S = datetime.datetime(1900, 1, 1).timestamp()
+
 
 def normalize_duration(x: Duration) -> NormalizedDuration:
     if isinstance(x, (int, float)) and x > 0:

--- a/temporian/implementation/numpy/data/dtype_normalization.py
+++ b/temporian/implementation/numpy/data/dtype_normalization.py
@@ -15,17 +15,13 @@
 """Shared data type normalization functions."""
 
 from __future__ import annotations
-import datetime
 import logging
-from typing import TYPE_CHECKING, Any, List, Optional, Tuple, Union
+from typing import TYPE_CHECKING, Any, List, Optional, Tuple
 
 import numpy as np
 
 from temporian.core.data.dtype import DType
-from temporian.core.data.duration_utils import (
-    MIN_TIMESTAMP_S,
-    datetime64_array_to_float64,
-)
+from temporian.core.data.duration_utils import datetime64_array_to_float64
 
 if TYPE_CHECKING:
     from temporian.core.typing import (
@@ -179,16 +175,16 @@ def normalize_timestamps(
     if not isinstance(values, np.ndarray):
         values = np.array(values)
 
-    # values is represented as a number. Cast to float64.
+    # values is represented as a number. Copy and cast to float64.
     if np.issubdtype(values.dtype, np.integer) or np.issubdtype(
         values.dtype, np.floating
     ):
-        values = values.astype(np.float64, copy=False)
+        values = values.astype(np.float64, copy=True)
 
     if values.dtype.type == np.float64:
         # Check NaN
         if np.isnan(values).any():
-            raise ValueError("Timestamps contains NaN values.")
+            raise ValueError("Timestamps contain NaN values.")
 
         return values, False
 
@@ -199,8 +195,6 @@ def normalize_timestamps(
     if values.dtype.type == np.datetime64:
         # values is a date. Cast to unix epoch in float64 seconds.
         values = datetime64_array_to_float64(values)
-        if np.any(values < MIN_TIMESTAMP_S):
-            raise ValueError("Timestamps contains null or invalid values.")
         return values, True
 
     raise ValueError(

--- a/temporian/implementation/numpy/data/dtype_normalization.py
+++ b/temporian/implementation/numpy/data/dtype_normalization.py
@@ -22,7 +22,10 @@ from typing import TYPE_CHECKING, Any, List, Optional, Tuple, Union
 import numpy as np
 
 from temporian.core.data.dtype import DType
-from temporian.core.data.duration_utils import datetime64_array_to_float64
+from temporian.core.data.duration_utils import (
+    MIN_TIMESTAMP_S,
+    datetime64_array_to_float64,
+)
 
 if TYPE_CHECKING:
     from temporian.core.typing import (
@@ -196,7 +199,7 @@ def normalize_timestamps(
     if values.dtype.type == np.datetime64:
         # values is a date. Cast to unix epoch in float64 seconds.
         values = datetime64_array_to_float64(values)
-        if np.any(values < 0):
+        if np.any(values < MIN_TIMESTAMP_S):
             raise ValueError("Timestamps contains null or invalid values.")
         return values, True
 

--- a/temporian/implementation/numpy/data/test/io_test.py
+++ b/temporian/implementation/numpy/data/test/io_test.py
@@ -80,6 +80,12 @@ class IOTest(absltest.TestCase):
             np.array([2], dtype=np.int64),
             np.array([2], dtype=np.float32),
             np.array([2], dtype=np.float64),
+            np.array([2], dtype=np.byte),
+            np.array([2], dtype=np.short),
+            np.array([2], dtype=np.longlong),
+            np.array([2], dtype=np.ubyte),
+            np.array([2], dtype=np.ushort),
+            np.array([2], dtype=np.ulonglong),
             pd.Series([2]),
         ]:
             logging.info("Testing: %s (%s)", timestamps, type(timestamps))
@@ -103,6 +109,7 @@ class IOTest(absltest.TestCase):
             np.array(["1970-01-02"], dtype=np.object_),
             # Pandas
             pd.Series([pd.Timestamp("1970-01-02")]),
+            np.array([pd.Timestamp("1970-01-02")]),  # dtype object
             pd.Series(["1970-01-02"]),
         ]:
             logging.info("Testing: %s (%s)", timestamps, type(timestamps))


### PR DESCRIPTION
**TL;DR:** This PR fixes some issues in `normalize_timestamps()`, simplifying the code, avoiding issues with numpy dtypes, and improving the error handling by avoiding unnecessary checks.

For context, this fixes an issue that showed up in a notebook by @achoum, caused by numpy representing numbers using `np.longlong` internally instead of the usual `np.int64`, after loading a CSV from pandas. This can be reproduced by doing:

```
>>> np.array([1, 2], dtype=np.longlong).dtype
dtype('int64')
>>> np.array([1, 2], dtype=np.longlong).dtype.type
<class 'numpy.longlong'>
```

The bug is solved by using `np.issubdtype(np.dtype, np.integer)`, instead of accessing `my_array.dtype.type` which refers to the underlying scalar type, and there are a bunch of those (see [Built in scalar types](https://numpy.org/doc/stable/reference/arrays.scalars.html#built-in-scalar-types)).