### PR TITLE
fix(ops): extend >, <, >=, <= to accept str and bytes scalars

### DIFF
--- a/temporian/core/event_set_ops.py
+++ b/temporian/core/event_set_ops.py
@@ -1073,12 +1073,12 @@ class EventSetOperations:
 
             return greater(input_left=self, input_right=other)
 
-        if isinstance(other, T_SCALAR):
+        if isinstance(other, T_SCALAR + (str, bytes)):
             from temporian.core.operators.scalar import greater_scalar
 
             return greater_scalar(input=self, value=other)
 
-        self._raise_error("compare", other, "(int,float)")
+        self._raise_error("compare", other, "(int,float,str,bytes)")
         assert False
 
     def __ge__(self: EventSetOrNode, other: Any) -> EventSetOrNode:
@@ -1149,12 +1149,12 @@ class EventSetOperations:
 
             return greater_equal(input_left=self, input_right=other)
 
-        if isinstance(other, T_SCALAR):
+        if isinstance(other, T_SCALAR + (str, bytes)):
             from temporian.core.operators.scalar import greater_equal_scalar
 
             return greater_equal_scalar(input=self, value=other)
 
-        self._raise_error("compare", other, "(int,float)")
+        self._raise_error("compare", other, "(int,float,str,bytes)")
         assert False
 
     def __lt__(self: EventSetOrNode, other: Any) -> EventSetOrNode:
@@ -1225,12 +1225,12 @@ class EventSetOperations:
 
             return less(input_left=self, input_right=other)
 
-        if isinstance(other, T_SCALAR):
+        if isinstance(other, T_SCALAR + (str, bytes)):
             from temporian.core.operators.scalar import less_scalar
 
             return less_scalar(input=self, value=other)
 
-        self._raise_error("compare", other, "(int,float)")
+        self._raise_error("compare", other, "(int,float,str,bytes)")
         assert False
 
     def __le__(self: EventSetOrNode, other: Any) -> EventSetOrNode:
@@ -1301,12 +1301,12 @@ class EventSetOperations:
 
             return less_equal(input_left=self, input_right=other)
 
-        if isinstance(other, T_SCALAR):
+        if isinstance(other, T_SCALAR + (str, bytes)):
             from temporian.core.operators.scalar import less_equal_scalar
 
             return less_equal_scalar(input=self, value=other)
 
-        self._raise_error("compare", other, "(int,float)")
+        self._raise_error("compare", other, "(int,float,str,bytes)")
         assert False
 
     def _raise_bool_error(self, boolean_op: str, other: Any) -> None:

--- a/temporian/core/operators/test/test_relational_scalar.py
+++ b/temporian/core/operators/test/test_relational_scalar.py
@@ -175,5 +175,50 @@ class RelationalScalarTest(absltest.TestCase):
         assertOperatorResult(self, self.evset != value, expected)
 
 
+    def test_less_scalar_str(self) -> None:
+        """Test < with a string scalar (regression for #369)."""
+        timestamps = [1, 2, 3, 4]
+        evset = event_set(timestamps=timestamps, features={"a": ["a", "b", "c", "d"]})
+        expected = event_set(
+            timestamps=timestamps,
+            features={"a": [True, True, False, False]},
+            same_sampling_as=evset,
+        )
+        assertOperatorResult(self, evset < "c", expected)
+
+    def test_greater_scalar_str(self) -> None:
+        """Test > with a string scalar (regression for #369)."""
+        timestamps = [1, 2, 3, 4]
+        evset = event_set(timestamps=timestamps, features={"a": ["a", "b", "c", "d"]})
+        expected = event_set(
+            timestamps=timestamps,
+            features={"a": [False, False, False, True]},
+            same_sampling_as=evset,
+        )
+        assertOperatorResult(self, evset > "c", expected)
+
+    def test_less_equal_scalar_str(self) -> None:
+        """Test <= with a string scalar (regression for #369)."""
+        timestamps = [1, 2, 3, 4]
+        evset = event_set(timestamps=timestamps, features={"a": ["a", "b", "c", "d"]})
+        expected = event_set(
+            timestamps=timestamps,
+            features={"a": [True, True, True, False]},
+            same_sampling_as=evset,
+        )
+        assertOperatorResult(self, evset <= "c", expected)
+
+    def test_greater_equal_scalar_str(self) -> None:
+        """Test >= with a string scalar (regression for #369)."""
+        timestamps = [1, 2, 3, 4]
+        evset = event_set(timestamps=timestamps, features={"a": ["a", "b", "c", "d"]})
+        expected = event_set(
+            timestamps=timestamps,
+            features={"a": [False, False, True, True]},
+            same_sampling_as=evset,
+        )
+        assertOperatorResult(self, evset >= "c", expected)
+
+
 if __name__ == "__main__":
     absltest.main()


### PR DESCRIPTION
Fixes #369

The four ordering operators (`__gt__`, `__ge__`, `__lt__`, `__le__`) in `event_set_ops.py` were checking `isinstance(other, T_SCALAR)` where `T_SCALAR = (int, float)`. So `evset < 'b'` raised a `ValueError` even though the underlying `RelationalScalarOperator` already supports `DType.STRING`.

Extended the check to `T_SCALAR + (str, bytes)` on all four operators and updated the error message. Four regression tests added, all passing.