### PR TITLE
Fix coverage workflow

### DIFF
--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -55,10 +55,12 @@ jobs:
             const pr = ${{fromJson(needs.coverage.outputs.cov-pr).totals.percent_covered}};
             const main = ${{fromJson(needs.coverage.outputs.cov-main).totals.percent_covered}};
             const diff = pr - main;
+            const report = `### Coverage report
+            **Main**: ${main.toFixed(2)}% | **PR**: ${pr.toFixed(2)}% | **Diff: ${diff.toFixed(2)} ${diff >= 0 ? '✅' : '⚠️'}**`;
+            await core.summary.addRaw(report).write()
             github.rest.issues.createComment({
               issue_number: context.issue.number,
               owner: context.repo.owner,
               repo: context.repo.repo,
-              body: `### Coverage report
-              **Main**: ${main.toFixed(2)}% | **PR**: ${pr.toFixed(2)}% | **Diff: ${diff.toFixed(2)} ${diff >= 0 ? '✅' : '⚠️'}**`
+              body: report
             })

--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -2,6 +2,10 @@ name: coverage
 
 on: [push]
 
+# limit default permissions to just read-only checkouts
+permissions:
+  contents: read
+
 jobs:
   coverage:
     runs-on: ubuntu-latest
@@ -48,6 +52,10 @@ jobs:
   comment:
     runs-on: ubuntu-latest
     needs: [coverage]
+    permissions:
+      # needed to add coverage comment to the pull request
+      pull-requests: write
+
     steps:
       - uses: actions/github-script@v6
         with:

--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -66,9 +66,13 @@ jobs:
             const report = `### Coverage report
             **Main**: ${main.toFixed(2)}% | **PR**: ${pr.toFixed(2)}% | **Diff: ${diff.toFixed(2)} ${diff >= 0 ? '✅' : '⚠️'}**`;
             await core.summary.addRaw(report).write()
-            github.rest.issues.createComment({
-              issue_number: context.issue.number,
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              body: report
-            })
+            try {
+              github.rest.issues.createComment({
+                issue_number: context.issue.number,
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                body: report
+              })
+            } catch (e) {
+              console.log("Could not post comment to pull request", e)
+            }

--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -1,6 +1,8 @@
 name: coverage
 
-on: [push]
+on:
+  # this allows for `contents: write` and `pull-requests: write` from forks
+  pull_request_target:
 
 # limit default permissions to just read-only checkouts
 permissions:
@@ -19,7 +21,8 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
         with:
-          ref: ${{ matrix.branch == 'main' && 'main' || '' }}
+          # for safety, `pull_request_target` changes the default checkout to be the target branch, so we have to request the merge (we're limited to `permissions: {contents: read}`, so this is ok)
+          ref: ${{ matrix.branch == 'main' && 'main' || (github.event.pull_request && format('refs/pull/{0}/merge', github.event.pull_request.number)) || '' }}
 
       - name: Bazel cache
         id: bazel-cache


### PR DESCRIPTION
This fixes:
1. https://github.com/google/temporian/actions/runs/8083954295
    [comment](https://github.com/google/temporian/actions/runs/8083954295/job/22088416732#step:2:71)
Unhandled error: HttpError: Not Found
2. Anyone using this workflow in a repository with paranoid default permissions (which my organizations do) see https://docs.github.com/en/organizations/managing-organization-settings/disabling-or-limiting-github-actions-for-your-organization#configuring-the-default-github_token-permissions -- note: you should apply the restriction to your repositories too (probably at the org level, but at least at the repository level) -- but, obviously that's a bigger change.
3. Pull Requests will now get comments (this fixes https://github.com/google/temporian/pull/381)