### PR TITLE
Avoid using optional.value() in cpp

### DIFF
--- a/temporian/implementation/numpy_cc/operators/tick_calendar.cc
+++ b/temporian/implementation/numpy_cc/operators/tick_calendar.cc
@@ -39,7 +39,7 @@ std::vector<double> find_ticks(
   const std::optional<std::time_t> end_t =
       end_timestamp.has_value()
           ? std::optional<std::time_t>{static_cast<std::time_t>(
-                std::floor(end_timestamp.value()))}
+                std::floor(*end_timestamp))}
           : std::nullopt;
 
   // Start time
@@ -86,7 +86,7 @@ std::vector<double> find_ticks(
 
                 // Finish conditions
                 if (end_t.has_value() &&
-                    cur_time.seconds_since_epoch > end_t.value()) {
+                    cur_time.seconds_since_epoch > *end_t) {
                   keep_looking = false;
                   break;
                 }

--- a/temporian/implementation/numpy_cc/operators/tick_calendar_utils_test.cc
+++ b/temporian/implementation/numpy_cc/operators/tick_calendar_utils_test.cc
@@ -30,9 +30,9 @@ TEST_P(UTCMkTimeTest, MatchExpected) {
       UTCMkTime(test_case.year, test_case.month, test_case.day, test_case.hour,
                 test_case.minute, test_case.second);
   EXPECT_TRUE(result.has_value());
-  EXPECT_EQ(result.value().seconds_since_epoch,
+  EXPECT_EQ((*result).seconds_since_epoch,
             test_case.expected_seconds_since_epoch);
-  EXPECT_EQ(result.value().wday, test_case.expected_wday);
+  EXPECT_EQ((*result).wday, test_case.expected_wday);
 }
 
 INSTANTIATE_TEST_SUITE_P(UTCMkTimeTestBase, UTCMkTimeTest,


### PR DESCRIPTION
This method fails on older macos so we need to replace it by the * operator