### PR TITLE
Fixed build-linux and build-macos-arm

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -17,7 +17,7 @@ jobs:
         python-version: ["3.8", "3.9", "3.10", "3.11"]
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v3  # v4 doesn't work on the container
 
       - name: Build package
         run: |
@@ -110,7 +110,7 @@ jobs:
       SYSTEM_VERSION_COMPAT: 0
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v3
 
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v4
@@ -137,7 +137,7 @@ jobs:
         python-version: ["3.8", "3.9", "3.10", "3.11"]
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v3
 
       - name: Install Python
         run: |
@@ -169,7 +169,7 @@ jobs:
       POETRY_PYPI_TOKEN_PYPI: ${{ secrets.PYPI_TOKEN }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v3
 
       - name: Install poetry
         run: pip install poetry

--- a/temporian/implementation/numpy_cc/operators/tick_calendar.cc
+++ b/temporian/implementation/numpy_cc/operators/tick_calendar.cc
@@ -53,7 +53,11 @@ py::array_t<double> tick_calendar(
 
               // Valid date
               if (cur_time_or.has_value()) {
-                const auto cur_time = cur_time_or.value();
+                // NOTE: std:optional.value() fails to build on github runner
+                // for arm64 macos although this function is on the
+                // c++17 standard.
+                // This alternative way to access the value works correctly.
+                const auto cur_time = *cur_time_or;
 
                 // Finish condition
                 if (cur_time.seconds_since_epoch > end_t) {


### PR DESCRIPTION
There seems to be a problem with actions/checkout@v4 on some containers
There is a problem with `std::optional.value()` function on some macos compilers