### PR TITLE
Disable coverage action in external PRs

### DIFF
--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -1,6 +1,6 @@
 name: coverage
 
-on: [pull_request]
+on: [push]
 
 jobs:
   coverage:


### PR DESCRIPTION
The comment step fails because of missing permissions on the fork, disabling it until we find a solution for external PRs to be able to pass all checks.