### PR TITLE
fix(ops): add_index preserves event arrays in each index partition

### DIFF
--- a/temporian/core/operators/test/test_add_index.py
+++ b/temporian/core/operators/test/test_add_index.py
@@ -178,6 +178,21 @@ class AddIndexTest(TestCase):
         self.assertEqual(result.data[(2, b"X")].timestamps.tolist(), [4, 5])
         self.assertEqual(result.data[(3, b"Z")].timestamps.tolist(), [6])
 
+    def test_add_index_preserves_event_count(self):
+        # Regression test for https://github.com/google/temporian/issues/437.
+        # add_index was returning 0 events per partition when run under numpy
+        # >= 2 due to a pybind11/numpy-2 incompatibility in the C++ kernel.
+        evset = event_set(
+            [1.0, 2.0, 3.0, 4.0, 5.0, 6.0],
+            features={"customer": ["A", "A", "B", "B", "B", "C"]},
+        )
+        result = evset.add_index("customer")
+        total = sum(len(d.timestamps) for d in result.data.values())
+        self.assertEqual(total, 6)
+        self.assertEqual(len(result.data[(b"A",)].timestamps), 2)
+        self.assertEqual(len(result.data[(b"B",)].timestamps), 3)
+        self.assertEqual(len(result.data[(b"C",)].timestamps), 1)
+
     def test_target_doesnt_exist(self):
         with self.assertRaisesRegex(ValueError, "is not a feature in input"):
             self.evset.add_index("e")

--- a/temporian/implementation/numpy/operators/add_index.py
+++ b/temporian/implementation/numpy/operators/add_index.py
@@ -1,11 +1,51 @@
 from collections import defaultdict
-from typing import Dict
+from typing import Dict, List, Tuple
+
+import numpy as np
 
 from temporian.core.operators.add_index import AddIndexOperator
 from temporian.implementation.numpy import implementation_lib
 from temporian.implementation.numpy.data.event_set import EventSet, IndexData
 from temporian.implementation.numpy.operators.base import OperatorImplementation
-from temporian.implementation.numpy_cc.operators import operators_cc
+
+
+def _compute_groups(
+    index_features: List[np.ndarray],
+) -> Tuple[list, np.ndarray, np.ndarray]:
+    """Groups row indices by the combined values of index_features.
+
+    Returns:
+        group_keys: list of tuples, one per unique group.
+        row_idxs: flat int64 array of row indices ordered by group.
+        group_begin_idx: int64 array of length len(group_keys)+1 with the
+            start offset of each group in row_idxs.
+    """
+    if len(index_features) == 0 or index_features[0].shape[0] == 0:
+        return [], np.array([], dtype=np.int64), np.array([0], dtype=np.int64)
+
+    num_rows = index_features[0].shape[0]
+
+    # Build a dict mapping group_key -> list of row indices.
+    groups: dict = defaultdict(list)
+    for row_idx in range(num_rows):
+        key = tuple(
+            int(f[row_idx]) if f.dtype.kind in ("i", "u")
+            else bytes(f[row_idx])
+            for f in index_features
+        )
+        groups[key].append(row_idx)
+
+    group_keys = []
+    all_row_idxs = []
+    begin_offsets = [0]
+    for key, rows in groups.items():
+        group_keys.append(key)
+        all_row_idxs.extend(rows)
+        begin_offsets.append(len(all_row_idxs))
+
+    row_idxs = np.array(all_row_idxs, dtype=np.int64)
+    group_begin_idx = np.array(begin_offsets, dtype=np.int64)
+    return group_keys, row_idxs, group_begin_idx
 
 
 class AddIndexNumpyImplementation(OperatorImplementation):
@@ -34,11 +74,9 @@ class AddIndexNumpyImplementation(OperatorImplementation):
         dst_data = {}
         for src_index, src_data in input.data.items():
             index_features = [src_data.features[i] for i in new_index_idxs]
-            (
-                group_keys,
-                row_idxs,
-                group_begin_idx,
-            ) = operators_cc.add_index_compute_index(index_features)
+            group_keys, row_idxs, group_begin_idx = _compute_groups(
+                index_features
+            )
 
             for group_idx, group_key in enumerate(group_keys):
                 dst_index = src_index + group_key


### PR DESCRIPTION
## Summary

Fixes #437.

`EventSet.add_index()` was building the index structure correctly (4959 index values) but not populating each partition with its event data, leaving every partition with 0 events.

**Root cause:** The C++ kernel `add_index_compute_index` (built with pybind11 2.11) is incompatible with numpy >= 2.0. Under numpy 2, the `mutable_unchecked<1>` write path silently produces wrong group-begin offsets, so every slice `[begin:end]` evaluates as empty even though `group_keys` is populated correctly.

## Changes

- Replaced the `operators_cc.add_index_compute_index` call with a pure-Python groupby (`_compute_groups`) that is correct under any supported numpy version. The C++ extension is still compiled; only `add_index` stops delegating this particular step to it.
- Added regression test: `add_index` must preserve total event count and correctly partition events by the new index column.

## Testing

Regression test `test_add_index_preserves_event_count` confirms total events are preserved and per-group counts are correct for string index columns.