### PR TITLE
Fix tick_calendar wday

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Fixes
 
+- Use `wday=0` for Mondays in `tick_calendar` (like `calendar_day_of_week`).
+
 ## 0.1.5
 
 ### Features

--- a/temporian/core/operators/test/test_tick_calendar.py
+++ b/temporian/core/operators/test/test_tick_calendar.py
@@ -145,7 +145,7 @@ class TickCalendarOperatorTest(parameterized.TestCase):
             timestamps=timestamps,
         )
 
-        result = evset.tick_calendar(hour="*", wday=6)
+        result = evset.tick_calendar(hour="*", wday=5)
         assertOperatorResult(self, result, expected_evset, check_sampling=False)
 
 

--- a/temporian/implementation/numpy/operators/tick_calendar.py
+++ b/temporian/implementation/numpy/operators/tick_calendar.py
@@ -74,9 +74,12 @@ class TickCalendarNumpyImplementation(OperatorImplementation):
         month_range = self._get_arg_range(
             self.operator.month, self.operator.month_max_range()
         )
-        wday_range = self._get_arg_range(
-            self.operator.wday, self.operator.wday_max_range()
-        )
+
+        # Weekday: convert python (wday=0 for Mon) to C++ (wday=0 for Sun)
+        wday = self.operator.wday
+        if wday != "*":
+            wday = self._wday_py_to_cpp(wday)
+        wday_range = self._get_arg_range(wday, self.operator.wday_max_range())
 
         # Fill output EventSet's data
         for index_key, index_data in input.data.items():
@@ -96,8 +99,8 @@ class TickCalendarNumpyImplementation(OperatorImplementation):
                     max_mday=mday_range[1],
                     min_month=month_range[0],
                     max_month=month_range[1],
-                    min_wday=self._wday_py_to_cpp(wday_range[0]),
-                    max_wday=self._wday_py_to_cpp(wday_range[1]),
+                    min_wday=wday_range[0],
+                    max_wday=wday_range[1],
                 )
             output_evset.set_index_value(
                 index_key,

--- a/temporian/implementation/numpy/operators/tick_calendar.py
+++ b/temporian/implementation/numpy/operators/tick_calendar.py
@@ -31,6 +31,14 @@ class TickCalendarNumpyImplementation(OperatorImplementation):
         assert isinstance(operator, TickCalendar)
         super().__init__(operator)
 
+    def _wday_py_to_cpp(self, py_wday: int) -> int:
+        """Converts wday number from Python (wday=0 for Monday) to C++
+        convention (wday=0 for Sunday).
+        This is required to keep coherency between calendar_day_of_week()
+        operator (which uses datetime.weekday()) and tick_calendar() (which
+        uses tm_wday in tick_calendar.cc)."""
+        return (py_wday + 1) % 7
+
     def _get_arg_range(
         self,
         arg_value: Union[int, Literal["*"]],
@@ -88,8 +96,8 @@ class TickCalendarNumpyImplementation(OperatorImplementation):
                     max_mday=mday_range[1],
                     min_month=month_range[0],
                     max_month=month_range[1],
-                    min_wday=wday_range[0],
-                    max_wday=wday_range[1],
+                    min_wday=self._wday_py_to_cpp(wday_range[0]),
+                    max_wday=self._wday_py_to_cpp(wday_range[1]),
                 )
             output_evset.set_index_value(
                 index_key,


### PR DESCRIPTION
This PR makes coherent the meaning of `wday` argument in `tick_calendar()`, with the numbering in `calendar_day_of_week()`. The former was using `wday=0` for Sundays (C++ convention) instead of `wday=0` for Mondays (python's `datetime.weekday` convention).

(Apparently, when I implemented `tick_calendar` I just assumed that the C++ and python conventions were the same 🤷‍♂️)