### PR TITLE
Fix docs builds

### DIFF
--- a/docs/.readthedocs.yaml
+++ b/docs/.readthedocs.yaml
@@ -19,11 +19,10 @@ build:
   jobs:
     post_create_environment:
       - pip install poetry
-      - poetry config virtualenvs.create false
       - npm install -g @bazel/bazelisk
 
     post_install:
-      - poetry install
+      - VIRTUAL_ENV=$READTHEDOCS_VIRTUALENV_PATH poetry install
       - pip install -r docs/src/tutorials/requirements.txt
 
     pre_build:


### PR DESCRIPTION
RTD builds have been failing for 3 days with `+ jupyter nbconvert --debug --ExecutePreprocessor.timeout=600 --execute docs/src/getting_started.ipynb --to notebook --inplace tools/run_notebooks.sh: line 25: jupyter: command not found`, RTD might have made changes to their default env, though I couldn't find an announcement or any info