### PR TITLE
fix(deps): cap numpy below 2.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,6 +38,10 @@ absl-py = "^1.3.0"
 protobuf = ">=3.20.3"
 pandas = ">=1.5.2"
 matplotlib = "^3.7.1"
+# The numpy_cc extensions are built with pybind11 2.11, which predates numpy 2
+# support (pybind11 2.12). Under numpy >= 2 the bindings return wrong values
+# instead of failing, so the cap is a correctness constraint, not a preference.
+numpy = ">=1.21,<2"
 
 # Extras (keep versions in sync with dev deps)
 apache-beam = { version = "^2.48.0", optional = true }


### PR DESCRIPTION
Fixes #435

I chased down why `resample` and `set_index` go wrong on numpy 2, and it isn't the operator logic — it's the compiled bindings. Same wheel, only the numpy version changed:

```
numpy 1.26.4:  build_sampling_idxs(...) -> (array([-1,  0,  1,  3]), 1)   correct
numpy 2.0.2:   build_sampling_idxs(...) -> (array([ 3,  3,  3,  3]), 1)   wrong
```

That reproduces the exact numbers in the issue. `a.resample(b)` gives `[nan, 1, 2, 4]` on numpy 1 and `[nan, 4, 4, 4]` on numpy 2. The second symptom has the same cause: `add_index_compute_index` returns `group_begin_idx = [0, 0, 0]` and `row_idxs = [1, 1, 1, 1]` under numpy 2, so every group slices to empty and `set_index('f2')` reports the right index values with zero events under each.

The C++ in `resample.cc` is correct — I walked the loop by hand and it yields `[-1, 0, 1, 3]`. The tell is that `first_valid_idx`, the scalar half of the same return, is right while the array half is garbage. It's the array marshalling that breaks, not the algorithm.

The cause is `WORKSPACE`: pybind11 is pinned to 2.11.0, and numpy 2 support landed in pybind11 2.12.0. Running a 2.11-built extension against numpy 2 is undefined, and here it fails silently rather than loudly.

Compounding it, `numpy` was never declared in `[tool.poetry.dependencies]` — it arrives transitively through pandas, so a fresh install just picks up 2.x and starts returning wrong numbers with no warning.

This PR is the containment half: declare numpy and cap it at `<2` so an install can't silently land somewhere the extensions don't work. I'd rather a user get a resolver message than wrong data.

The durable fix is bumping pybind11 to >= 2.12 and rebuilding, which produces binaries that work on both 1.x and 2.x and lets the cap come off. I left that out deliberately: I don't have bazel here, so I couldn't build or verify it, and I'd rather not push an unverified toolchain bump. Happy to do it in a follow-up if you'd like, or it may be quicker for someone with the build set up.

One thing worth deciding separately: the cap only helps new resolves. Anyone who already has temporian and numpy 2 in an environment keeps getting silently wrong results. A version check at import that raises would turn that into a loud failure — I didn't add it unprompted since it's a user-visible behaviour change, but it seems worth having given the failure mode.