### PR TITLE
Add op tests

### DIFF
--- a/temporian/core/operators/add_index.py
+++ b/temporian/core/operators/add_index.py
@@ -37,10 +37,10 @@ class AddIndexOperator(Operator):
     ) -> None:
         super().__init__()
 
-        self._output_feature_schemas = self._get_output_feature_schemas(
+        output_feature_schemas = self._get_output_feature_schemas(
             input, indexes
         )
-        self._output_indexes = self._get_output_indexes(input, indexes)
+        output_indexes = self._get_output_indexes(input, indexes)
         self._indexes = indexes
 
         self.add_input("input", input)
@@ -50,8 +50,8 @@ class AddIndexOperator(Operator):
         self.add_output(
             "output",
             create_node_new_features_new_sampling(
-                features=self._output_feature_schemas,
-                indexes=self._output_indexes,
+                features=output_feature_schemas,
+                indexes=output_indexes,
                 is_unix_timestamp=input.schema.is_unix_timestamp,
                 creator=self,
             ),
@@ -75,11 +75,11 @@ class AddIndexOperator(Operator):
 
         new_indexes: List[IndexSchema] = []
         for index in indexes:
-            if index not in feature_dict:
-                raise ValueError(f"{index} is not a feature in input.")
-
             if index in index_dict:
                 raise ValueError(f"{index} is already an index in input.")
+
+            if index not in feature_dict:
+                raise ValueError(f"{index} is not a feature in input.")
 
             new_indexes.append(
                 IndexSchema(name=index, dtype=feature_dict[index])
@@ -100,14 +100,6 @@ class AddIndexOperator(Operator):
             inputs=[pb.OperatorDef.Input(key="input")],
             outputs=[pb.OperatorDef.Output(key="output")],
         )
-
-    @property
-    def output_feature_schemas(self) -> List[FeatureSchema]:
-        return self._output_feature_schemas
-
-    @property
-    def output_indexes(self) -> List[IndexSchema]:
-        return self._output_indexes
 
     @property
     def indexes(self) -> List[str]:

--- a/temporian/core/operators/drop_index.py
+++ b/temporian/core/operators/drop_index.py
@@ -50,7 +50,7 @@ class DropIndexOperator(Operator):
             input, indexes, keep
         )
 
-        self._output_indexes = [
+        output_indexes = [
             index_level
             for index_level in input.schema.indexes
             if index_level.name not in indexes
@@ -60,7 +60,7 @@ class DropIndexOperator(Operator):
             "output",
             create_node_new_features_new_sampling(
                 features=self._output_feature_schemas,
-                indexes=self._output_indexes,
+                indexes=output_indexes,
                 is_unix_timestamp=input.schema.is_unix_timestamp,
                 creator=self,
             ),
@@ -74,19 +74,9 @@ class DropIndexOperator(Operator):
             return input.schema.features
 
         index_dict = input.schema.index_name_to_dtype()
-        feature_dict = input.schema.feature_name_to_dtype()
 
         new_features: List[FeatureSchema] = []
         for index in indexes:
-            if index not in index_dict:
-                raise ValueError(f"{index} is not an index in input.")
-
-            if index in feature_dict:
-                raise ValueError(
-                    f"{index} already exists in input's features. If you"
-                    " want to drop the index, specify `keep=False`."
-                )
-
             new_features.append(
                 FeatureSchema(name=index, dtype=index_dict[index])
             )
@@ -97,10 +87,6 @@ class DropIndexOperator(Operator):
     @property
     def output_feature_schemas(self) -> List[FeatureSchema]:
         return self._output_feature_schemas
-
-    @property
-    def output_indexes(self) -> List[IndexSchema]:
-        return self._output_indexes
 
     @property
     def indexes(self) -> List[str]:
@@ -150,7 +136,7 @@ def _normalize_indexes(
     index_dict = input.schema.index_name_to_dtype()
     for index in indexes:
         if index not in index_dict:
-            raise KeyError(
+            raise ValueError(
                 f"{index} is not an index in {input.schema.indexes}."
             )
 

--- a/temporian/core/operators/glue.py
+++ b/temporian/core/operators/glue.py
@@ -41,11 +41,11 @@ class GlueOperator(Operator):
         # serialization.
 
         if len(inputs) < 2:
-            raise ValueError("At least two arguments should be provided")
+            raise ValueError("At least two arguments should be provided.")
 
         if len(inputs) >= MAX_NUM_ARGUMENTS:
             raise ValueError(
-                f"Too many (>{MAX_NUM_ARGUMENTS}) arguments provided"
+                f"Too many (>{MAX_NUM_ARGUMENTS}) arguments provided."
             )
 
         # inputs

--- a/temporian/core/operators/test/test_begin.py
+++ b/temporian/core/operators/test/test_begin.py
@@ -38,7 +38,7 @@ class BeginTest(TestCase):
     def test_empty(self):
         evset = event_set(timestamps=[], features={"a": []})
 
-        result = evset.end()
+        result = evset.begin()
 
         expected = event_set(timestamps=[])
 

--- a/temporian/core/operators/test/test_begin.py
+++ b/temporian/core/operators/test/test_begin.py
@@ -35,6 +35,15 @@ class BeginTest(TestCase):
 
         assertOperatorResult(self, result, expected, check_sampling=False)
 
+    def test_empty(self):
+        evset = event_set(timestamps=[], features={"a": []})
+
+        result = evset.end()
+
+        expected = event_set(timestamps=[])
+
+        assertOperatorResult(self, result, expected, check_sampling=False)
+
 
 if __name__ == "__main__":
     absltest.main()

--- a/temporian/core/operators/test/test_drop_index.py
+++ b/temporian/core/operators/test/test_drop_index.py
@@ -23,15 +23,15 @@ class DropIndexTest(TestCase):
     def setUp(self) -> None:
         self.timestamps = [0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8]
         self.features = {
-            "state_id": ["A", "A", "A", "B", "B", "B", "B", "B"],
-            "store_id": [0, 0, 0, 0, 0, 1, 1, 1],
-            "item_id": [1, 1, 1, 2, 2, 2, 2, 3],
-            "sales": [10.0, 11.0, 12.0, 13.0, 14.0, 15.0, 16.0, 17.0],
+            "a": ["A", "A", "A", "B", "B", "B", "B", "B"],
+            "b": [0, 0, 0, 0, 0, 1, 1, 1],
+            "c": [1, 1, 1, 2, 2, 2, 2, 3],
+            "d": [10.0, 11.0, 12.0, 13.0, 14.0, 15.0, 16.0, 17.0],
         }
         self.evset = event_set(
             timestamps=self.timestamps,
             features=self.features,
-            indexes=["store_id", "item_id"],
+            indexes=["b", "c"],
         )
 
     def test_drop_all(self) -> None:
@@ -39,10 +39,10 @@ class DropIndexTest(TestCase):
             timestamps=self.timestamps,
             # Old indexes are now the last features
             features={
-                "state_id": self.features["state_id"],
-                "sales": self.features["sales"],
-                "store_id": self.features["store_id"],
-                "item_id": self.features["item_id"],
+                "a": self.features["a"],
+                "d": self.features["d"],
+                "b": self.features["b"],
+                "c": self.features["c"],
             },
         )
 
@@ -55,15 +55,15 @@ class DropIndexTest(TestCase):
             timestamps=self.timestamps,
             # Old indexes are now the last features
             features={
-                "item_id": self.features["item_id"],
-                "state_id": self.features["state_id"],
-                "sales": self.features["sales"],
-                "store_id": self.features["store_id"],
+                "c": self.features["c"],
+                "a": self.features["a"],
+                "d": self.features["d"],
+                "b": self.features["b"],
             },
-            indexes=["item_id"],
+            indexes=["c"],
         )
 
-        result = self.evset.drop_index("store_id")
+        result = self.evset.drop_index("b")
 
         assertOperatorResult(self, result, expected, check_sampling=False)
 
@@ -72,15 +72,15 @@ class DropIndexTest(TestCase):
             timestamps=self.timestamps,
             # Old indexes are now the last features
             features={
-                "store_id": self.features["store_id"],
-                "state_id": self.features["state_id"],
-                "sales": self.features["sales"],
-                "item_id": self.features["item_id"],
+                "b": self.features["b"],
+                "a": self.features["a"],
+                "d": self.features["d"],
+                "c": self.features["c"],
             },
-            indexes=["store_id"],
+            indexes=["b"],
         )
 
-        result = self.evset.drop_index("item_id")
+        result = self.evset.drop_index("c")
 
         assertOperatorResult(self, result, expected, check_sampling=False)
 
@@ -89,14 +89,14 @@ class DropIndexTest(TestCase):
             timestamps=self.timestamps,
             # Old indexes are now the last features
             features={
-                "store_id": self.features["store_id"],
-                "state_id": self.features["state_id"],
-                "sales": self.features["sales"],
+                "b": self.features["b"],
+                "a": self.features["a"],
+                "d": self.features["d"],
             },
-            indexes=["store_id"],
+            indexes=["b"],
         )
 
-        result = self.evset.drop_index("item_id", keep=False)
+        result = self.evset.drop_index("c", keep=False)
 
         assertOperatorResult(self, result, expected, check_sampling=False)
 
@@ -121,6 +121,16 @@ class DropIndexTest(TestCase):
         result = evset.drop_index("b")
 
         assertOperatorResult(self, result, expected, check_sampling=False)
+
+    def test_wrong_index(self):
+        with self.assertRaisesRegex(ValueError, "x is not an index in"):
+            self.evset.drop_index("x")
+
+    def test_empty_list(self):
+        with self.assertRaisesRegex(
+            ValueError, "Cannot specify empty list as `indexes` argument"
+        ):
+            self.evset.drop_index([])
 
 
 if __name__ == "__main__":

--- a/temporian/core/operators/test/test_end.py
+++ b/temporian/core/operators/test/test_end.py
@@ -35,6 +35,15 @@ class EndTest(TestCase):
 
         assertOperatorResult(self, result, expected, check_sampling=False)
 
+    def test_empty(self):
+        evset = event_set(timestamps=[], features={"a": []})
+
+        result = evset.end()
+
+        expected = event_set(timestamps=[])
+
+        assertOperatorResult(self, result, expected, check_sampling=False)
+
 
 if __name__ == "__main__":
     absltest.main()

--- a/temporian/core/operators/test/test_fast_fourier_transform.py
+++ b/temporian/core/operators/test/test_fast_fourier_transform.py
@@ -106,6 +106,15 @@ class FastFourierTransformTest(TestCase):
                 num_events=20, num_spectral_lines=15
             )
 
+    def test_wrong_num_spectral_lines_negative(self):
+        evset = event_set([], {"a": f32([])})
+        with self.assertRaisesRegex(
+            ValueError, "num_spectral_lines should be positive. Got"
+        ):
+            evset.experimental_fast_fourier_transform(
+                num_events=20, num_spectral_lines=-1
+            )
+
 
 if __name__ == "__main__":
     absltest.main()

--- a/temporian/core/operators/test/test_filter.py
+++ b/temporian/core/operators/test/test_filter.py
@@ -39,6 +39,33 @@ class FilterTest(TestCase):
 
         assertOperatorResult(self, result, expected, check_sampling=False)
 
+    def test_no_condition(self):
+        evset = event_set([0, 1, 2], features={"cond": [True, False, True]})
+
+        result = evset.filter()
+
+        expected = event_set([0, 2], features={"cond": [True, True]})
+
+        assertOperatorResult(self, result, expected, check_sampling=False)
+
+    def test_condition_many_features(self):
+        evset = event_set([])
+        condition = event_set(
+            [], features={"a": [], "b": []}, same_sampling_as=evset
+        )
+        with self.assertRaisesRegex(
+            ValueError, "Condition must be a single feature. Got"
+        ):
+            evset.filter(condition)
+
+    def test_condition_not_boolean(self):
+        evset = event_set([])
+        condition = event_set([0], features={"a": [3]}, same_sampling_as=evset)
+        with self.assertRaisesRegex(
+            ValueError, "Condition must be a boolean feature. Got"
+        ):
+            evset.filter(condition)
+
 
 if __name__ == "__main__":
     absltest.main()

--- a/temporian/core/operators/test/test_glue.py
+++ b/temporian/core/operators/test/test_glue.py
@@ -14,7 +14,7 @@
 
 from absl.testing import absltest
 from absl.testing.parameterized import TestCase
-from temporian.core.operators.glue import glue
+from temporian.core.operators.glue import MAX_NUM_ARGUMENTS, glue
 
 from temporian.implementation.numpy.data.io import event_set
 from temporian.test.utils import assertOperatorResult, f32
@@ -88,6 +88,18 @@ class GlueTest(TestCase):
                 [], features={"a": []}, same_sampling_as=evset_1
             )
             glue(evset_1, evset_2)
+
+    def test_no_evsets(self):
+        with self.assertRaisesRegex(
+            ValueError,
+            "At least two arguments should be provided.",
+        ):
+            glue()
+
+    def test_too_many_evsets(self):
+        evsets = [event_set([], features={"a": []})] * (MAX_NUM_ARGUMENTS + 1)
+        with self.assertRaisesRegex(ValueError, "Too many"):
+            glue(*evsets)
 
     def test_order_unchanged(self):
         """Tests that input evsets' order is kept.

--- a/temporian/core/operators/test/test_join.py
+++ b/temporian/core/operators/test/test_join.py
@@ -115,6 +115,15 @@ class JoinTest(TestCase):
         with self.assertRaisesRegex(ValueError, "Got float64 instead for left"):
             evset_1.join(evset_2, on="c")
 
+    def test_same_sampling(self):
+        evset_1 = event_set([0], features={"a": [0]})
+        evset_2 = event_set([0], features={"b": [0]}, same_sampling_as=evset_1)
+        with self.assertRaisesRegex(
+            ValueError,
+            "Both inputs have the same sampling. Use ",
+        ):
+            evset_1.join(evset_2)
+
 
 if __name__ == "__main__":
     absltest.main()

--- a/temporian/core/operators/test/test_since_last.py
+++ b/temporian/core/operators/test/test_since_last.py
@@ -97,6 +97,14 @@ class SinceLastTest(TestCase):
 
         assertOperatorResult(self, result, expected)
 
+    def test_negative_steps(self):
+        evset = event_set([])
+
+        with self.assertRaisesRegex(
+            ValueError, "Number of steps must be greater than 0. Got"
+        ):
+            evset.since_last(steps=-1)
+
 
 if __name__ == "__main__":
     absltest.main()

--- a/temporian/core/operators/test/test_until_next.py
+++ b/temporian/core/operators/test/test_until_next.py
@@ -63,9 +63,9 @@ class UntilNextTest(absltest.TestCase):
         sampling = event_set([])
 
         with self.assertRaisesRegex(
-            ValueError, "A duration should be a strictly"
+            ValueError, "Timeout should be finite. Instead, got "
         ):
-            evset.until_next(sampling=sampling, timeout=math.nan)
+            evset.until_next(sampling=sampling, timeout=math.inf)
 
 
 if __name__ == "__main__":

--- a/temporian/implementation/numpy/operators/glue.py
+++ b/temporian/implementation/numpy/operators/glue.py
@@ -14,7 +14,7 @@
 
 """Implementation for the Glue operator."""
 
-from typing import Dict, List
+from typing import Dict
 
 from temporian.core.operators.glue import GlueOperator
 from temporian.implementation.numpy import implementation_lib
@@ -38,10 +38,6 @@ class GlueNumpyImplementation(OperatorImplementation):
 
         # Dictionary order is guaranteed
         evsets = list(inputs.values())
-        if len(evsets) < 2:
-            raise ValueError(
-                f"Glue operator cannot be called on a {len(evsets)} EventSets."
-            )
 
         dst_evset = EventSet(data={}, schema=output_schema)
         for index_key, index_data in evsets[0].data.items():


### PR DESCRIPTION
add missing tests for the operator tests I restructured. most of them now at 100% coverage in core and numpy.

opened PR against #295 for easier review, since it branches off of it.