### PR TITLE
Added bokeh_wegbl backend

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### Improvements
 
 - Added `before_first` and `after_last` parameters to `EventSet.tick` and `EventSet.tick_calendar`
+- Added `bokeh_webgl` as a possible `backend` for `tp.plot`.
 
 ### Fixes
 

--- a/temporian/implementation/numpy/data/plotter.py
+++ b/temporian/implementation/numpy/data/plotter.py
@@ -88,9 +88,16 @@ def bokeh_backend():
     return plotter_bokeh.Plotter
 
 
+def bokeh_webgl_backend():
+    from temporian.implementation.numpy.data import plotter_bokeh
+
+    return plotter_bokeh.PlotterWebGL
+
+
 BACKENDS: Dict[str, Callable] = {
     "matplotlib": matplotlib_backend,
     "bokeh": bokeh_backend,
+    "bokeh_webgl": bokeh_webgl_backend,
 }
 
 
@@ -279,7 +286,7 @@ def plot(
             effectively selects a backend that support interactive plotting.
             Ignored if "backend" is set.
         backend: Plotting library to use. Possible values are: matplotlib,
-            bokeh. If set, overrides the "interactive" argument.
+            bokeh, and bokeh_webgl. If set, overrides the "interactive" argument.
         merge: If true, plots all features in the same plots. If false, plots
             features in separate plots. merge=True on event-sets [e1, e2] is
             equivalent to plotting (e1, e2).


### PR DESCRIPTION
While testing locally the interactive plot using bokeh stops rendering when the eventset reaches 3 million timestamps (single feature, single index) that's around 45.8MB in memory.

The new plotter configures bokeh to use WebGL and allows me to render plots up to 30 million timestamps (457.8MB in memory).

I experimented with [bokeh server](https://docs.bokeh.org/en/latest/docs/user_guide/server.html) but it didn't perform better.