### PR TITLE
Fix OSError on Windows for pre-epoch datetimes in duration conversion

### DIFF
--- a/temporian/core/data/duration_utils.py
+++ b/temporian/core/data/duration_utils.py
@@ -60,7 +60,10 @@ def normalize_timestamp(x: Timestamp) -> NormalizedTimestamp:
         return x.astype("datetime64[ns]").astype(np.float64) / 1e9
 
     if isinstance(x, datetime.datetime):
-        return float(x.replace(tzinfo=datetime.timezone.utc).timestamp())
+        epoch = datetime.datetime(1970, 1, 1, tzinfo=datetime.timezone.utc)
+        return float(
+            (x.replace(tzinfo=datetime.timezone.utc) - epoch).total_seconds()
+        )
 
     if isinstance(x, int):
         return float(x)
@@ -160,7 +163,10 @@ def convert_numpy_datetime64_to_duration(
 
 def convert_datetime_to_duration(date: datetime.datetime) -> NormalizedDuration:
     """Convert datetime to duration epoch UTC."""
-    return float(date.replace(tzinfo=datetime.timezone.utc).timestamp())
+    epoch = datetime.datetime(1970, 1, 1, tzinfo=datetime.timezone.utc)
+    return float(
+        (date.replace(tzinfo=datetime.timezone.utc) - epoch).total_seconds()
+    )
 
 
 def convert_datetime_date_to_duration(

--- a/temporian/core/data/test/BUILD
+++ b/temporian/core/data/test/BUILD
@@ -28,6 +28,17 @@ py_test(
     ],
 )
 
+py_test(
+    name = "test_duration_utils",
+    srcs = ["test_duration_utils.py"],
+    srcs_version = "PY3",
+    deps = [
+        # already_there/absl/testing:absltest
+        # already_there/absl/testing:parameterized
+        "//temporian/core/data:duration_utils",
+    ],
+)
+
 
 py_test(
     name = "schema_test",

--- a/temporian/core/data/test/test_duration_utils.py
+++ b/temporian/core/data/test/test_duration_utils.py
@@ -1,0 +1,49 @@
+# Copyright 2021 Google LLC.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import datetime
+
+from absl.testing import absltest, parameterized
+
+from temporian.core.data.duration_utils import (
+    convert_datetime_to_duration,
+    normalize_timestamp,
+)
+
+
+class DurationUtilsTest(parameterized.TestCase):
+    @parameterized.parameters(
+        # (datetime, expected seconds from unix epoch)
+        (datetime.datetime(1970, 1, 1), 0.0),
+        (datetime.datetime(1960, 1, 1), -315619200.0),
+        (datetime.datetime(1969, 12, 31, 23, 59, 59), -1.0),
+        (datetime.datetime(2023, 7, 19, 18, 37, 36), 1689791856.0),
+    )
+    def test_normalize_timestamp_datetime(self, dtime, expected):
+        # Pre-epoch datetimes must not raise OSError (was broken on Windows,
+        # see issue #395) and must return the correct negative offset.
+        self.assertEqual(normalize_timestamp(dtime), expected)
+
+    @parameterized.parameters(
+        (datetime.datetime(1970, 1, 1), 0.0),
+        (datetime.datetime(1960, 1, 1), -315619200.0),
+        (datetime.datetime(1969, 12, 31, 23, 59, 59), -1.0),
+        (datetime.datetime(2023, 7, 19, 18, 37, 36), 1689791856.0),
+    )
+    def test_convert_datetime_to_duration(self, dtime, expected):
+        self.assertEqual(convert_datetime_to_duration(dtime), expected)
+
+
+if __name__ == "__main__":
+    absltest.main()


### PR DESCRIPTION
Fixes #395

`normalize_timestamp()` and `convert_datetime_to_duration()` computed epoch seconds via `datetime.timestamp()`, which relies on the platform C `mktime` and raises `OSError` on Windows for datetimes before the Unix epoch (1970-01-01) — see [cpython#94414](https://github.com/python/cpython/issues/94414).

Both now subtract an explicit UTC epoch and use `timedelta.total_seconds()`, which is cross-platform and handles negative offsets. Return type (`float`) and non-datetime handling are unchanged.

Added `temporian/core/data/test/test_duration_utils.py` covering pre-1970 datetimes (e.g. `1960-01-01` -> `-315619200.0`) for both functions.