### PR TITLE
Fix silent data loss in add_index for unsupported dtypes

### DIFF
--- a/temporian/core/operators/test/test_add_index.py
+++ b/temporian/core/operators/test/test_add_index.py
@@ -198,6 +198,20 @@ class AddIndexTest(TestCase):
         ):
             self.evset.set_index([])
 
+    def test_float_index_raises_error(self):
+        """Test that add_index on float column raises error instead of silent data loss.
+
+        Regression test for https://github.com/google/temporian/issues/437
+        """
+        evset = event_set(
+            [1, 2, 3],
+            features={"a": [1.0, 2.0, 3.0], "b": [1, 2, 3]},
+        )
+
+        with self.assertRaises(Exception):
+            # Float columns cannot be used as indexes
+            evset.add_index("a")
+
 
 if __name__ == "__main__":
     absltest.main()

--- a/temporian/implementation/numpy_cc/operators/add_index.cc
+++ b/temporian/implementation/numpy_cc/operators/add_index.cc
@@ -223,8 +223,9 @@ void recursive_build_index(const py::list &features,
     if (casted_feature.dtype().kind() == 'S') {
       process_feature_string(casted_feature, features, feature_idx,
                              selected_rows, index_acc, partial_group);
+      return;
     }
-    return;
+    // Unsupported array dtype - fall through to error handler
   }
 
   py::print("Feature:", feature.get_type());


### PR DESCRIPTION
  ## Summary
  Fixes #437

  The `add_index()` operation was silently returning 0 events when the index column had an unsupported numpy dtype (e.g., unicode strings with dtype kind `'U'`).

  ## Root Cause
  In `add_index.cc` lines 221-228, when a numpy array's dtype kind was not `'S'` (bytes), the function would return without processing the feature OR raising an error, leaving the group accumulator empty.

  ## Fix
  Moved the `return` statement inside the `if (dtype().kind() == 'S')` block so that unsupported array dtypes fall through to the error handler that throws `std::invalid_argument("Non supported feature type")`.