### PR TITLE
Tick and tick calendar include left and right

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@
 
 ### Fixes
 
+- Fixed a bug in `EventSet.tick_calendar` where it would miss the first tick under certain conditions
+- Fixed a bug in `EventSet.tick` where it would miss the last tick under certain conditions
+
 ## 0.8.1
 
 Adding missing wheels for macos, no changes to the library
@@ -40,8 +43,6 @@ Adding missing wheels for macos, no changes to the library
 ### Fixes
 
 - Fixed a bug with `EventSet.tick_calendar` and daylight savings time.
-- Fixed a bug in `EventSet.tick_calendar` where it would miss the first tick under certain conditions
-- Fixed a bug in `EventSet.tick` where it would miss the last tick under certain conditions
 - Fixed a bug with calendar operations and daylight savings time.
 
 ### Thanks

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### Improvements
 
+- Added `before_first` and `after_last` parameters to `EventSet.tick` and `EventSet.tick_calendar`
+
 ### Fixes
 
 ## 0.8.1
@@ -38,6 +40,8 @@ Adding missing wheels for macos, no changes to the library
 ### Fixes
 
 - Fixed a bug with `EventSet.tick_calendar` and daylight savings time.
+- Fixed a bug in `EventSet.tick_calendar` where it would miss the first tick under certain conditions
+- Fixed a bug in `EventSet.tick` where it would miss the last tick under certain conditions
 - Fixed a bug with calendar operations and daylight savings time.
 
 ### Thanks

--- a/temporian/core/event_set_ops.py
+++ b/temporian/core/event_set_ops.py
@@ -4136,6 +4136,8 @@ class EventSetOperations:
         mday: Optional[Union[int, Literal["*"]]] = None,
         month: Optional[Union[int, Literal["*"]]] = None,
         wday: Optional[Union[int, Literal["*"]]] = None,
+        include_right: bool = True,
+        include_left: bool = False,
     ) -> EventSetOrNode:
         """Generates events periodically at fixed times or dates e.g. each month.
 
@@ -4252,6 +4254,8 @@ class EventSetOperations:
             wday: '*' (any day), None (auto) or number in range `[0-6]`
                     (Sun-Sat) to tick at particular day of week. Can only be
                     specified if `day_of_month` is `None`.
+            include_right: If True, a tick after the last timestamp is included.
+            include_left: If True, a tick before the first timestamp is included.
 
         Returns:
             A feature-less EventSet with timestamps at specified interval.
@@ -4266,6 +4270,8 @@ class EventSetOperations:
             mday=mday,
             month=month,
             wday=wday,
+            include_right=include_right,
+            include_left=include_left,
         )
 
     def timestamps(self: EventSetOrNode) -> EventSetOrNode:

--- a/temporian/core/event_set_ops.py
+++ b/temporian/core/event_set_ops.py
@@ -4087,7 +4087,11 @@ class EventSetOperations:
         return since_last(self, steps=steps, sampling=sampling)
 
     def tick(
-        self: EventSetOrNode, interval: Duration, align: bool = True
+        self: EventSetOrNode,
+        interval: Duration,
+        align: bool = True,
+        include_right: bool = True,
+        include_left: bool = False,
     ) -> EventSetOrNode:
         """Generates timestamps at regular intervals in the range of a guide
         [`EventSet`][temporian.EventSet].
@@ -4120,13 +4124,21 @@ class EventSetOperations:
                 (similar to [`EventSet.begin()`][temporian.EventSet.begin]).
                 If true (default), ticks are generated on timestamps that are
                 multiple of `interval`.
+            include_right: If True, a tick after the last timestamp is included.
+            include_left: If True, a tick before the first timestamp is included.
 
         Returns:
             A feature-less EventSet with regular timestamps.
         """
         from temporian.core.operators.tick import tick
 
-        return tick(self, interval=interval, align=align)
+        return tick(
+            self,
+            interval=interval,
+            align=align,
+            include_right=include_right,
+            include_left=include_left,
+        )
 
     def tick_calendar(
         self: EventSetOrNode,

--- a/temporian/core/event_set_ops.py
+++ b/temporian/core/event_set_ops.py
@@ -4312,11 +4312,11 @@ class EventSetOperations:
                     (Sun-Sat) to tick at particular day of week. Can only be
                     specified if `day_of_month` is `None`.
             after_last: If True, a tick after the last timestamp is included.
-                    Useful for windows operations were you want the timestamps
+                    Useful for window operations where you want the timestamps
                     to be included in the range of the ticks.
             before_first: If True, a tick before the first timestamp is
                     included.
-                    Useful for windows operations were you want the timestamps
+                    Useful for window operations where you want the timestamps
                     to be included in the range of the ticks.
 
         Returns:

--- a/temporian/core/operators/test/test_tick.py
+++ b/temporian/core/operators/test/test_tick.py
@@ -12,14 +12,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from absl.testing import absltest
-from absl.testing.parameterized import TestCase
+from absl.testing import absltest, parameterized
 
 from temporian.implementation.numpy.data.io import event_set
 from temporian.test.utils import assertOperatorResult
 
 
-class TickTest(TestCase):
+class TickTest(parameterized.TestCase):
     def test_no_align(self):
         evset = event_set([1, 5.5])
         result = evset.tick(4.0, align=False)
@@ -72,90 +71,192 @@ class TickTest(TestCase):
             self, result, expected_output, check_sampling=False
         )
 
-    def test_not_inclusive_right(self):
-        evset = event_set([1, 5, 9])
-        # Not aligned, no include right, end matches last tick
-        result = evset.tick(4.0, align=False, include_right=False)
-        expected_output = event_set([1, 5, 9])
-        assertOperatorResult(
-            self, result, expected_output, check_sampling=False
-        )
-        # Not aligned, no include right, end doesn't match last tick
-        result = evset.tick(3.0, align=False, include_right=False)
-        expected_output = event_set([1, 4, 7])
-        assertOperatorResult(
-            self, result, expected_output, check_sampling=False
-        )
-
-        # Aligned, no include right, end doesn't match last tick
-        result = evset.tick(4.0, align=True, include_right=False)
-        expected_output = event_set([4, 8])
-        assertOperatorResult(
-            self, result, expected_output, check_sampling=False
-        )
-        # Not aligned, no include right, end matches last tick
-        result = evset.tick(3.0, align=True, include_right=False)
-        expected_output = event_set([3, 6, 9])
-        assertOperatorResult(
-            self, result, expected_output, check_sampling=False
-        )
-
-    def test_inclusive_right(self):
-        evset = event_set([1, 5, 9])
-        # Not aligned, include right, end matches last tick
-        result = evset.tick(4.0, align=False, include_right=True)
-        expected_output = event_set([1, 5, 9])
-        assertOperatorResult(
-            self, result, expected_output, check_sampling=False
-        )
-        # Not aligned, include right, end doesn't match last tick
-        result = evset.tick(3.0, align=False, include_right=True)
-        expected_output = event_set([1, 4, 7, 10])
+    @parameterized.parameters(
+        # Not aligned, end matches last tick
+        {
+            "input": [1, 5, 9],
+            "output": [1, 5, 9],
+            "align": False,
+            "interval": 4,
+        },
+        # Not aligned, end doesn't match last tick
+        {
+            "input": [1, 5, 9],
+            "output": [1, 4, 7],
+            "align": False,
+            "interval": 3,
+        },
+        # Aligned, end doesn't match last tick
+        {
+            "input": [1, 5, 9],
+            "output": [4, 8],
+            "align": True,
+            "interval": 4,
+        },
+        # Aligned, end matches last tick
+        {
+            "input": [1, 5, 9],
+            "output": [3, 6, 9],
+            "align": True,
+            "interval": 3,
+        },
+    )
+    def test_not_inclusive_right(self, input, output, align, interval):
+        evset = event_set(input)
+        result = evset.tick(interval, align=align, include_right=False)
+        expected_output = event_set(output)
         assertOperatorResult(
             self, result, expected_output, check_sampling=False
         )
 
-        # Aligned, include right, end doesn't match last tick
-        result = evset.tick(4.0, align=True, include_right=True)
-        expected_output = event_set([4, 8, 12])
-        assertOperatorResult(
-            self, result, expected_output, check_sampling=False
-        )
-        # Not aligned, include right, end matches last tick
-        result = evset.tick(3.0, align=True, include_right=True)
-        expected_output = event_set([3, 6, 9])
+    @parameterized.parameters(
+        # Not aligned, end matches last tick
+        {
+            "input": [1, 5, 9],
+            "output": [1, 5, 9],
+            "align": False,
+            "interval": 4,
+        },
+        # Not aligned, end doesn't match last tick
+        {
+            "input": [1, 5, 9],
+            "output": [1, 4, 7, 10],
+            "align": False,
+            "interval": 3,
+        },
+        # Aligned, end doesn't match last tick
+        {
+            "input": [1, 5, 9],
+            "output": [4, 8, 12],
+            "align": True,
+            "interval": 4,
+        },
+        # Aligned, end matches last tick
+        {
+            "input": [1, 5, 9],
+            "output": [3, 6, 9],
+            "align": True,
+            "interval": 3,
+        },
+    )
+    def test_inclusive_right(self, input, output, align, interval):
+        evset = event_set(input)
+        result = evset.tick(interval, align=align, include_right=True)
+        expected_output = event_set(output)
         assertOperatorResult(
             self, result, expected_output, check_sampling=False
         )
 
-    def test_not_inclusive_left(self):
-        evset = event_set([1, 5, 9])
-        # Not aligned, no include left, start matches first tick
-        result = evset.tick(4.0, align=False, include_left=False)
-        expected_output = event_set([1, 5, 9])
+    @parameterized.parameters(
+        # Not aligned, start matches first tick
+        {
+            "input": [1, 5, 9],
+            "output": [1, 5, 9],
+            "align": False,
+            "interval": 4,
+        },
+        # Aligned, start doesn't match first tick
+        {
+            "input": [1, 5, 9],
+            "output": [4, 8, 12],
+            "align": True,
+            "interval": 4,
+        },
+    )
+    def test_not_inclusive_left(self, input, output, align, interval):
+        evset = event_set(input)
+        result = evset.tick(interval, align=align, include_left=False)
+        expected_output = event_set(output)
         assertOperatorResult(
             self, result, expected_output, check_sampling=False
         )
 
-        # Aligned, no include left, start doesn't match first tick
-        result = evset.tick(4.0, align=True, include_left=False)
-        expected_output = event_set([4, 8, 12])
+    @parameterized.parameters(
+        # Not aligned, start matches first tick
+        {
+            "input": [1, 5, 9],
+            "output": [1, 5, 9],
+            "align": False,
+            "interval": 4,
+        },
+        # Aligned, start doesn't match first tick
+        {
+            "input": [1, 5, 9],
+            "output": [0, 4, 8, 12],
+            "align": True,
+            "interval": 4,
+        },
+    )
+    def test_inclusive_left(self, input, output, align, interval):
+        evset = event_set(input)
+        result = evset.tick(interval, align=align, include_left=True)
+        expected_output = event_set(output)
         assertOperatorResult(
             self, result, expected_output, check_sampling=False
         )
 
-    def test_inclusive_left(self):
-        evset = event_set([1, 5, 9])
-        # Not aligned, include left, start matches first tick
-        result = evset.tick(4.0, align=False, include_left=True)
-        expected_output = event_set([1, 5, 9])
-        assertOperatorResult(
-            self, result, expected_output, check_sampling=False
+    @parameterized.parameters(
+        # all negatives
+        {
+            "input": [-9, -5, -1],
+            "output": [-9, -5, -1],
+            "align": False,
+            "interval": 4,
+            "right": False,
+            "left": False,
+        },
+        # include right, end matches last tick
+        {
+            "input": [-9, -5, -1],
+            "output": [-9, -5, -1],
+            "align": False,
+            "interval": 4,
+            "right": True,
+            "left": False,
+        },
+        # include right, end doesn't match last tick
+        {
+            "input": [-9, -5, -1],
+            "output": [-9, -6, -3, 0],
+            "align": False,
+            "interval": 3,
+            "right": True,
+            "left": False,
+        },
+        # include left, include left
+        {
+            "input": [-9, -5, -1],
+            "output": [-9, -5, -1],
+            "align": False,
+            "interval": 4,
+            "right": False,
+            "left": True,
+        },
+        # include left, aligned so that left doesn't match first tick
+        {
+            "input": [-9, -5, -1],
+            "output": [-12, -8, -4],
+            "align": True,
+            "interval": 4,
+            "right": False,
+            "left": True,
+        },
+        # include left adn right, aligned so that left doesn't match first tick
+        {
+            "input": [-9, -5, -1],
+            "output": [-12, -8, -4, 0],
+            "align": True,
+            "interval": 4,
+            "right": True,
+            "left": True,
+        },
+    )
+    def test_negatives(self, input, output, align, interval, right, left):
+        evset = event_set(input)
+        result = evset.tick(
+            interval, align=align, include_right=right, include_left=left
         )
-
-        # Aligned, include left, start doesn't match first tick
-        result = evset.tick(4.0, align=True, include_left=True)
-        expected_output = event_set([0, 4, 8, 12])
+        expected_output = event_set(output)
         assertOperatorResult(
             self, result, expected_output, check_sampling=False
         )

--- a/temporian/core/operators/test/test_tick.py
+++ b/temporian/core/operators/test/test_tick.py
@@ -23,7 +23,7 @@ class TickTest(TestCase):
     def test_no_align(self):
         evset = event_set([1, 5.5])
         result = evset.tick(4.0, align=False)
-        expected = event_set([1, 5])
+        expected = event_set([1, 5, 9])
 
         assertOperatorResult(self, result, expected, check_sampling=False)
 
@@ -38,7 +38,7 @@ class TickTest(TestCase):
 
     def test_align(self):
         evset = event_set([1, 5.5, 8.1])
-        expected_output = event_set([4, 8])
+        expected_output = event_set([4, 8, 12])
         result = evset.tick(4.0, align=True)
 
         assertOperatorResult(
@@ -56,7 +56,7 @@ class TickTest(TestCase):
 
     def test_no_align_single(self):
         evset = event_set([1])
-        expected_output = event_set([1])
+        expected_output = event_set([])
         result = evset.tick(4.0, align=False)
 
         assertOperatorResult(
@@ -68,6 +68,94 @@ class TickTest(TestCase):
         expected_output = event_set([])
         result = evset.tick(4.0, align=True)
 
+        assertOperatorResult(
+            self, result, expected_output, check_sampling=False
+        )
+
+    def test_not_inclusive_right(self):
+        evset = event_set([1, 5, 9])
+        # Not aligned, no include right, end matches last tick
+        result = evset.tick(4.0, align=False, include_right=False)
+        expected_output = event_set([1, 5, 9])
+        assertOperatorResult(
+            self, result, expected_output, check_sampling=False
+        )
+        # Not aligned, no include right, end doesn't match last tick
+        result = evset.tick(3.0, align=False, include_right=False)
+        expected_output = event_set([1, 4, 7])
+        assertOperatorResult(
+            self, result, expected_output, check_sampling=False
+        )
+
+        # Aligned, no include right, end doesn't match last tick
+        result = evset.tick(4.0, align=True, include_right=False)
+        expected_output = event_set([4, 8])
+        assertOperatorResult(
+            self, result, expected_output, check_sampling=False
+        )
+        # Not aligned, no include right, end matches last tick
+        result = evset.tick(3.0, align=True, include_right=False)
+        expected_output = event_set([3, 6, 9])
+        assertOperatorResult(
+            self, result, expected_output, check_sampling=False
+        )
+
+    def test_inclusive_right(self):
+        evset = event_set([1, 5, 9])
+        # Not aligned, include right, end matches last tick
+        result = evset.tick(4.0, align=False, include_right=True)
+        expected_output = event_set([1, 5, 9])
+        assertOperatorResult(
+            self, result, expected_output, check_sampling=False
+        )
+        # Not aligned, include right, end doesn't match last tick
+        result = evset.tick(3.0, align=False, include_right=True)
+        expected_output = event_set([1, 4, 7, 10])
+        assertOperatorResult(
+            self, result, expected_output, check_sampling=False
+        )
+
+        # Aligned, include right, end doesn't match last tick
+        result = evset.tick(4.0, align=True, include_right=True)
+        expected_output = event_set([4, 8, 12])
+        assertOperatorResult(
+            self, result, expected_output, check_sampling=False
+        )
+        # Not aligned, include right, end matches last tick
+        result = evset.tick(3.0, align=True, include_right=True)
+        expected_output = event_set([3, 6, 9])
+        assertOperatorResult(
+            self, result, expected_output, check_sampling=False
+        )
+
+    def test_not_inclusive_left(self):
+        evset = event_set([1, 5, 9])
+        # Not aligned, no include left, start matches first tick
+        result = evset.tick(4.0, align=False, include_left=False)
+        expected_output = event_set([1, 5, 9])
+        assertOperatorResult(
+            self, result, expected_output, check_sampling=False
+        )
+
+        # Aligned, no include left, start doesn't match first tick
+        result = evset.tick(4.0, align=True, include_left=False)
+        expected_output = event_set([4, 8, 12])
+        assertOperatorResult(
+            self, result, expected_output, check_sampling=False
+        )
+
+    def test_inclusive_left(self):
+        evset = event_set([1, 5, 9])
+        # Not aligned, include left, start matches first tick
+        result = evset.tick(4.0, align=False, include_left=True)
+        expected_output = event_set([1, 5, 9])
+        assertOperatorResult(
+            self, result, expected_output, check_sampling=False
+        )
+
+        # Aligned, include left, start doesn't match first tick
+        result = evset.tick(4.0, align=True, include_left=True)
+        expected_output = event_set([0, 4, 8, 12])
         assertOperatorResult(
             self, result, expected_output, check_sampling=False
         )

--- a/temporian/core/operators/test/test_tick.py
+++ b/temporian/core/operators/test/test_tick.py
@@ -53,19 +53,66 @@ class TickTest(parameterized.TestCase):
             self, result, expected_output, check_sampling=False
         )
 
-    def test_no_align_single(self):
+    # test expected behavior for a single event for all combination of params
+    @parameterized.parameters(
+        {
+            "align": False,
+            "after_last": True,
+            "before_first": False,
+            "expected": [1],
+        },
+        {
+            "align": False,
+            "after_last": False,
+            "before_first": False,
+            "expected": [1],
+        },
+        {
+            "align": False,
+            "after_last": True,
+            "before_first": True,
+            "expected": [1],
+        },
+        {
+            "align": False,
+            "after_last": False,
+            "before_first": True,
+            "expected": [1],
+        },
+        {
+            "align": True,
+            "after_last": True,
+            "before_first": False,
+            "expected": [4],
+        },
+        {
+            "align": True,
+            "after_last": False,
+            "before_first": False,
+            "expected": [],
+        },
+        {
+            "align": True,
+            "after_last": True,
+            "before_first": True,
+            "expected": [0, 4],
+        },
+        {
+            "align": True,
+            "after_last": False,
+            "before_first": True,
+            "expected": [0],
+        },
+    )
+    def test_single_event(self, align, after_last, before_first, expected):
         evset = event_set([1])
-        expected_output = event_set([])
-        result = evset.tick(4.0, align=False)
-
-        assertOperatorResult(
-            self, result, expected_output, check_sampling=False
+        expected_output = event_set(expected)
+        result = evset.tick(
+            4.0,
+            align=align,
+            after_last=after_last,
+            before_first=before_first,
         )
-
-    def test_align_single(self):
-        evset = event_set([1])
-        expected_output = event_set([])
-        result = evset.tick(4.0, align=True)
 
         assertOperatorResult(
             self, result, expected_output, check_sampling=False
@@ -103,7 +150,7 @@ class TickTest(parameterized.TestCase):
     )
     def test_not_inclusive_right(self, input, output, align, interval):
         evset = event_set(input)
-        result = evset.tick(interval, align=align, include_right=False)
+        result = evset.tick(interval, align=align, after_last=False)
         expected_output = event_set(output)
         assertOperatorResult(
             self, result, expected_output, check_sampling=False
@@ -141,7 +188,7 @@ class TickTest(parameterized.TestCase):
     )
     def test_inclusive_right(self, input, output, align, interval):
         evset = event_set(input)
-        result = evset.tick(interval, align=align, include_right=True)
+        result = evset.tick(interval, align=align, after_last=True)
         expected_output = event_set(output)
         assertOperatorResult(
             self, result, expected_output, check_sampling=False
@@ -165,7 +212,7 @@ class TickTest(parameterized.TestCase):
     )
     def test_not_inclusive_left(self, input, output, align, interval):
         evset = event_set(input)
-        result = evset.tick(interval, align=align, include_left=False)
+        result = evset.tick(interval, align=align, before_first=False)
         expected_output = event_set(output)
         assertOperatorResult(
             self, result, expected_output, check_sampling=False
@@ -189,7 +236,7 @@ class TickTest(parameterized.TestCase):
     )
     def test_inclusive_left(self, input, output, align, interval):
         evset = event_set(input)
-        result = evset.tick(interval, align=align, include_left=True)
+        result = evset.tick(interval, align=align, before_first=True)
         expected_output = event_set(output)
         assertOperatorResult(
             self, result, expected_output, check_sampling=False
@@ -202,59 +249,59 @@ class TickTest(parameterized.TestCase):
             "output": [-9, -5, -1],
             "align": False,
             "interval": 4,
-            "right": False,
-            "left": False,
+            "future": False,
+            "past": False,
         },
-        # include right, end matches last tick
+        # include future, end matches last tick
         {
             "input": [-9, -5, -1],
             "output": [-9, -5, -1],
             "align": False,
             "interval": 4,
-            "right": True,
-            "left": False,
+            "future": True,
+            "past": False,
         },
-        # include right, end doesn't match last tick
+        # include future, end doesn't match last tick
         {
             "input": [-9, -5, -1],
             "output": [-9, -6, -3, 0],
             "align": False,
             "interval": 3,
-            "right": True,
-            "left": False,
+            "future": True,
+            "past": False,
         },
-        # include left, include left
+        # include past, include past
         {
             "input": [-9, -5, -1],
             "output": [-9, -5, -1],
             "align": False,
             "interval": 4,
-            "right": False,
-            "left": True,
+            "future": False,
+            "past": True,
         },
-        # include left, aligned so that left doesn't match first tick
+        # include past, aligned so that past doesn't match first tick
         {
             "input": [-9, -5, -1],
             "output": [-12, -8, -4],
             "align": True,
             "interval": 4,
-            "right": False,
-            "left": True,
+            "future": False,
+            "past": True,
         },
-        # include left adn right, aligned so that left doesn't match first tick
+        # include past and future, aligned so that past doesn't match first tick
         {
             "input": [-9, -5, -1],
             "output": [-12, -8, -4, 0],
             "align": True,
             "interval": 4,
-            "right": True,
-            "left": True,
+            "future": True,
+            "past": True,
         },
     )
-    def test_negatives(self, input, output, align, interval, right, left):
+    def test_negatives(self, input, output, align, interval, future, past):
         evset = event_set(input)
         result = evset.tick(
-            interval, align=align, include_right=right, include_left=left
+            interval, align=align, after_last=future, before_first=past
         )
         expected_output = event_set(output)
         assertOperatorResult(

--- a/temporian/core/operators/test/test_tick_calendar.py
+++ b/temporian/core/operators/test/test_tick_calendar.py
@@ -25,60 +25,114 @@ class TickCalendarOperatorTest(parameterized.TestCase):
             # Test: specify only mday, all days at 00:00
             "span": ["2020-01-01 00:00", "2020-03-01 00:00"],
             "calendar_args": dict(mday=1),
-            "expected": [
+            "left": None,
+            "ticks": [
                 "2020-01-01 00:00",
                 "2020-02-01 00:00",
                 "2020-03-01 00:00",
             ],
+            "right": None,
         },
         {
             # Test: mday=31, February should be ignored
             "span": ["2020-01-01 00:00", "2020-03-31 00:00"],
             "calendar_args": dict(mday=31),
-            "expected": [
+            "left": "2019-12-31 00:00",
+            "ticks": [
                 "2020-01-31 00:00",
                 "2020-03-31 00:00",
             ],
+            "right": None,
         },
         {
             # Test: offsets in hours at beginning and end
             "span": ["2020-01-01 13:04", "2020-03-06 19:35"],
             "calendar_args": dict(mday=1),
-            "expected": ["2020-02-01 00:00", "2020-03-01 00:00"],
+            "left": "2020-01-01 00:00",
+            "ticks": [
+                "2020-02-01 00:00",
+                "2020-03-01 00:00",
+            ],
+            "right": "2020-04-01 00:00",
         },
         {
             # Test: 3 days in the span, should only consider start/end
             "span": ["2020-01-01", "2020-01-02", "2020-01-03"],
             "calendar_args": dict(mday="*"),
-            "expected": ["2020-01-01", "2020-01-02", "2020-01-03"],
+            "left": None,
+            "ticks": ["2020-01-01", "2020-01-02", "2020-01-03"],
+            "right": None,
         },
         {
             # Test: specific mday/hour and offsets
             "span": ["2020-01-02 13:04", "2020-03-05 19:35"],
             "calendar_args": dict(hour=3, mday=5),
-            "expected": ["2020-02-05 03:00", "2020-03-05 03:00"],
+            "left": "2019-12-05 03:00",
+            "ticks": [
+                "2020-01-05 03:00",
+                "2020-02-05 03:00",
+                "2020-03-05 03:00",
+            ],
+            "right": "2020-04-05 03:00",
         },
         {
             # Test: Edge cases for range
             "span": ["2020-01-10 13:00", "2020-03-10 12:59:59.99"],
             "calendar_args": dict(hour=13, mday=10),
-            "expected": ["2020-01-10 13:00", "2020-02-10 13:00"],
+            "left": None,
+            "ticks": [
+                "2020-01-10 13:00",
+                "2020-02-10 13:00",
+            ],
+            "right": "2020-03-10 13:00",
+        },
+        {
+            # Test: Edge cases for range
+            "span": ["2020-01-10 12:59:59.99", "2020-03-10 13:00"],
+            "calendar_args": dict(hour=13, mday=10),
+            "left": "2019-12-10 13:00",
+            "ticks": [
+                "2020-01-10 13:00",
+                "2020-02-10 13:00",
+                "2020-03-10 13:00",
+            ],
+            "right": None,
         },
     )
-    def test_base(self, span, expected, calendar_args):
-        evset = event_set(timestamps=span)
-        expected_evset = event_set(timestamps=expected)
-        result = evset.tick_calendar(**calendar_args)
+    def test_base(self, span, left, ticks, right, calendar_args):
+        for include_right in [None, True, False]:
+            for include_left in [None, True, False]:
+                expected = ticks
 
-        # NOTE: check_sampling=False still checks timestamps
-        assertOperatorResult(self, result, expected_evset, check_sampling=False)
+                if include_right is None:
+                    # inclusive on the right by default
+                    if right is not None:
+                        expected = expected + [right]
+                else:
+                    calendar_args["include_right"] = include_right
+                    if include_right and right is not None:
+                        expected = expected + [right]
 
-        # Check that it's exactly the same with env TZ!=UTC defined
-        with SetTimezone():
-            result = evset.tick_calendar(**calendar_args)
-            assertOperatorResult(
-                self, result, expected_evset, check_sampling=False
-            )
+                if include_left is not None:
+                    calendar_args["include_left"] = include_left
+                    if include_left and left is not None:
+                        expected = [left] + expected
+
+                evset = event_set(timestamps=span)
+                expected_evset = event_set(timestamps=expected)
+                result = evset.tick_calendar(**calendar_args)
+
+                # NOTE: check_sampling=False still checks timestamps
+                assertOperatorResult(
+                    self, result, expected_evset, check_sampling=False
+                )
+
+                # Check that it's exactly the same with env TZ!=UTC defined
+                with SetTimezone():
+                    result = evset.tick_calendar(**calendar_args)
+                    assertOperatorResult(
+                        self, result, expected_evset, check_sampling=False
+                    )
 
     def test_end_of_month_seconds(self):
         # All seconds at mday=31, should only be valid for months 1, 3, 5
@@ -92,7 +146,10 @@ class TickCalendarOperatorTest(parameterized.TestCase):
         expected_evset = event_set(
             timestamps=seconds_at_01_01(1, 31)
             + seconds_at_01_01(3, 31)
-            + seconds_at_01_01(5, 31),
+            + seconds_at_01_01(5, 31)
+            + [
+                datetime(2020, 7, 31, 1, 1, 0)
+            ]  # inclusive on the right by default,
         )
         result = evset.tick_calendar(second="*", minute=1, hour=1, mday=31)
         assertOperatorResult(self, result, expected_evset, check_sampling=False)
@@ -117,6 +174,10 @@ class TickCalendarOperatorTest(parameterized.TestCase):
             for hour in range(24):
                 for minute in range(60):
                     timestamps += [datetime(year, month, day, hour, minute, 0)]
+
+        # inclusive on the right by default
+        timestamps.append(datetime(2020, 1, 3, 0, 0, 0))
+
         expected_evset = event_set(
             timestamps=timestamps,
         )
@@ -141,6 +202,10 @@ class TickCalendarOperatorTest(parameterized.TestCase):
             for hour in range(24):
                 timestamps += [day + timedelta(hours=hour)]
             day += one_week
+
+        # inclusive on the right by default
+        timestamps.append(datetime(2024, 1, 6, 0, 0, 0))
+
         expected_evset = event_set(
             timestamps=timestamps,
         )

--- a/temporian/core/operators/test/test_tick_calendar.py
+++ b/temporian/core/operators/test/test_tick_calendar.py
@@ -13,10 +13,11 @@
 # limitations under the License.
 
 from datetime import datetime, timedelta, timezone
+
 from absl.testing import absltest, parameterized
 
 from temporian.implementation.numpy.data.io import event_set
-from temporian.test.utils import assertOperatorResult, SetTimezone
+from temporian.test.utils import SetTimezone, assertOperatorResult
 
 
 class TickCalendarOperatorTest(parameterized.TestCase):
@@ -95,6 +96,18 @@ class TickCalendarOperatorTest(parameterized.TestCase):
                 "2020-01-10 13:00",
                 "2020-02-10 13:00",
                 "2020-03-10 13:00",
+            ],
+            "right": None,
+        },
+        {
+            # Test: Negative timestamps
+            "span": ["1930-07-30 12:59:59.99", "1930-09-30 13:00"],
+            "calendar_args": dict(hour=13, mday=30),
+            "left": "1930-06-30 13:00",
+            "ticks": [
+                "1930-07-30 13:00",
+                "1930-08-30 13:00",
+                "1930-09-30 13:00",
             ],
             "right": None,
         },

--- a/temporian/core/operators/tick.py
+++ b/temporian/core/operators/tick.py
@@ -37,21 +37,21 @@ class Tick(Operator):
         input: EventSetNode,
         interval: NormalizedDuration,
         align: bool,
-        include_right: bool = True,
-        include_left: bool = False,
+        after_last: bool = True,
+        before_first: bool = False,
     ):
         super().__init__()
 
         self._interval = interval
         self._align = align
-        self._include_right = include_right
-        self._include_left = include_left
+        self._after_last = after_last
+        self._before_first = before_first
 
         self.add_input("input", input)
         self.add_attribute("interval", interval)
         self.add_attribute("align", align)
-        self.add_attribute("include_right", include_right)
-        self.add_attribute("include_left", include_left)
+        self.add_attribute("after_last", after_last)
+        self.add_attribute("before_first", before_first)
 
         self.add_output(
             "output",
@@ -74,12 +74,12 @@ class Tick(Operator):
         return self._align
 
     @property
-    def include_right(self) -> bool:
-        return self._include_right
+    def after_last(self) -> bool:
+        return self._after_last
 
     @property
-    def include_left(self) -> bool:
-        return self._include_left
+    def before_first(self) -> bool:
+        return self._before_first
 
     @classmethod
     def build_op_definition(cls) -> pb.OperatorDef:
@@ -95,11 +95,11 @@ class Tick(Operator):
                     type=pb.OperatorDef.Attribute.Type.BOOL,
                 ),
                 pb.OperatorDef.Attribute(
-                    key="include_right",
+                    key="after_last",
                     type=pb.OperatorDef.Attribute.Type.BOOL,
                 ),
                 pb.OperatorDef.Attribute(
-                    key="include_left",
+                    key="before_first",
                     type=pb.OperatorDef.Attribute.Type.BOOL,
                 ),
             ],
@@ -117,8 +117,8 @@ def tick(
     input: EventSetOrNode,
     interval: Duration,
     align: bool = True,
-    include_right: bool = True,
-    include_left: bool = False,
+    after_last: bool = True,
+    before_first: bool = False,
 ) -> EventSetOrNode:
     assert isinstance(input, EventSetNode)
 
@@ -126,6 +126,6 @@ def tick(
         input=input,
         interval=normalize_duration(interval),
         align=align,
-        include_right=include_right,
-        include_left=include_left,
+        after_last=after_last,
+        before_first=before_first,
     ).outputs["output"]

--- a/temporian/core/operators/tick.py
+++ b/temporian/core/operators/tick.py
@@ -17,6 +17,11 @@
 
 from temporian.core import operator_lib
 from temporian.core.compilation import compile
+from temporian.core.data.duration_utils import (
+    Duration,
+    NormalizedDuration,
+    normalize_duration,
+)
 from temporian.core.data.node import (
     EventSetNode,
     create_node_new_features_new_sampling,
@@ -24,25 +29,29 @@ from temporian.core.data.node import (
 from temporian.core.operators.base import Operator
 from temporian.core.typing import EventSetOrNode
 from temporian.proto import core_pb2 as pb
-from temporian.core.data.duration_utils import (
-    Duration,
-    NormalizedDuration,
-    normalize_duration,
-)
 
 
 class Tick(Operator):
     def __init__(
-        self, input: EventSetNode, interval: NormalizedDuration, align: bool
+        self,
+        input: EventSetNode,
+        interval: NormalizedDuration,
+        align: bool,
+        include_right: bool = True,
+        include_left: bool = False,
     ):
         super().__init__()
 
         self._interval = interval
         self._align = align
+        self._include_right = include_right
+        self._include_left = include_left
 
         self.add_input("input", input)
         self.add_attribute("interval", interval)
         self.add_attribute("align", align)
+        self.add_attribute("include_right", include_right)
+        self.add_attribute("include_left", include_left)
 
         self.add_output(
             "output",
@@ -64,6 +73,14 @@ class Tick(Operator):
     def align(self) -> bool:
         return self._align
 
+    @property
+    def include_right(self) -> bool:
+        return self._include_right
+
+    @property
+    def include_left(self) -> bool:
+        return self._include_left
+
     @classmethod
     def build_op_definition(cls) -> pb.OperatorDef:
         return pb.OperatorDef(
@@ -75,6 +92,14 @@ class Tick(Operator):
                 ),
                 pb.OperatorDef.Attribute(
                     key="align",
+                    type=pb.OperatorDef.Attribute.Type.BOOL,
+                ),
+                pb.OperatorDef.Attribute(
+                    key="include_right",
+                    type=pb.OperatorDef.Attribute.Type.BOOL,
+                ),
+                pb.OperatorDef.Attribute(
+                    key="include_left",
                     type=pb.OperatorDef.Attribute.Type.BOOL,
                 ),
             ],
@@ -89,10 +114,18 @@ operator_lib.register_operator(Tick)
 # TODO: Add support for begin/end arguments.
 @compile
 def tick(
-    input: EventSetOrNode, interval: Duration, align: bool = True
+    input: EventSetOrNode,
+    interval: Duration,
+    align: bool = True,
+    include_right: bool = True,
+    include_left: bool = False,
 ) -> EventSetOrNode:
     assert isinstance(input, EventSetNode)
 
     return Tick(
-        input=input, interval=normalize_duration(interval), align=align
+        input=input,
+        interval=normalize_duration(interval),
+        align=align,
+        include_right=include_right,
+        include_left=include_left,
     ).outputs["output"]

--- a/temporian/core/operators/tick_calendar.py
+++ b/temporian/core/operators/tick_calendar.py
@@ -14,7 +14,7 @@
 
 
 """TickCalendar operator class and public API function definitions."""
-from typing import Literal, Tuple, Optional, Union
+from typing import Literal, Optional, Tuple, Union
 
 import numpy as np
 
@@ -42,8 +42,8 @@ class TickCalendar(Operator):
         mday: Union[int, TypeWildCard],
         month: Union[int, TypeWildCard],
         wday: Union[int, TypeWildCard],
-        include_right: bool = True,
-        include_left: bool = False,
+        after_last: bool = True,
+        before_first: bool = False,
     ):
         super().__init__()
         if not input.schema.is_unix_timestamp:
@@ -58,16 +58,16 @@ class TickCalendar(Operator):
         self._mday = self._check_arg(mday, self.mday_max_range())
         self._month = self._check_arg(month, self.month_max_range())
         self._wday = self._check_arg(wday, self.wday_max_range())
-        self.include_right = include_right
-        self.include_left = include_left
+        self.after_last = after_last
+        self.before_first = before_first
         self.add_attribute("second", second)
         self.add_attribute("minute", minute)
         self.add_attribute("hour", hour)
         self.add_attribute("mday", mday)
         self.add_attribute("month", month)
         self.add_attribute("wday", wday)
-        self.add_attribute("include_right", include_right)
-        self.add_attribute("include_left", include_left)
+        self.add_attribute("after_last", after_last)
+        self.add_attribute("before_first", before_first)
 
         self.add_input("input", input)
 
@@ -185,11 +185,11 @@ class TickCalendar(Operator):
                     type=pb.OperatorDef.Attribute.Type.ANY,
                 ),
                 pb.OperatorDef.Attribute(
-                    key="include_right",
+                    key="after_last",
                     type=pb.OperatorDef.Attribute.Type.BOOL,
                 ),
                 pb.OperatorDef.Attribute(
-                    key="include_left",
+                    key="before_first",
                     type=pb.OperatorDef.Attribute.Type.BOOL,
                 ),
             ],
@@ -211,8 +211,8 @@ def tick_calendar(
     mday: Optional[Union[int, TypeWildCard]] = None,
     month: Optional[Union[int, TypeWildCard]] = None,
     wday: Optional[Union[int, TypeWildCard]] = None,
-    include_right: bool = True,
-    include_left: bool = False,
+    after_last: bool = True,
+    before_first: bool = False,
 ) -> EventSetOrNode:
     # Don't allow empty args
     if all(arg is None for arg in (second, minute, hour, mday, month, wday)):
@@ -272,6 +272,6 @@ def tick_calendar(
         mday=mday,
         month=month,
         wday=wday,
-        include_right=include_right,
-        include_left=include_left,
+        after_last=after_last,
+        before_first=before_first,
     ).outputs["output"]

--- a/temporian/core/operators/tick_calendar.py
+++ b/temporian/core/operators/tick_calendar.py
@@ -42,6 +42,8 @@ class TickCalendar(Operator):
         mday: Union[int, TypeWildCard],
         month: Union[int, TypeWildCard],
         wday: Union[int, TypeWildCard],
+        include_right: bool = True,
+        include_left: bool = False,
     ):
         super().__init__()
         if not input.schema.is_unix_timestamp:
@@ -56,12 +58,16 @@ class TickCalendar(Operator):
         self._mday = self._check_arg(mday, self.mday_max_range())
         self._month = self._check_arg(month, self.month_max_range())
         self._wday = self._check_arg(wday, self.wday_max_range())
+        self.include_right = include_right
+        self.include_left = include_left
         self.add_attribute("second", second)
         self.add_attribute("minute", minute)
         self.add_attribute("hour", hour)
         self.add_attribute("mday", mday)
         self.add_attribute("month", month)
         self.add_attribute("wday", wday)
+        self.add_attribute("include_right", include_right)
+        self.add_attribute("include_left", include_left)
 
         self.add_input("input", input)
 
@@ -178,6 +184,14 @@ class TickCalendar(Operator):
                     key="wday",
                     type=pb.OperatorDef.Attribute.Type.ANY,
                 ),
+                pb.OperatorDef.Attribute(
+                    key="include_right",
+                    type=pb.OperatorDef.Attribute.Type.BOOL,
+                ),
+                pb.OperatorDef.Attribute(
+                    key="include_left",
+                    type=pb.OperatorDef.Attribute.Type.BOOL,
+                ),
             ],
             inputs=[pb.OperatorDef.Input(key="input")],
             outputs=[pb.OperatorDef.Output(key="output")],
@@ -197,6 +211,8 @@ def tick_calendar(
     mday: Optional[Union[int, TypeWildCard]] = None,
     month: Optional[Union[int, TypeWildCard]] = None,
     wday: Optional[Union[int, TypeWildCard]] = None,
+    include_right: bool = True,
+    include_left: bool = False,
 ) -> EventSetOrNode:
     # Don't allow empty args
     if all(arg is None for arg in (second, minute, hour, mday, month, wday)):
@@ -256,4 +272,6 @@ def tick_calendar(
         mday=mday,
         month=month,
         wday=wday,
+        include_right=include_right,
+        include_left=include_left,
     ).outputs["output"]

--- a/temporian/implementation/numpy/operators/tick.py
+++ b/temporian/implementation/numpy/operators/tick.py
@@ -57,6 +57,11 @@ class TickNumpyImplementation(OperatorImplementation):
                     if save_begin != begin:
                         begin += self.operator.interval
 
+                if self.operator.include_left:
+                    begin -= self.operator.interval
+                if self.operator.include_right:
+                    end += self.operator.interval
+
                 dst_timestamps = np.arange(
                     begin,
                     np.nextafter(end, math.inf),

--- a/temporian/implementation/numpy/operators/tick.py
+++ b/temporian/implementation/numpy/operators/tick.py
@@ -16,13 +16,14 @@
 """Implementation for the Tick operator."""
 
 
+import math
 from typing import Dict
 
-import math
 import numpy as np
-from temporian.implementation.numpy.data.event_set import IndexData, EventSet
+
 from temporian.core.operators.tick import Tick
 from temporian.implementation.numpy import implementation_lib
+from temporian.implementation.numpy.data.event_set import EventSet, IndexData
 from temporian.implementation.numpy.operators.base import OperatorImplementation
 
 
@@ -41,7 +42,7 @@ class TickNumpyImplementation(OperatorImplementation):
 
         # fill output EventSet data
         for index_key, index_data in input.data.items():
-            if len(index_data.timestamps) <= 1:
+            if len(index_data.timestamps) < 1:
                 dst_timestamps = np.array([], dtype=np.float64)
             else:
                 begin = index_data.timestamps[0]
@@ -58,15 +59,15 @@ class TickNumpyImplementation(OperatorImplementation):
                     if save_begin != begin:
                         begin += self.operator.interval
 
-                # adjust begin if include_left and the first tick is not going
+                # adjust begin if before_first and the first tick is not going
                 # to be equal to the begin
-                if self.operator.include_left and (
+                if self.operator.before_first and (
                     (save_begin - begin) % self.operator.interval != 0
                 ):
                     begin -= self.operator.interval
-                # adjust end if include_right and the final tick is not going
+                # adjust end if after_last and the final tick is not going
                 # to be equal to the end
-                if self.operator.include_right and (
+                if self.operator.after_last and (
                     (save_end - begin) % self.operator.interval != 0
                 ):
                     end += self.operator.interval

--- a/temporian/implementation/numpy/operators/tick.py
+++ b/temporian/implementation/numpy/operators/tick.py
@@ -71,10 +71,14 @@ class TickNumpyImplementation(OperatorImplementation):
                 ):
                     end += self.operator.interval
 
+                interval = np.float64(self.operator.interval)
+                # arange doesn't include the end so we move it to the next tick
+                end = begin + ((end - begin) // interval + 1) * interval
+
                 dst_timestamps = np.arange(
                     begin,
-                    np.nextafter(end, math.inf),
-                    self.operator.interval,
+                    end,
+                    interval,
                     dtype=np.float64,
                 )
 

--- a/temporian/implementation/numpy/operators/tick_calendar.py
+++ b/temporian/implementation/numpy/operators/tick_calendar.py
@@ -15,13 +15,13 @@
 
 """Implementation for the TickCalendar operator."""
 
-from typing import Dict, Literal, Union, Tuple
+from typing import Dict, Literal, Tuple, Union
 
 import numpy as np
 
-from temporian.implementation.numpy.data.event_set import IndexData, EventSet
 from temporian.core.operators.tick_calendar import TickCalendar
 from temporian.implementation.numpy import implementation_lib
+from temporian.implementation.numpy.data.event_set import EventSet, IndexData
 from temporian.implementation.numpy.operators.base import OperatorImplementation
 from temporian.implementation.numpy_cc.operators import operators_cc
 
@@ -81,8 +81,8 @@ class TickCalendarNumpyImplementation(OperatorImplementation):
             wday = self._wday_py_to_cpp(wday)
         wday_range = self._get_arg_range(wday, self.operator.wday_max_range())
 
-        include_right = self.operator.include_right
-        include_left = self.operator.include_left
+        after_last = self.operator.after_last
+        before_first = self.operator.before_first
 
         # Fill output EventSet's data
         for index_key, index_data in input.data.items():
@@ -104,8 +104,8 @@ class TickCalendarNumpyImplementation(OperatorImplementation):
                     max_month=month_range[1],
                     min_wday=wday_range[0],
                     max_wday=wday_range[1],
-                    include_right=include_right,
-                    include_left=include_left,
+                    after_last=after_last,
+                    before_first=before_first,
                 )
             output_evset.set_index_value(
                 index_key,

--- a/temporian/implementation/numpy/operators/tick_calendar.py
+++ b/temporian/implementation/numpy/operators/tick_calendar.py
@@ -81,6 +81,9 @@ class TickCalendarNumpyImplementation(OperatorImplementation):
             wday = self._wday_py_to_cpp(wday)
         wday_range = self._get_arg_range(wday, self.operator.wday_max_range())
 
+        include_right = self.operator.include_right
+        include_left = self.operator.include_left
+
         # Fill output EventSet's data
         for index_key, index_data in input.data.items():
             if len(index_data.timestamps) == 0:
@@ -101,6 +104,8 @@ class TickCalendarNumpyImplementation(OperatorImplementation):
                     max_month=month_range[1],
                     min_wday=wday_range[0],
                     max_wday=wday_range[1],
+                    include_right=include_right,
+                    include_left=include_left,
                 )
             output_evset.set_index_value(
                 index_key,

--- a/temporian/implementation/numpy_cc/operators/tick_calendar.cc
+++ b/temporian/implementation/numpy_cc/operators/tick_calendar.cc
@@ -145,13 +145,13 @@ py::array_t<double> tick_calendar(
     const int min_mday, const int max_mday,      // month days
     const int min_month, const int max_month,    // month range
     const int min_wday, const int max_wday,      // weekdays
-    const bool include_right, const bool include_left) {
+    const bool after_last, const bool before_first) {
   auto ticks =
       find_ticks(start_timestamp, end_timestamp, true, -1, min_second,
                  max_second, min_minute, max_minute, min_hour, max_hour,
                  min_mday, max_mday, min_month, max_month, min_wday, max_wday);
 
-  if (include_right && (ticks.back() < end_timestamp)) {
+  if (after_last && (ticks.empty() || ticks.back() < end_timestamp)) {
     // starting from the end, find 1 tick to the right
     auto right_ticks =
         find_ticks(end_timestamp, std::nullopt, true, 1, min_second, max_second,
@@ -160,7 +160,7 @@ py::array_t<double> tick_calendar(
     ticks.insert(ticks.end(), right_ticks.begin(), right_ticks.end());
   }
 
-  if (include_left && (ticks.front() > start_timestamp)) {
+  if (before_first && (ticks.empty() || ticks.front() > start_timestamp)) {
     // starting from the start, find 1 tick to the left
     auto left_ticks = find_ticks(start_timestamp, std::nullopt, false, 1,
                                  min_second, max_second, min_minute, max_minute,
@@ -186,5 +186,6 @@ void init_tick_calendar(py::module& m) {
         py::arg("min_minute"), py::arg("max_minute"), py::arg("min_hour"),
         py::arg("max_hour"), py::arg("min_mday"), py::arg("max_mday"),
         py::arg("min_month"), py::arg("max_month"), py::arg("min_wday"),
-        py::arg("max_wday"), py::arg("include_right"), py::arg("include_left"));
+        py::arg("max_wday"), py::arg("after_last"),
+        py::arg("before_first"));
 }


### PR DESCRIPTION
- Added option to include the right to both operators and made it `True` by default
- Added option to include the left to both operators and made it `False` by default
- Both options have no effect if the start/end is equal to the first/last tick
- Fixed a bug in tick_calendar where it would miss the first tick under certain conditions
- ~Changed the behavior of the tick operator when input has 1 item, now it always returns an empty event set (used to return one element if `align=False` and empty otherwise)~


[Calendar ops](https://github.com/google/temporian/pull/325) needs to be merged first